### PR TITLE
Update localization to cascade thru contact languages

### DIFF
--- a/cmd/flowserver/flow.go
+++ b/cmd/flowserver/flow.go
@@ -44,10 +44,11 @@ func (r *flowResponse) MarshalJSON() ([]byte, error) {
 }
 
 type startRequest struct {
-	Flows   json.RawMessage      `json:"flows"    validate:"required"`
-	Contact json.RawMessage      `json:"contact"  validate:"required"`
-	Extra   json.RawMessage      `json:"extra,omitempty"`
-	Input   *utils.TypedEnvelope `json:"input"`
+	Environment *json.RawMessage     `json:"env"`
+	Flows       json.RawMessage      `json:"flows"    validate:"required"`
+	Contact     json.RawMessage      `json:"contact"  validate:"required"`
+	Extra       json.RawMessage      `json:"extra,omitempty"`
+	Input       *utils.TypedEnvelope `json:"input"`
 }
 
 func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -67,6 +68,16 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	err = utils.ValidateAll(start)
 	if err != nil {
 		return nil, err
+	}
+
+	var env utils.Environment
+	if start.Environment != nil {
+		env, err = utils.ReadEnvironment(start.Environment)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		env = utils.NewDefaultEnvironment()
 	}
 
 	// read our flows
@@ -93,11 +104,11 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 		}
 	}
 
-	// build our environment
-	env := engine.NewFlowEnvironment(utils.NewDefaultEnvironment(), startFlows, []flows.FlowRun{}, []*flows.Contact{contact})
+	// build our flow environment
+	flowEnv := engine.NewFlowEnvironment(env, startFlows, []flows.FlowRun{}, []*flows.Contact{contact})
 
 	// start our flow
-	session, err := engine.StartFlow(env, startFlows[0], contact, nil, input, start.Extra)
+	session, err := engine.StartFlow(flowEnv, startFlows[0], contact, nil, input, start.Extra)
 	if err != nil {
 		return nil, fmt.Errorf("error starting flow: %s", err)
 	}
@@ -106,10 +117,11 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 }
 
 type resumeRequest struct {
-	Flows   json.RawMessage      `json:"flows"       validate:"required,min=1"`
-	Contact json.RawMessage      `json:"contact"     validate:"required"`
-	Session json.RawMessage      `json:"session"     validate:"required"`
-	Event   *utils.TypedEnvelope `json:"event"       validate:"required"`
+	Environment *json.RawMessage     `json:"env"`
+	Flows       json.RawMessage      `json:"flows"       validate:"required,min=1"`
+	Contact     json.RawMessage      `json:"contact"     validate:"required"`
+	Session     json.RawMessage      `json:"session"     validate:"required"`
+	Event       *utils.TypedEnvelope `json:"event"       validate:"required"`
 }
 
 func handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -129,6 +141,16 @@ func handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	err = utils.ValidateAll(resume)
 	if err != nil {
 		return nil, err
+	}
+
+	var env utils.Environment
+	if resume.Environment != nil {
+		env, err = utils.ReadEnvironment(resume.Environment)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		env = utils.NewDefaultEnvironment()
 	}
 
 	// read our flows
@@ -165,11 +187,11 @@ func handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	}
 
 	// build our environment
-	env := engine.NewFlowEnvironment(utils.NewDefaultEnvironment(), flowList, session.Runs(), []*flows.Contact{contact})
+	flowEnv := engine.NewFlowEnvironment(env, flowList, session.Runs(), []*flows.Contact{contact})
 
 	// hydrate all our runs
 	for _, run := range session.Runs() {
-		err = run.Hydrate(env)
+		err = run.Hydrate(flowEnv)
 		if err != nil {
 			return nil, utils.NewValidationError(err.Error())
 		}
@@ -182,7 +204,7 @@ func handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	}
 
 	// resume our flow
-	session, err = engine.ResumeFlow(env, activeRun, event)
+	session, err = engine.ResumeFlow(flowEnv, activeRun, event)
 	if err != nil {
 		return nil, fmt.Errorf("error resuming flow: %s", err)
 	}

--- a/cmd/flowserver/flow.go
+++ b/cmd/flowserver/flow.go
@@ -44,7 +44,7 @@ func (r *flowResponse) MarshalJSON() ([]byte, error) {
 }
 
 type startRequest struct {
-	Environment *json.RawMessage     `json:"env"`
+	Environment *json.RawMessage     `json:"environment"`
 	Flows       json.RawMessage      `json:"flows"    validate:"required"`
 	Contact     json.RawMessage      `json:"contact"  validate:"required"`
 	Extra       json.RawMessage      `json:"extra,omitempty"`
@@ -117,7 +117,7 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 }
 
 type resumeRequest struct {
-	Environment *json.RawMessage     `json:"env"`
+	Environment *json.RawMessage     `json:"environment"`
 	Flows       json.RawMessage      `json:"flows"       validate:"required,min=1"`
 	Contact     json.RawMessage      `json:"contact"     validate:"required"`
 	Session     json.RawMessage      `json:"session"     validate:"required"`

--- a/excellent/functions_test.go
+++ b/excellent/functions_test.go
@@ -311,7 +311,7 @@ var funcTests = []struct {
 }
 
 func TestFunctions(t *testing.T) {
-	env := utils.NewEnvironment(utils.DateFormat_dd_MM_yyyy, utils.TimeFormat_HH_mm_ss, time.UTC)
+	env := utils.NewEnvironment(utils.DateFormat_dd_MM_yyyy, utils.TimeFormat_HH_mm_ss, time.UTC, utils.LanguageList{})
 
 	for _, test := range funcTests {
 		xFunc := XFUNCTIONS[test.name]
@@ -370,7 +370,7 @@ var rangeTests = []struct {
 }
 
 func TestRangeFunctions(t *testing.T) {
-	env := utils.NewEnvironment(utils.DateFormat_dd_MM_yyyy, utils.TimeFormat_HH_mm_ss, time.UTC)
+	env := utils.NewEnvironment(utils.DateFormat_dd_MM_yyyy, utils.TimeFormat_HH_mm_ss, time.UTC, utils.LanguageList{})
 
 	for _, test := range rangeTests {
 		xFunc := XFUNCTIONS[test.name]

--- a/excellent/tests_test.go
+++ b/excellent/tests_test.go
@@ -166,7 +166,7 @@ var testTests = []struct {
 }
 
 func TestTests(t *testing.T) {
-	env := utils.NewEnvironment(utils.DateFormat_dd_MM_yyyy, utils.TimeFormat_HH_mm_ss, time.UTC)
+	env := utils.NewEnvironment(utils.DateFormat_dd_MM_yyyy, utils.TimeFormat_HH_mm_ss, time.UTC, utils.LanguageList{})
 
 	for _, test := range testTests {
 		testFunc := XTESTS[test.name]

--- a/flows/actions/save_contact_field.go
+++ b/flows/actions/save_contact_field.go
@@ -55,26 +55,7 @@ func (a *SaveContactField) Execute(run flows.FlowRun, step flows.Step) error {
 		run.AddError(step, err)
 	}
 
-	// if this is either name or language, we save directly to the contact
-	if a.FieldName == "name" && a.FieldUUID == "" {
-		run.Contact().SetName(value)
-	} else if a.FieldName == "language" && a.FieldUUID == "" {
-		// try to parse our language
-		lang := utils.NilLanguage
-		lang, err = utils.ParseLanguage(value)
-
-		// if this doesn't look valid, log an error and don't set our language
-		if err != nil {
-			run.AddError(step, err)
-		} else {
-			run.Contact().SetLanguage(lang)
-			run.SetLanguage(lang)
-			value = string(lang)
-		}
-	} else {
-		// save to our field dictionary
-		run.Contact().Fields().Save(a.FieldUUID, a.FieldName, value)
-	}
+	run.Contact().Fields().Save(a.FieldUUID, a.FieldName, value)
 
 	// log our event
 	if err == nil {

--- a/flows/actions/update_contact.go
+++ b/flows/actions/update_contact.go
@@ -68,7 +68,6 @@ func (a *UpdateContactAction) Execute(run flows.FlowRun, step flows.Step) error 
 			run.AddError(step, err)
 		} else {
 			run.Contact().SetLanguage(lang)
-			run.SetLanguages(run.Contact().PreferredLanguages())
 			value = string(lang)
 		}
 	}

--- a/flows/actions/update_contact.go
+++ b/flows/actions/update_contact.go
@@ -68,7 +68,7 @@ func (a *UpdateContactAction) Execute(run flows.FlowRun, step flows.Step) error 
 			run.AddError(step, err)
 		} else {
 			run.Contact().SetLanguage(lang)
-			run.SetLanguage(lang)
+			run.SetLanguages(run.Contact().PreferredLanguages())
 			value = string(lang)
 		}
 	}

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -11,14 +11,13 @@ import (
 
 // Contact represents a single contact
 type Contact struct {
-	uuid              ContactUUID
-	name              string
-	language          utils.Language
-	backdownLanguages utils.LanguageList
-	timezone          *time.Location
-	urns              URNList
-	groups            GroupList
-	fields            *Fields
+	uuid     ContactUUID
+	name     string
+	language utils.Language
+	timezone *time.Location
+	urns     URNList
+	groups   GroupList
+	fields   *Fields
 }
 
 // SetLanguage sets the language for this contact
@@ -27,16 +26,8 @@ func (c *Contact) SetLanguage(lang utils.Language) { c.language = lang }
 // Language gets the language for this contact
 func (c *Contact) Language() utils.Language { return c.language }
 
-// PreferredLanguages gets all languages for this contact in order of preference
-func (c *Contact) PreferredLanguages() utils.LanguageList {
-	var languages utils.LanguageList
-
-	if c.language != utils.NilLanguage {
-		languages = append(languages, c.language)
-	}
-
-	return append(languages, c.backdownLanguages...)
-}
+// Language gets the language for this contact
+func (c *Contact) PreferredLanguages() utils.LanguageList { return utils.LanguageList{c.language} }
 
 func (c *Contact) SetTimezone(tz *time.Location) {
 	if tz == nil {
@@ -130,14 +121,13 @@ func ReadContact(data json.RawMessage) (*Contact, error) {
 }
 
 type contactEnvelope struct {
-	UUID              ContactUUID        `json:"uuid"`
-	Name              string             `json:"name"`
-	Language          utils.Language     `json:"language"`
-	BackdownLanguages utils.LanguageList `json:"backdown_languages,omitempty"`
-	Timezone          string             `json:"timezone"`
-	URNs              URNList            `json:"urns"`
-	Groups            GroupList          `json:"groups"`
-	Fields            *Fields            `json:"fields,omitempty"`
+	UUID     ContactUUID    `json:"uuid"`
+	Name     string         `json:"name"`
+	Language utils.Language `json:"language"`
+	Timezone string         `json:"timezone"`
+	URNs     URNList        `json:"urns"`
+	Groups   GroupList      `json:"groups"`
+	Fields   *Fields        `json:"fields,omitempty"`
 }
 
 func (c *Contact) UnmarshalJSON(data []byte) error {
@@ -152,7 +142,6 @@ func (c *Contact) UnmarshalJSON(data []byte) error {
 	c.name = ce.Name
 	c.uuid = ce.UUID
 	c.language = ce.Language
-	c.backdownLanguages = ce.BackdownLanguages
 	tz, err := time.LoadLocation(ce.Timezone)
 	if err != nil {
 		return err
@@ -186,7 +175,6 @@ func (c *Contact) MarshalJSON() ([]byte, error) {
 	ce.Name = c.name
 	ce.UUID = c.uuid
 	ce.Language = c.language
-	ce.BackdownLanguages = c.backdownLanguages
 	ce.Timezone = c.timezone.String()
 	ce.URNs = c.urns
 	ce.Groups = c.groups

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -26,15 +26,8 @@ func (c *Contact) SetLanguage(lang utils.Language) { c.language = lang }
 // Language gets the language for this contact
 func (c *Contact) Language() utils.Language { return c.language }
 
-// Language gets the language for this contact
-func (c *Contact) PreferredLanguages() utils.LanguageList { return utils.LanguageList{c.language} }
-
 func (c *Contact) SetTimezone(tz *time.Location) {
-	if tz == nil {
-		c.timezone = time.UTC
-	} else {
-		c.timezone = tz
-	}
+	c.timezone = tz
 }
 func (c *Contact) Timezone() *time.Location { return c.timezone }
 
@@ -175,10 +168,12 @@ func (c *Contact) MarshalJSON() ([]byte, error) {
 	ce.Name = c.name
 	ce.UUID = c.uuid
 	ce.Language = c.language
-	ce.Timezone = c.timezone.String()
 	ce.URNs = c.urns
 	ce.Groups = c.groups
 	ce.Fields = c.fields
+	if c.timezone != nil {
+		ce.Timezone = c.timezone.String()
+	}
 
 	return json.Marshal(ce)
 }

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -11,14 +11,14 @@ import (
 
 // Contact represents a single contact
 type Contact struct {
-	uuid           ContactUUID
-	name           string
-	language       utils.Language
-	otherLanguages utils.LanguageList
-	timezone       *time.Location
-	urns           URNList
-	groups         GroupList
-	fields         *Fields
+	uuid              ContactUUID
+	name              string
+	language          utils.Language
+	backdownLanguages utils.LanguageList
+	timezone          *time.Location
+	urns              URNList
+	groups            GroupList
+	fields            *Fields
 }
 
 // SetLanguage sets the language for this contact
@@ -35,7 +35,7 @@ func (c *Contact) PreferredLanguages() utils.LanguageList {
 		languages = append(languages, c.language)
 	}
 
-	return append(languages, c.otherLanguages...)
+	return append(languages, c.backdownLanguages...)
 }
 
 func (c *Contact) SetTimezone(tz *time.Location) {
@@ -130,14 +130,14 @@ func ReadContact(data json.RawMessage) (*Contact, error) {
 }
 
 type contactEnvelope struct {
-	UUID           ContactUUID        `json:"uuid"`
-	Name           string             `json:"name"`
-	Language       utils.Language     `json:"language"`
-	OtherLanguages utils.LanguageList `json:"other_languages,omitempty"`
-	Timezone       string             `json:"timezone"`
-	URNs           URNList            `json:"urns"`
-	Groups         GroupList          `json:"groups"`
-	Fields         *Fields            `json:"fields,omitempty"`
+	UUID              ContactUUID        `json:"uuid"`
+	Name              string             `json:"name"`
+	Language          utils.Language     `json:"language"`
+	BackdownLanguages utils.LanguageList `json:"backdown_languages,omitempty"`
+	Timezone          string             `json:"timezone"`
+	URNs              URNList            `json:"urns"`
+	Groups            GroupList          `json:"groups"`
+	Fields            *Fields            `json:"fields,omitempty"`
 }
 
 func (c *Contact) UnmarshalJSON(data []byte) error {
@@ -152,7 +152,7 @@ func (c *Contact) UnmarshalJSON(data []byte) error {
 	c.name = ce.Name
 	c.uuid = ce.UUID
 	c.language = ce.Language
-	c.otherLanguages = ce.OtherLanguages
+	c.backdownLanguages = ce.BackdownLanguages
 	tz, err := time.LoadLocation(ce.Timezone)
 	if err != nil {
 		return err
@@ -186,7 +186,7 @@ func (c *Contact) MarshalJSON() ([]byte, error) {
 	ce.Name = c.name
 	ce.UUID = c.uuid
 	ce.Language = c.language
-	ce.OtherLanguages = c.otherLanguages
+	ce.BackdownLanguages = c.backdownLanguages
 	ce.Timezone = c.timezone.String()
 	ce.URNs = c.urns
 	ce.Groups = c.groups

--- a/flows/definition/localization.go
+++ b/flows/definition/localization.go
@@ -11,21 +11,24 @@ type itemTranslations map[string][]string
 // languageTranslations map a node uuid to item_translations - say "node1-asdf" to { "text": "je suis francais!" }
 type languageTranslations map[flows.UUID]itemTranslations
 
-func (t *languageTranslations) GetTextArray(uuid flows.UUID, key string) ([]string, bool) {
+func (t *languageTranslations) GetTextArray(uuid flows.UUID, key string) []string {
 	item, found := (*t)[uuid]
 	if found {
 		translation, found := item[key]
 		if found {
-			return translation, true
+			return translation
 		}
 	}
-	return nil, false
+	return nil
 }
 
 // flowTranslations are our top level container for all the translations for a language
 type flowTranslations map[utils.Language]*languageTranslations
 
-func (t *flowTranslations) GetLanguageTranslations(lang utils.Language) (flows.Translations, bool) {
+func (t *flowTranslations) GetLanguageTranslations(lang utils.Language) flows.Translations {
 	translations, found := (*t)[lang]
-	return translations, found
+	if found {
+		return translations
+	}
+	return nil
 }

--- a/flows/definition/localization.go
+++ b/flows/definition/localization.go
@@ -11,35 +11,21 @@ type itemTranslations map[string][]string
 // languageTranslations map a node uuid to item_translations - say "node1-asdf" to { "text": "je suis francais!" }
 type languageTranslations map[flows.UUID]itemTranslations
 
-func (t *languageTranslations) GetTranslations(uuid flows.UUID, key string, backdown []string) []string {
+func (t *languageTranslations) GetTextArray(uuid flows.UUID, key string) ([]string, bool) {
 	item, found := (*t)[uuid]
 	if found {
 		translation, found := item[key]
 		if found {
-			return translation
+			return translation, true
 		}
 	}
-	return backdown
-}
-
-func (t *languageTranslations) GetText(uuid flows.UUID, key string, backdown string) string {
-	item, found := (*t)[uuid]
-	if found {
-		translation, found := item[key]
-		if found && len(translation) > 0 {
-			return translation[0]
-		}
-	}
-	return backdown
+	return nil, false
 }
 
 // flowTranslations are our top level container for all the translations for a language
 type flowTranslations map[utils.Language]*languageTranslations
 
-func (t *flowTranslations) GetTranslations(lang utils.Language) flows.Translations {
+func (t *flowTranslations) GetLanguageTranslations(lang utils.Language) (flows.Translations, bool) {
 	translations, found := (*t)[lang]
-	if found {
-		return translations
-	}
-	return nil
+	return translations, found
 }

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -10,9 +10,6 @@ import (
 
 // StartFlow starts the flow for the passed in contact, returning the created FlowRun
 func StartFlow(env flows.FlowEnvironment, flow flows.Flow, contact *flows.Contact, parent flows.FlowRun, input flows.Input, extra json.RawMessage) (flows.Session, error) {
-	// set our environment's timezone to our contact's timezone
-	env.SetTimezone(contact.Timezone())
-
 	// build our run
 	run := flow.CreateRun(env, contact, parent)
 
@@ -39,9 +36,6 @@ func StartFlow(env flows.FlowEnvironment, flow flows.Flow, contact *flows.Contac
 
 // ResumeFlow resumes our flow from the last step
 func ResumeFlow(env flows.FlowEnvironment, run flows.FlowRun, event flows.Event) (flows.Session, error) {
-	// set our environment's timezone to our contact's timezone
-	env.SetTimezone(run.Contact().Timezone())
-
 	// to resume a flow, hydrate our run with the environment
 	err := run.Hydrate(env)
 	if err != nil {

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -32,7 +32,8 @@ func StartFlow(env flows.FlowEnvironment, flow flows.Flow, contact *flows.Contac
 		return run.Session(), nil
 	}
 
-	initTranslations(run)
+	// set our language based on our contact
+	run.SetLanguages(run.Contact().PreferredLanguages())
 
 	// off to the races
 	err := continueRunUntilWait(run, flow.Nodes()[0].UUID(), nil, input)
@@ -55,7 +56,8 @@ func ResumeFlow(env flows.FlowEnvironment, run flows.FlowRun, event flows.Event)
 		return run.Session(), nil
 	}
 
-	initTranslations(run)
+	// set our language based on our contact
+	run.SetLanguages(run.Contact().PreferredLanguages())
 
 	// grab the last step
 	step := run.Path()[len(run.Path())-1]
@@ -93,20 +95,6 @@ func ResumeFlow(env flows.FlowEnvironment, run flows.FlowRun, event flows.Event)
 	}
 
 	return run.Session(), nil
-}
-
-// initializes our context based on our flow and current context
-func initTranslations(run flows.FlowRun) {
-	// set our language based on our contact if we have one
-	contact := run.Contact()
-	if contact != nil {
-		run.SetLanguage(contact.Language())
-	} else {
-		run.SetLanguage(run.Flow().Language())
-	}
-
-	// set the translations on our context
-	run.SetFlowTranslations(run.Flow().Translations())
 }
 
 // Continues the flow entering the passed in flow

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -32,9 +32,6 @@ func StartFlow(env flows.FlowEnvironment, flow flows.Flow, contact *flows.Contac
 		return run.Session(), nil
 	}
 
-	// set our language based on our contact
-	run.SetLanguages(run.Contact().PreferredLanguages())
-
 	// off to the races
 	err := continueRunUntilWait(run, flow.Nodes()[0].UUID(), nil, input)
 	return run.Session(), err
@@ -55,9 +52,6 @@ func ResumeFlow(env flows.FlowEnvironment, run flows.FlowRun, event flows.Event)
 	if len(run.Path()) == 0 {
 		return run.Session(), nil
 	}
-
-	// set our language based on our contact
-	run.SetLanguages(run.Contact().PreferredLanguages())
 
 	// grab the last step
 	step := run.Path()[len(run.Path())-1]

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -246,7 +246,6 @@ type FlowRun interface {
 	CreateStep(Node) Step
 	Path() []Step
 
-	SetLanguages(utils.LanguageList)
 	GetText(uuid UUID, key string, native string) string
 	GetTextArray(uuid UUID, key string, native []string) []string
 

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -148,13 +148,12 @@ type Wait interface {
 
 // FlowTranslations provide a way to get the Translations for a flow for a specific language
 type FlowTranslations interface {
-	GetTranslations(utils.Language) Translations
+	GetLanguageTranslations(utils.Language) (Translations, bool)
 }
 
 // Translations provide a way to get the translation for a specific language for a uuid/key pair
 type Translations interface {
-	GetText(uuid UUID, key string, backdown string) string
-	GetTranslations(uuid UUID, key string, backdown []string) []string
+	GetTextArray(uuid UUID, key string) ([]string, bool)
 }
 
 type Context interface {
@@ -247,10 +246,9 @@ type FlowRun interface {
 	CreateStep(Node) Step
 	Path() []Step
 
-	SetLanguage(utils.Language)
-	SetFlowTranslations(FlowTranslations)
-	GetText(uuid UUID, key string, backdown string) string
-	GetTranslations(uuid UUID, key string, backdown []string) []string
+	SetLanguages(utils.LanguageList)
+	GetText(uuid UUID, key string, native string) string
+	GetTextArray(uuid UUID, key string, native []string) []string
 
 	Webhook() *utils.RequestResponse
 	SetWebhook(*utils.RequestResponse)

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -148,12 +148,12 @@ type Wait interface {
 
 // FlowTranslations provide a way to get the Translations for a flow for a specific language
 type FlowTranslations interface {
-	GetLanguageTranslations(utils.Language) (Translations, bool)
+	GetLanguageTranslations(utils.Language) Translations
 }
 
 // Translations provide a way to get the translation for a specific language for a uuid/key pair
 type Translations interface {
-	GetTextArray(uuid UUID, key string) ([]string, bool)
+	GetTextArray(uuid UUID, key string) []string
 }
 
 type Context interface {

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -84,7 +84,7 @@ func (r *SwitchRouter) PickRoute(run flows.FlowRun, exits []flows.Exit, step flo
 		args := make([]interface{}, len(c.Arguments)+1)
 		args[0] = operand
 
-		localizedArgs := run.GetTranslations(c.UUID, "arguments", c.Arguments)
+		localizedArgs := run.GetTextArray(c.UUID, "arguments", c.Arguments)
 		for i := range c.Arguments {
 			test := localizedArgs[i]
 			args[i+1], err = excellent.EvaluateTemplate(env, run.Context(), test)

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -210,7 +210,7 @@ func (r *flowRun) ExitedOn() *time.Time        { return r.exitedOn }
 func (r *flowRun) SetLanguages(langs utils.LanguageList) {
 	r.languages = langs
 
-	// if languge list doesn't include the flow's native language, add that last
+	// if language list doesn't include the flow's native language, add that last
 	includesFlowLang := false
 	for _, lang := range r.languages {
 		if lang == r.Flow().Language() {

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -208,7 +208,18 @@ func (r *flowRun) TimesOutOn() *time.Time      { return r.timesOutOn }
 func (r *flowRun) ExitedOn() *time.Time        { return r.exitedOn }
 
 func (r *flowRun) SetLanguages(langs utils.LanguageList) {
-	r.languages = append(langs, r.Flow().Language())
+	r.languages = langs
+
+	// if languge list doesn't include the flow's native language, add that last
+	includesFlowLang := false
+	for _, lang := range r.languages {
+		if lang == r.Flow().Language() {
+			includesFlowLang = true
+		}
+	}
+	if !includesFlowLang {
+		r.languages = append(r.languages, r.Flow().Language())
+	}
 }
 func (r *flowRun) GetText(uuid flows.UUID, key string, native string) string {
 	textArray := r.GetTextArray(uuid, key, []string{native})

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -77,10 +77,8 @@ func (r *flowRun) Hydrate(env flows.FlowEnvironment) error {
 	if err != nil {
 		return err
 	}
-	r.contact = runContact
 
-	// build our context
-	r.context = NewContextForContact(runContact, r)
+	r.setContact(runContact)
 
 	// populate our run references
 	if r.parent != nil {
@@ -100,6 +98,19 @@ func (r *flowRun) Hydrate(env flows.FlowEnvironment) error {
 	}
 
 	return nil
+}
+
+func (r *flowRun) setContact(contact *flows.Contact) {
+	r.contact = contact
+
+	// build our context
+	r.context = NewContextForContact(contact, r)
+
+	if contact != nil {
+		r.SetLanguages(contact.PreferredLanguages())
+	} else {
+		r.SetLanguages(nil)
+	}
 }
 
 func (r *flowRun) FlowUUID() flows.FlowUUID       { return r.flowUUID }
@@ -238,8 +249,7 @@ func NewRun(env flows.FlowEnvironment, flow flows.Flow, contact *flows.Contact, 
 		modifiedOn:  now,
 	}
 
-	// create our new context
-	r.context = NewContextForContact(contact, r)
+	r.setContact(contact)
 
 	// set our session
 	if parent != nil {

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -210,10 +210,10 @@ func (r *flowRun) GetTextArray(uuid flows.UUID, key string, native []string) []s
 			return native
 		}
 
-		translations, found := r.Flow().Translations().GetLanguageTranslations(lang)
-		if found {
-			textArray, found := translations.GetTextArray(uuid, key)
-			if found && len(textArray) == len(native) {
+		translations := r.Flow().Translations().GetLanguageTranslations(lang)
+		if translations != nil {
+			textArray := translations.GetTextArray(uuid, key)
+			if textArray != nil && len(textArray) == len(native) {
 				return textArray
 			}
 		}

--- a/utils/dates_test.go
+++ b/utils/dates_test.go
@@ -57,7 +57,7 @@ var timeTests = []struct {
 }
 
 func TestDateFromString(t *testing.T) {
-	env := NewEnvironment(DateFormat_dd_MM_yyyy, TimeFormat_HH_mm_ss, time.UTC)
+	env := NewEnvironment(DateFormat_dd_MM_yyyy, TimeFormat_HH_mm_ss, time.UTC, LanguageList{})
 
 	for _, test := range timeTests {
 		env.SetDateFormat(test.DateFormat)

--- a/utils/language.go
+++ b/utils/language.go
@@ -12,6 +12,8 @@ type Language string
 // NilLanguage represents our nil, or unknown language
 var NilLanguage = Language("")
 
+type LanguageList []Language
+
 // ParseLanguage returns a new Language for the passed in language string, or an error if not found
 func ParseLanguage(lang string) (Language, error) {
 	if len(lang) != 3 {

--- a/utils/language.go
+++ b/utils/language.go
@@ -12,8 +12,6 @@ type Language string
 // NilLanguage represents our nil, or unknown language
 var NilLanguage = Language("")
 
-type LanguageList []Language
-
 // ParseLanguage returns a new Language for the passed in language string, or an error if not found
 func ParseLanguage(lang string) (Language, error) {
 	if len(lang) != 3 {
@@ -26,4 +24,18 @@ func ParseLanguage(lang string) (Language, error) {
 	}
 
 	return Language(base.ISO3()), nil
+}
+
+type LanguageList []Language
+
+func (ll LanguageList) RemoveDuplicates() LanguageList {
+	result := LanguageList{}
+	seen := map[Language]bool{}
+	for _, val := range ll {
+		if _, ok := seen[val]; !ok {
+			result = append(result, val)
+			seen[val] = true
+		}
+	}
+	return result
 }


### PR DESCRIPTION
Gets rid FlowRun.flowTranslations altogether because we can't pick a single language translation for the run - that translation might not have a specific text, so need to always cascade thru all the language translations.