### PR TITLE
Self-describing constants for run and webhook statuses

### DIFF
--- a/cmd/flowrunner/testdata/flows/all_actions_test.json
+++ b/cmd/flowrunner/testdata/flows/all_actions_test.json
@@ -172,7 +172,7 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
             "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-            "status": "S",
+            "status": "success",
             "status_code": 200,
             "type": "webhook_called",
             "url": "http://127.0.0.1:49999/?cmd=success"
@@ -306,7 +306,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-                    "status": "S",
+                    "status": "success",
                     "status_code": 200,
                     "type": "webhook_called",
                     "url": "http://127.0.0.1:49999/?cmd=success"
@@ -333,7 +333,7 @@
               "body": "{ \"ok\": \"true\" }",
               "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
               "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-              "status": "S",
+              "status": "success",
               "status_code": 200,
               "url": "http://127.0.0.1:49999/?cmd=success"
             }

--- a/cmd/flowrunner/testdata/flows/all_actions_test.json
+++ b/cmd/flowrunner/testdata/flows/all_actions_test.json
@@ -64,7 +64,7 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
             "flow_uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
-            "status": "C",
+            "status": "completed",
             "type": "flow_exited"
           },
           "step_uuid": ""
@@ -238,7 +238,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "exited_on": "2000-01-01T00:00:00.000000000-00:00",
                     "flow_uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
-                    "status": "C",
+                    "status": "completed",
                     "type": "flow_exited"
                   },
                   {
@@ -326,7 +326,7 @@
                 "value": "m"
               }
             },
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "webhook": {
@@ -349,7 +349,7 @@
             "parent_uuid": "",
             "path": [],
             "results": {},
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/brochure_test.json
+++ b/cmd/flowrunner/testdata/flows/brochure_test.json
@@ -72,7 +72,7 @@
               }
             ],
             "results": {},
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -236,7 +236,7 @@
                 "value": "Ryan Lewis"
               }
             },
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/date_parse_test.json
+++ b/cmd/flowrunner/testdata/flows/date_parse_test.json
@@ -63,7 +63,7 @@
               }
             ],
             "results": {},
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -196,7 +196,7 @@
                 "value": "1977-06-23T15:34:00.000000-05:00"
               }
             },
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/default_result_test.json
+++ b/cmd/flowrunner/testdata/flows/default_result_test.json
@@ -72,7 +72,7 @@
               }
             ],
             "results": {},
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -229,7 +229,7 @@
                 "value": "Ryan Lewis"
               }
             },
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/empty_test.json
+++ b/cmd/flowrunner/testdata/flows/empty_test.json
@@ -15,7 +15,7 @@
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",
             "path": [],
             "results": {},
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/node_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/node_loop_test.json
@@ -56,7 +56,7 @@
               }
             ],
             "results": {},
-            "status": "E",
+            "status": "errored",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/subflow.json
+++ b/cmd/flowrunner/testdata/flows/subflow.json
@@ -31,7 +31,7 @@
                             "uuid": "19a95efc-ac69-4b6a-a90b-f84a60b49e4f",
                             "type": "has_run_status",
                             "arguments": [
-                                "C"
+                                "completed"
                             ],
                             "exit_uuid": "2ce7eeea-ee70-4e1a-b8f4-84d8102a8aef"
                         },

--- a/cmd/flowrunner/testdata/flows/subflow_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_loop_test.json
@@ -69,7 +69,7 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
             "flow_uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
-            "status": "E",
+            "status": "errored",
             "type": "flow_exited"
           },
           "step_uuid": ""
@@ -90,7 +90,7 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
             "flow_uuid": "a8d27b94-d3d0-4a96-8074-0f162f342195",
-            "status": "E",
+            "status": "errored",
             "type": "flow_exited"
           },
           "step_uuid": ""
@@ -137,7 +137,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "exited_on": "2000-01-01T00:00:00.000000000-00:00",
                     "flow_uuid": "a8d27b94-d3d0-4a96-8074-0f162f342195",
-                    "status": "E",
+                    "status": "errored",
                     "type": "flow_exited"
                   },
                   {
@@ -151,7 +151,7 @@
               }
             ],
             "results": {},
-            "status": "E",
+            "status": "errored",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           },
@@ -186,7 +186,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "exited_on": "2000-01-01T00:00:00.000000000-00:00",
                     "flow_uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
-                    "status": "E",
+                    "status": "errored",
                     "type": "flow_exited"
                   },
                   {
@@ -200,7 +200,7 @@
               }
             ],
             "results": {},
-            "status": "E",
+            "status": "errored",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           },
@@ -234,7 +234,7 @@
               }
             ],
             "results": {},
-            "status": "E",
+            "status": "errored",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/subflow_other.json
+++ b/cmd/flowrunner/testdata/flows/subflow_other.json
@@ -39,7 +39,7 @@
                             "type": "has_run_status",
                             "uuid": "57eda3da-817b-4942-a5fc-e1ea5d12c82d",
                             "arguments": [
-                                "C"
+                                "completed"
                             ],
                             "exit_uuid": "f68d80e5-651c-404a-bbc0-efa6966254a6"
                         }

--- a/cmd/flowrunner/testdata/flows/subflow_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_test.json
@@ -99,7 +99,7 @@
               }
             ],
             "results": {},
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -137,7 +137,7 @@
               }
             ],
             "results": {},
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -178,7 +178,7 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
             "flow_uuid": "a8d27b94-d3d0-4a96-8074-0f162f342195",
-            "status": "C",
+            "status": "completed",
             "type": "flow_exited"
           },
           "step_uuid": ""
@@ -231,7 +231,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "exited_on": "2000-01-01T00:00:00.000000000-00:00",
                     "flow_uuid": "a8d27b94-d3d0-4a96-8074-0f162f342195",
-                    "status": "C",
+                    "status": "completed",
                     "type": "flow_exited"
                   }
                 ],
@@ -256,7 +256,7 @@
               }
             ],
             "results": {},
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           },
@@ -338,7 +338,7 @@
                 "value": "Ryan Lewis"
               }
             },
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": ""
           }

--- a/cmd/flowrunner/testdata/flows/two_questions_test.json
+++ b/cmd/flowrunner/testdata/flows/two_questions_test.json
@@ -246,7 +246,7 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "request": "POST /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nContent-Length: 69\r\nAccept-Encoding: gzip\r\n\r\n{ \"contact\": \"ba96bf7f-bc2a-4873-a7c7-254d1927c4e3\", \"soda\": \"Coke\" }",
             "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-            "status": "S",
+            "status": "success",
             "status_code": 200,
             "type": "webhook_called",
             "url": "http://127.0.0.1:49999/?cmd=success"
@@ -368,7 +368,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "request": "POST /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nContent-Length: 69\r\nAccept-Encoding: gzip\r\n\r\n{ \"contact\": \"ba96bf7f-bc2a-4873-a7c7-254d1927c4e3\", \"soda\": \"Coke\" }",
                     "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-                    "status": "S",
+                    "status": "success",
                     "status_code": 200,
                     "type": "webhook_called",
                     "url": "http://127.0.0.1:49999/?cmd=success"
@@ -408,7 +408,7 @@
               "body": "{ \"ok\": \"true\" }",
               "request": "POST /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nContent-Length: 69\r\nAccept-Encoding: gzip\r\n\r\n{ \"contact\": \"ba96bf7f-bc2a-4873-a7c7-254d1927c4e3\", \"soda\": \"Coke\" }",
               "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-              "status": "S",
+              "status": "success",
               "status_code": 200,
               "url": "http://127.0.0.1:49999/?cmd=success"
             }

--- a/cmd/flowrunner/testdata/flows/two_questions_test.json
+++ b/cmd/flowrunner/testdata/flows/two_questions_test.json
@@ -71,7 +71,7 @@
               }
             ],
             "results": {},
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -215,7 +215,7 @@
                 "value": "Blue"
               }
             },
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -401,7 +401,7 @@
                 "value": "Coke"
               }
             },
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "webhook": {

--- a/cmd/flowrunner/testdata/flows/webhook_persists.json
+++ b/cmd/flowrunner/testdata/flows/webhook_persists.json
@@ -48,7 +48,7 @@
                     "cases": [
                         {
                             "arguments": [
-                                "S"
+                                "success"
                             ],
                             "uuid": "789b45bc-005a-46db-8331-6a966c0141c2",
                             "exit_uuid": "bb09f6b6-89f4-45bd-8cc9-1d4655914590",

--- a/cmd/flowrunner/testdata/flows/webhook_persists_test.json
+++ b/cmd/flowrunner/testdata/flows/webhook_persists_test.json
@@ -28,7 +28,7 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
             "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-            "status": "S",
+            "status": "success",
             "status_code": 200,
             "type": "webhook_called",
             "url": "http://127.0.0.1:49999/?cmd=success"
@@ -88,7 +88,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-                    "status": "S",
+                    "status": "success",
                     "status_code": 200,
                     "type": "webhook_called",
                     "url": "http://127.0.0.1:49999/?cmd=success"
@@ -138,7 +138,7 @@
               "body": "{ \"ok\": \"true\" }",
               "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
               "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-              "status": "S",
+              "status": "success",
               "status_code": 200,
               "url": "http://127.0.0.1:49999/?cmd=success"
             }
@@ -200,7 +200,7 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-                    "status": "S",
+                    "status": "success",
                     "status_code": 200,
                     "type": "webhook_called",
                     "url": "http://127.0.0.1:49999/?cmd=success"
@@ -272,7 +272,7 @@
               "body": "{ \"ok\": \"true\" }",
               "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
               "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: \r\n\r\n{ \"ok\": \"true\" }",
-              "status": "S",
+              "status": "success",
               "status_code": 200,
               "url": "http://127.0.0.1:49999/?cmd=success"
             }

--- a/cmd/flowrunner/testdata/flows/webhook_persists_test.json
+++ b/cmd/flowrunner/testdata/flows/webhook_persists_test.json
@@ -128,7 +128,7 @@
               }
             ],
             "results": {},
-            "status": "A",
+            "status": "active",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "wait": {
@@ -265,7 +265,7 @@
               }
             ],
             "results": {},
-            "status": "C",
+            "status": "completed",
             "timesout_on": "2000-01-01T00:00:00.000000000-00:00",
             "uuid": "",
             "webhook": {

--- a/excellent/tests.go
+++ b/excellent/tests.go
@@ -200,11 +200,11 @@ func HasRunStatus(env utils.Environment, args ...interface{}) interface{} {
 
 // HasWebhookStatus returns whether the passed in webhook response, `response`, has the passed in status
 //
-// Valid webhook statuses are "S" for success, "F" for a connection failure and "E" for
+// Valid webhook statuses are "success", "connection_error" for a connection error, and "response_error" for
 // a non-2xx response code.
 //
-//  @(has_webhook_status(webhook, "S")) -> true
-//  @(has_webhook_status(webhook, "F")) -> false
+//  @(has_webhook_status(webhook, "success")) -> true
+//  @(has_webhook_status(webhook, "connection_error")) -> false
 //
 // @test has_webhook_status(response)
 func HasWebhookStatus(env utils.Environment, args ...interface{}) interface{} {
@@ -223,7 +223,7 @@ func HasWebhookStatus(env utils.Environment, args ...interface{}) interface{} {
 		return fmt.Errorf("HAS_WEBHOOK_STATUS must be called with a string as second argument")
 	}
 
-	if utils.RequestResponseStatus(strings.ToUpper(status)) == rr.Status() {
+	if utils.RequestResponseStatus(strings.ToLower(status)) == rr.Status() {
 		return XTestResult{true, rr.Status()}
 	}
 

--- a/excellent/tests.go
+++ b/excellent/tests.go
@@ -169,11 +169,10 @@ func HasValue(env utils.Environment, args ...interface{}) interface{} {
 
 // HasRunStatus returns whether `run` has the passed in status
 //
-// Valid run statuses are "A" for active, "C" for complete, "E" for expired
-// and "I" for interrupted
+// Valid run statuses are "active", "completed", "expired" and "interrupted"
 //
-//  @(has_run_status(run, "C")) -> true
-//  @(has_run_status(child, "E")) -> false
+//  @(has_run_status(run, "completed")) -> true
+//  @(has_run_status(child, "expired")) -> false
 //
 // @test has_run_status(run)
 func HasRunStatus(env utils.Environment, args ...interface{}) interface{} {
@@ -192,7 +191,7 @@ func HasRunStatus(env utils.Environment, args ...interface{}) interface{} {
 		return fmt.Errorf("HAS_RUN_STATUS must be called with a string as second argument")
 	}
 
-	if flows.RunStatus(strings.ToUpper(status)) == run.Status() {
+	if flows.RunStatus(strings.ToLower(status)) == run.Status() {
 		return XTestResult{true, run.Status()}
 	}
 

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -345,9 +345,9 @@ func createCase(baseLanguage utils.Language, exitMap map[string]flows.Exit, r le
 		test := subflowTest{}
 		err = json.Unmarshal(r.Test.Data, &test)
 		if test.ExitType == "completed" {
-			arguments = []string{"C"}
+			arguments = []string{"completed"}
 		} else {
-			arguments = []string{"E"}
+			arguments = []string{"errored"}
 		}
 	case "webhook_status":
 		test := webhookTest{}

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -354,7 +354,7 @@ func createCase(baseLanguage utils.Language, exitMap map[string]flows.Exit, r le
 		err = json.Unmarshal(r.Test.Data, &test)
 		if test.Status == "success" {
 			testType = "has_webhook_status"
-			arguments = []string{"S"}
+			arguments = []string{"success"}
 		} else {
 			return routers.Case{}, fmt.Errorf("No failure test")
 		}

--- a/flows/events/flow_exited.go
+++ b/flows/events/flow_exited.go
@@ -20,7 +20,7 @@ const TypeFlowExited string = "flow_exited"
 //    "flow_uuid": "0e06f977-cbb7-475f-9d0b-a0c4aaec7f6a",
 //    "contact_uuid": "95eb96df-461b-4668-b168-727f8ceb13dd",
 //    "exited_on": "2006-01-02T15:04:05Z",
-//    "status": "C"
+//    "status": "completed"
 //   }
 // ```
 //

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -72,19 +72,19 @@ type RunStatus string
 
 const (
 	// StatusActive represents an active flow run that is awaiting input
-	StatusActive RunStatus = "A"
+	StatusActive RunStatus = "active"
 
 	// StatusCompleted represents a flow run that has run to completion
-	StatusCompleted RunStatus = "C"
+	StatusCompleted RunStatus = "completed"
 
 	// StatusErrored represents a flow run that encountered an error
-	StatusErrored RunStatus = "E"
+	StatusErrored RunStatus = "errored"
 
 	// StatusExpired represents a flow run that expired due to inactivity
-	StatusExpired RunStatus = "X"
+	StatusExpired RunStatus = "expired"
 
 	// StatusInterrupted represents a flow run that was interrupted by another flow
-	StatusInterrupted RunStatus = "I"
+	StatusInterrupted RunStatus = "interrupted"
 )
 
 func (r RunStatus) String() string { return string(r) }

--- a/utils/http.go
+++ b/utils/http.go
@@ -17,13 +17,13 @@ type RequestResponseStatus string
 
 const (
 	// RRSuccess represents that the webhook was successful
-	RRSuccess RequestResponseStatus = "S"
+	RRSuccess RequestResponseStatus = "success"
 
-	// RRConnectionFailure represents that the webhook had a connection failure
-	RRConnectionFailure RequestResponseStatus = "F"
+	// RRConnectionError represents that the webhook had a connection error
+	RRConnectionError RequestResponseStatus = "connection_error"
 
-	// RRStatusFailure represents that the webhook had a non 2xx status code
-	RRStatusFailure RequestResponseStatus = "E"
+	// RRResponseError represents that the webhook response had a non 2xx status code
+	RRResponseError RequestResponseStatus = "response_error"
 )
 
 func (r RequestResponseStatus) String() string {
@@ -112,7 +112,7 @@ func newRRFromRequestAndError(r *http.Request, requestTrace string, requestError
 	rr.url = r.URL.String()
 
 	rr.request = requestTrace
-	rr.status = RRConnectionFailure
+	rr.status = RRConnectionError
 	rr.body = requestError.Error()
 
 	return &rr, nil
@@ -129,7 +129,7 @@ func newRRFromResponse(requestTrace string, r *http.Response) (*RequestResponse,
 	if rr.statusCode/100 == 2 {
 		rr.status = RRSuccess
 	} else {
-		rr.status = RRStatusFailure
+		rr.status = RRResponseError
 	}
 
 	rr.request = requestTrace


### PR DESCRIPTION
We use self-describing constants everywhere else for things like event types so not seeing a reason to keep these as single chars, e.g. "expired" vs "errored" instead of "E" vs "X" 