### PR TITLE
Sessions and runs refactor

### DIFF
--- a/cmd/docgen/run.go
+++ b/cmd/docgen/run.go
@@ -81,7 +81,7 @@ func createExampleSession(flowDef string) (flows.Session, error) {
 
 	// start our flow
 	env := engine.NewSessionEnvironment(utils.NewDefaultEnvironment(), []flows.Flow{subflow}, []flows.Channel{}, []*flows.Contact{})
-	return engine.StartFlow(env, flow, contact, nil, nil, nil)
+	return engine.StartFlow(env, flow, contact, nil, nil, nil, nil)
 }
 
 func eventsForAction(actionJSON []byte) (json.RawMessage, error) {

--- a/cmd/docgen/run.go
+++ b/cmd/docgen/run.go
@@ -80,7 +80,7 @@ func createExampleSession(flowDef string) (flows.Session, error) {
 	}
 
 	// start our flow
-	env := engine.NewFlowEnvironment(utils.NewDefaultEnvironment(), []flows.Flow{subflow}, []flows.FlowRun{}, []*flows.Contact{})
+	env := engine.NewSessionEnvironment(utils.NewDefaultEnvironment(), []flows.Flow{subflow}, []flows.Channel{}, []*flows.Contact{})
 	return engine.StartFlow(env, flow, contact, nil, nil, nil)
 }
 

--- a/cmd/docgen/run.go
+++ b/cmd/docgen/run.go
@@ -81,7 +81,7 @@ func createExampleSession(flowDef string) (flows.Session, error) {
 
 	// start our flow
 	env := engine.NewSessionEnvironment(utils.NewDefaultEnvironment(), []flows.Flow{subflow}, []flows.Channel{}, []*flows.Contact{})
-	return engine.StartFlow(env, flow, contact, nil, nil, nil, nil)
+	return engine.StartFlow(env, flow, contact, nil, nil, nil)
 }
 
 func eventsForAction(actionJSON []byte) (json.RawMessage, error) {

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -202,7 +202,7 @@ func main() {
 	env := engine.NewSessionEnvironment(baseEnv, runnerFlows, []flows.Channel{channel}, []*flows.Contact{contact})
 
 	// and start our flow
-	session, err := engine.StartFlow(env, runnerFlows[0], contact, nil, nil, nil, nil)
+	session, err := engine.StartFlow(env, runnerFlows[0], contact, nil, nil, nil)
 	if err != nil {
 		log.Fatal("Error starting flow: ", err)
 	}

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -190,7 +190,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Error reading channel file: ", err)
 	}
-	_, err = flows.ReadChannel(json.RawMessage(channelJSON))
+	channel, err := flows.ReadChannel(json.RawMessage(channelJSON))
 	if err != nil {
 		log.Fatal("Error unmarshalling channel: ", err)
 	}
@@ -199,10 +199,10 @@ func main() {
 	baseEnv := utils.NewDefaultEnvironment()
 	la, _ := time.LoadLocation("America/Los_Angeles")
 	baseEnv.SetTimezone(la)
-	env := engine.NewSessionEnvironment(baseEnv, runnerFlows, []flows.FlowRun{}, []*flows.Contact{contact})
+	env := engine.NewSessionEnvironment(baseEnv, runnerFlows, []flows.Channel{channel}, []*flows.Contact{contact})
 
 	// and start our flow
-	session, err := engine.StartFlow(env, runnerFlows[0], contact, nil, nil, nil)
+	session, err := engine.StartFlow(env, runnerFlows[0], contact, nil, nil, nil, nil)
 	if err != nil {
 		log.Fatal("Error starting flow: ", err)
 	}
@@ -239,21 +239,14 @@ func main() {
 		inputs = append(inputs, event)
 
 		// rebuild our session
-		session, err = runs.ReadSession(outJSON)
+		session, err = runs.ReadSession(session.Environment(), outJSON)
 		if err != nil {
 			log.Fatalf("Error unmarshalling output: %s", err)
 		}
 		baseEnv := utils.NewDefaultEnvironment()
 		la, _ := time.LoadLocation("America/Los_Angeles")
 		baseEnv.SetTimezone(la)
-		env = engine.NewSessionEnvironment(baseEnv, runnerFlows, session.Runs(), []*flows.Contact{contact})
 
-		for _, run := range session.Runs() {
-			err = run.Hydrate(env)
-			if err != nil {
-				log.Fatalf("Error hydrating run: %s", err)
-			}
-		}
 		run = session.ActiveRun()
 
 		session, err = engine.ResumeFlow(env, run, []flows.Event{event})

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -199,7 +199,7 @@ func main() {
 	baseEnv := utils.NewDefaultEnvironment()
 	la, _ := time.LoadLocation("America/Los_Angeles")
 	baseEnv.SetTimezone(la)
-	env := engine.NewFlowEnvironment(baseEnv, runnerFlows, []flows.FlowRun{}, []*flows.Contact{contact})
+	env := engine.NewSessionEnvironment(baseEnv, runnerFlows, []flows.FlowRun{}, []*flows.Contact{contact})
 
 	// and start our flow
 	session, err := engine.StartFlow(env, runnerFlows[0], contact, nil, nil, nil)
@@ -246,7 +246,7 @@ func main() {
 		baseEnv := utils.NewDefaultEnvironment()
 		la, _ := time.LoadLocation("America/Los_Angeles")
 		baseEnv.SetTimezone(la)
-		env = engine.NewFlowEnvironment(baseEnv, runnerFlows, session.Runs(), []*flows.Contact{contact})
+		env = engine.NewSessionEnvironment(baseEnv, runnerFlows, session.Runs(), []*flows.Contact{contact})
 
 		for _, run := range session.Runs() {
 			err = run.Hydrate(env)

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -109,7 +109,7 @@ func runFlow(env utils.Environment, flowFilename string, contactFilename string,
 	}
 
 	// start our contact down this flow
-	flowEnv := engine.NewFlowEnvironment(env, runnerFlows, []flows.FlowRun{}, []*flows.Contact{contact})
+	flowEnv := engine.NewSessionEnvironment(env, runnerFlows, []flows.FlowRun{}, []*flows.Contact{contact})
 	session, err := engine.StartFlow(flowEnv, runnerFlows[0], contact, nil, nil, extra)
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func runFlow(env utils.Environment, flowFilename string, contactFilename string,
 		if err != nil {
 			return nil, fmt.Errorf("Error marshalling output: %s", err)
 		}
-		flowEnv = engine.NewFlowEnvironment(env, runnerFlows, session.Runs(), []*flows.Contact{contact})
+		flowEnv = engine.NewSessionEnvironment(env, runnerFlows, session.Runs(), []*flows.Contact{contact})
 
 		// hydrate our runs so we can call ActiveRun
 		for _, r := range session.Runs() {

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -111,7 +111,7 @@ func runFlow(env utils.Environment, flowFilename string, contactFilename string,
 
 	// start our contact down this flow
 	sessionEnv := engine.NewSessionEnvironment(env, runnerFlows, []flows.Channel{channel}, []*flows.Contact{contact})
-	session, err := engine.StartFlow(sessionEnv, runnerFlows[0], contact, nil, nil, extra, nil)
+	session, err := engine.StartFlow(sessionEnv, runnerFlows[0], contact, nil, nil, extra)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -67,14 +67,14 @@ func readFile(prefix string, filename string) ([]byte, error) {
 	return bytes, err
 }
 
-func runFlow(env utils.Environment, flowFilename string, contactFilename string, channelFilename string, callerEvents []flows.Event, extra json.RawMessage) ([]*Output, error) {
+func runFlow(env utils.Environment, flowFilename string, contactFilename string, channelFilename string, callerEvents []flows.Event, extra json.RawMessage) (flows.Session, []*Output, error) {
 	flowJSON, err := readFile("flows/", flowFilename)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	runnerFlows, err := definition.ReadFlows(json.RawMessage(flowJSON))
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling flows '%s': %s", flowFilename, err)
+		return nil, nil, fmt.Errorf("Error unmarshalling flows '%s': %s", flowFilename, err)
 	}
 
 	// rewrite the URL on any webhook actions
@@ -91,28 +91,29 @@ func runFlow(env utils.Environment, flowFilename string, contactFilename string,
 
 	contactJSON, err := readFile("contacts/", contactFilename)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	contact, err := flows.ReadContact(json.RawMessage(contactJSON))
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling contact '%s': %s", contactFilename, err)
+		return nil, nil, fmt.Errorf("Error unmarshalling contact '%s': %s", contactFilename, err)
 	}
 
 	channelJSON, err := readFile("channels/", channelFilename)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	_, err = flows.ReadChannel(json.RawMessage(channelJSON))
+
+	channel, err := flows.ReadChannel(json.RawMessage(channelJSON))
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling channel '%s': %s", channelFilename, err)
+		return nil, nil, fmt.Errorf("Error unmarshalling channel '%s': %s", channelFilename, err)
 	}
 
 	// start our contact down this flow
-	flowEnv := engine.NewSessionEnvironment(env, runnerFlows, []flows.FlowRun{}, []*flows.Contact{contact})
-	session, err := engine.StartFlow(flowEnv, runnerFlows[0], contact, nil, nil, extra)
+	sessionEnv := engine.NewSessionEnvironment(env, runnerFlows, []flows.Channel{channel}, []*flows.Contact{contact})
+	session, err := engine.StartFlow(sessionEnv, runnerFlows[0], contact, nil, nil, extra, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	outputs := make([]*Output, 0)
@@ -121,43 +122,34 @@ func runFlow(env utils.Environment, flowFilename string, contactFilename string,
 	for i := range callerEvents {
 		outJSON, err := json.MarshalIndent(session, "", "  ")
 		if err != nil {
-			return nil, fmt.Errorf("Error marshalling output: %s", err)
+			return nil, nil, fmt.Errorf("Error marshalling output: %s", err)
 		}
 		outputs = append(outputs, &Output{outJSON, marshalEventLog(session.Log())})
 
-		session, err = runs.ReadSession(outJSON)
+		session, err = runs.ReadSession(sessionEnv, outJSON)
 		if err != nil {
-			return nil, fmt.Errorf("Error marshalling output: %s", err)
-		}
-		flowEnv = engine.NewSessionEnvironment(env, runnerFlows, session.Runs(), []*flows.Contact{contact})
-
-		// hydrate our runs so we can call ActiveRun
-		for _, r := range session.Runs() {
-			err := r.Hydrate(flowEnv)
-			if err != nil {
-				return nil, fmt.Errorf("Error marshalling output: %s", err)
-			}
+			return nil, nil, fmt.Errorf("Error marshalling output: %s", err)
 		}
 
 		activeRun := session.ActiveRun()
 
 		// if we aren't at a wait, that's an error
 		if activeRun == nil {
-			return nil, fmt.Errorf("Did not stop at expected wait, have unused resume events: %#v", callerEvents[i:])
+			return nil, nil, fmt.Errorf("Did not stop at expected wait, have unused resume events: %#v", callerEvents[i:])
 		}
-		session, err = engine.ResumeFlow(flowEnv, activeRun, []flows.Event{callerEvents[i]})
+		session, err = engine.ResumeFlow(sessionEnv, activeRun, []flows.Event{callerEvents[i]})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	outJSON, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("Error marshalling output: %s", err)
+		return nil, nil, fmt.Errorf("Error marshalling output: %s", err)
 	}
 	outputs = append(outputs, &Output{outJSON, marshalEventLog(session.Log())})
 
-	return outputs, nil
+	return session, outputs, nil
 }
 
 // set up a mock server for webhook actions
@@ -226,7 +218,7 @@ func TestFlows(t *testing.T) {
 		}
 
 		// run our flow
-		outputs, err := runFlow(env, test.flow, test.contact, test.channel, callerEvents, flowTest.Extra)
+		session, outputs, err := runFlow(env, test.flow, test.contact, test.channel, callerEvents, flowTest.Extra)
 		if err != nil {
 			t.Errorf("Error running flow for flow '%s' and output '%s': %s", test.flow, test.output, err)
 			continue
@@ -276,11 +268,11 @@ func TestFlows(t *testing.T) {
 				actualOutput := outputs[i]
 				expectedOutput := expectedOutputs[i]
 
-				actualSession, err := runs.ReadSession(actualOutput.Session)
+				actualSession, err := runs.ReadSession(session.Environment(), actualOutput.Session)
 				if err != nil {
 					t.Errorf("Error unmarshalling session running flow '%s': %s\n", test.flow, err)
 				}
-				expectedSession, err := runs.ReadSession(expectedOutput.Session)
+				expectedSession, err := runs.ReadSession(session.Environment(), expectedOutput.Session)
 				if err != nil {
 					t.Errorf("Error unmarshalling expected session running flow '%s': %s\n", test.flow, err)
 				}
@@ -295,8 +287,8 @@ func TestFlows(t *testing.T) {
 					run := actualSession.Runs()[i]
 					expected := expectedSession.Runs()[i]
 
-					if run.FlowUUID() != expected.FlowUUID() {
-						t.Errorf("Actual run flow UUID: %s does not match expected: %s for flow '%s'", run.FlowUUID(), expected.FlowUUID(), test.flow)
+					if run.Flow() != expected.Flow() {
+						t.Errorf("Actual run flow: %s does not match expected: %s for flow '%s'", run.Flow().UUID(), expected.Flow().UUID(), test.flow)
 					}
 
 					if run.Status() != expected.Status() {

--- a/cmd/flowrunner/testdata/channels/default.json
+++ b/cmd/flowrunner/testdata/channels/default.json
@@ -1,5 +1,6 @@
 {
-        "uuid": "channel1-test-4b7f-a34b-e37e31e86451",
+        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
         "name": "Twilio Channel",
+        "address": "+12345671111",
         "type": "T"
-    }
+}

--- a/cmd/flowrunner/testdata/flows/all_actions_test.json
+++ b/cmd/flowrunner/testdata/flows/all_actions_test.json
@@ -183,7 +183,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "child_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -339,7 +338,6 @@
             }
           },
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/brochure_test.json
+++ b/cmd/flowrunner/testdata/flows/brochure_test.json
@@ -35,7 +35,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -135,7 +134,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -143,10 +141,9 @@
             "flow_uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
             "input": {
               "channel_uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-              "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
               "created_on": "2000-01-01T00:00:00.000000000-00:00",
               "text": "Ryan Lewis",
-              "type": "msg_received",
+              "type": "msg",
               "urn": "tel:+12065551212"
             },
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/date_parse_test.json
+++ b/cmd/flowrunner/testdata/flows/date_parse_test.json
@@ -35,7 +35,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -113,7 +112,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -121,10 +119,9 @@
             "flow_uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4",
             "input": {
               "channel_uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-              "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
               "created_on": "2000-01-01T00:00:00.000000000-00:00",
               "text": "I was born on 1977.06.23 at 3:34 pm",
-              "type": "msg_received",
+              "type": "msg",
               "urn": "tel:+12065551212"
             },
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/default_result_test.json
+++ b/cmd/flowrunner/testdata/flows/default_result_test.json
@@ -35,7 +35,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -131,7 +130,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -139,10 +137,9 @@
             "flow_uuid": "c37ae862-4802-447a-a783-1fe029a170e9",
             "input": {
               "channel_uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-              "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
               "created_on": "2000-01-01T00:00:00.000000000-00:00",
               "text": "Ryan Lewis",
-              "type": "msg_received",
+              "type": "msg",
               "urn": "tel:+12065551212"
             },
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/empty_test.json
+++ b/cmd/flowrunner/testdata/flows/empty_test.json
@@ -6,7 +6,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/node_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/node_loop_test.json
@@ -26,7 +26,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/subflow_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_loop_test.json
@@ -108,7 +108,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "child_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -156,7 +155,6 @@
             "uuid": ""
           },
           {
-            "channel_uuid": "",
             "child_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -205,7 +203,6 @@
             "uuid": ""
           },
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/subflow_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_test.json
@@ -64,7 +64,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "child_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -108,7 +107,6 @@
             }
           },
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -197,7 +195,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "child_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -261,7 +258,6 @@
             "uuid": ""
           },
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -269,10 +265,9 @@
             "flow_uuid": "a8d27b94-d3d0-4a96-8074-0f162f342195",
             "input": {
               "channel_uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-              "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
               "created_on": "2000-01-01T00:00:00.000000000-00:00",
               "text": "Ryan Lewis",
-              "type": "msg_received",
+              "type": "msg",
               "urn": "tel:+12065551212"
             },
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/two_questions_test.json
+++ b/cmd/flowrunner/testdata/flows/two_questions_test.json
@@ -43,7 +43,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -129,7 +128,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -137,10 +135,9 @@
             "flow_uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4",
             "input": {
               "channel_uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-              "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
               "created_on": "2000-01-01T00:00:00.000000000-00:00",
               "text": "Blue",
-              "type": "msg_received",
+              "type": "msg",
               "urn": "tel:+12065551212"
             },
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -267,7 +264,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -275,10 +271,9 @@
             "flow_uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4",
             "input": {
               "channel_uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-              "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
               "created_on": "2000-01-01T00:00:00.000000000-00:00",
               "text": "Coke",
-              "type": "msg_received",
+              "type": "msg",
               "urn": "tel:+12065551212"
             },
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/webhook_persists_test.json
+++ b/cmd/flowrunner/testdata/flows/webhook_persists_test.json
@@ -58,7 +58,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -162,7 +161,6 @@
       "session": {
         "runs": [
           {
-            "channel_uuid": "",
             "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -170,10 +168,9 @@
             "flow_uuid": "08d8a831-ca01-4a33-a26d-40f83aa4b625",
             "input": {
               "channel_uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-              "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
               "created_on": "2000-01-01T00:00:00.000000000-00:00",
               "text": "Something!",
-              "type": "msg_received",
+              "type": "msg",
               "urn": "tel:+12065551212"
             },
             "modified_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowserver/flow.go
+++ b/cmd/flowserver/flow.go
@@ -104,7 +104,7 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	}
 
 	// start our flow
-	session, err := engine.StartFlow(sessionEnv, flowlist[0], contact, nil, callerEvents, start.Extra)
+	session, err := engine.StartFlow(sessionEnv, flowlist[0], contact, nil, callerEvents, start.Extra, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error starting flow: %s", err)
 	}

--- a/cmd/flowserver/flow.go
+++ b/cmd/flowserver/flow.go
@@ -94,8 +94,8 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	// build our flow environment
-	flowEnv := engine.NewFlowEnvironment(env, flowlist, channelList, []*flows.Contact{contact})
+	// build our session environment
+	sessionEnv := engine.NewSessionEnvironment(env, flowlist, channelList, []*flows.Contact{contact})
 
 	// read our caller events
 	callerEvents, err := events.ReadEvents(start.Events)
@@ -104,7 +104,7 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	}
 
 	// start our flow
-	session, err := engine.StartFlow(flowEnv, flowlist[0], contact, nil, callerEvents, start.Extra)
+	session, err := engine.StartFlow(sessionEnv, flowlist[0], contact, nil, callerEvents, start.Extra)
 	if err != nil {
 		return nil, fmt.Errorf("error starting flow: %s", err)
 	}
@@ -172,10 +172,10 @@ func handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	}
 
 	// build our environment
-	flowEnv := engine.NewFlowEnvironment(env, flowList, channelList, []*flows.Contact{contact})
+	sessionEnv := engine.NewSessionEnvironment(env, flowList, channelList, []*flows.Contact{contact})
 
 	// read our session
-	session, err := runs.ReadSession(flowEnv, resume.Session)
+	session, err := runs.ReadSession(sessionEnv, resume.Session)
 	if err != nil {
 		return nil, err
 	}
@@ -192,14 +192,6 @@ func handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	// hydrate all our runs
-	for _, run := range session.Runs() {
-		err = run.Hydrate(flowEnv)
-		if err != nil {
-			return nil, utils.NewValidationError(err.Error())
-		}
-	}
-
 	// set our contact on our run
 	activeRun := session.ActiveRun()
 	if activeRun == nil {
@@ -207,7 +199,7 @@ func handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	}
 
 	// resume our flow
-	session, err = engine.ResumeFlow(flowEnv, activeRun, callerEvents)
+	session, err = engine.ResumeFlow(sessionEnv, activeRun, callerEvents)
 	if err != nil {
 		return nil, fmt.Errorf("error resuming flow: %s", err)
 	}

--- a/cmd/flowserver/flow.go
+++ b/cmd/flowserver/flow.go
@@ -104,7 +104,7 @@ func handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	}
 
 	// start our flow
-	session, err := engine.StartFlow(sessionEnv, flowlist[0], contact, nil, callerEvents, start.Extra, nil)
+	session, err := engine.StartFlow(sessionEnv, flowlist[0], contact, nil, callerEvents, start.Extra)
 	if err != nil {
 		return nil, fmt.Errorf("error starting flow: %s", err)
 	}

--- a/flows/actions/start_flow.go
+++ b/flows/actions/start_flow.go
@@ -75,7 +75,7 @@ func (a *StartFlowAction) Execute(run flows.FlowRun, step flows.Step) error {
 	run.ApplyEvent(step, a, events.NewFlowEnterEvent(a.FlowUUID, run.Contact().UUID()))
 
 	// start it for our current contact
-	_, err = engine.StartFlow(run.Environment(), flow, run.Contact(), run, nil, nil, run.Session())
+	_, err = engine.StartFlow(run.Environment(), flow, run.Contact(), run, nil, nil)
 
 	// if we received an error, shortcut out, this session is horked
 	if err != nil {

--- a/flows/actions/start_flow.go
+++ b/flows/actions/start_flow.go
@@ -75,7 +75,7 @@ func (a *StartFlowAction) Execute(run flows.FlowRun, step flows.Step) error {
 	run.ApplyEvent(step, a, events.NewFlowEnterEvent(a.FlowUUID, run.Contact().UUID()))
 
 	// start it for our current contact
-	_, err = engine.StartFlow(run.Environment(), flow, run.Contact(), run, nil, nil)
+	_, err = engine.StartFlow(run.Environment(), flow, run.Contact(), run, nil, nil, run.Session())
 
 	// if we received an error, shortcut out, this session is horked
 	if err != nil {

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -7,32 +7,37 @@ import (
 	"github.com/nyaruka/goflow/utils"
 )
 
-// Channel represents a channel in the system. Channels have a UUID, name, type and configuration
-type Channel struct {
+type channel struct {
 	uuid        ChannelUUID
 	name        string
+	address     string
 	channelType ChannelType
-	config      string
 }
 
 // UUID returns the UUID of this channel
-func (c *Channel) UUID() ChannelUUID { return c.uuid }
+func (c *channel) UUID() ChannelUUID { return c.uuid }
 
 // Name returns the name of this channel
-func (c *Channel) Name() string { return c.name }
+func (c *channel) Name() string { return c.name }
+
+// Name returns the address of this channel
+func (c *channel) Address() string { return c.address }
 
 // Type returns the type of this channel
-func (c *Channel) Type() ChannelType { return c.channelType }
+func (c *channel) Type() ChannelType { return c.channelType }
 
 // Resolve satisfies our resolver interface
-func (c *Channel) Resolve(key string) interface{} {
+func (c *channel) Resolve(key string) interface{} {
 	switch key {
+
+	case "uuid":
+		return c.uuid
 
 	case "name":
 		return c.name
 
-	case "uuid":
-		return c.uuid
+	case "address":
+		return c.address
 
 	case "type":
 		return c.channelType
@@ -42,39 +47,43 @@ func (c *Channel) Resolve(key string) interface{} {
 }
 
 // Default returns the default value for a channel, which is itself
-func (c *Channel) Default() interface{} {
+func (c *channel) Default() interface{} {
 	return c
 }
 
 // String returns the default string value for a channel, which is its name
-func (c *Channel) String() string {
+func (c *channel) String() string {
 	return c.name
 }
 
-var _ utils.VariableResolver = (*Channel)(nil)
+var _ utils.VariableResolver = (*channel)(nil)
 
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding
 //------------------------------------------------------------------------------------------
 
-// ReadChannel decodes a channel from the passed in JSON
-func ReadChannel(data json.RawMessage) (*Channel, error) {
-	channel := &Channel{}
-	err := json.Unmarshal(data, channel)
-	if err == nil {
-		// err = run.Validate()
-	}
-	return channel, err
-}
-
 type channelEnvelope struct {
 	UUID        ChannelUUID `json:"uuid"`
 	Name        string      `json:"name"`
+	Address     string      `json:"address"`
 	ChannelType ChannelType `json:"type"`
 }
 
+// ReadChannel decodes a channel from the passed in JSON
+func ReadChannels(data []json.RawMessage) ([]Channel, error) {
+	channels := make([]Channel, len(data))
+	for c := range data {
+		channels[c] = &channel{}
+		err := json.Unmarshal(data[c], channels[c])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return channels, nil
+}
+
 // UnmarshalJSON is our custom unmarshalling of a channel
-func (c *Channel) UnmarshalJSON(data []byte) error {
+func (c *channel) UnmarshalJSON(data []byte) error {
 	var ce channelEnvelope
 	var err error
 
@@ -83,19 +92,21 @@ func (c *Channel) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	c.name = ce.Name
 	c.uuid = ce.UUID
+	c.name = ce.Name
+	c.address = ce.Address
 	c.channelType = ce.ChannelType
 
 	return nil
 }
 
 // MarshalJSON is our custom marshalling of a channel
-func (c *Channel) MarshalJSON() ([]byte, error) {
+func (c *channel) MarshalJSON() ([]byte, error) {
 	var ce channelEnvelope
 
-	ce.Name = c.name
 	ce.UUID = c.uuid
+	ce.Name = c.name
+	ce.Address = c.address
 	ce.ChannelType = c.channelType
 
 	return json.Marshal(ce)

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -69,17 +69,27 @@ type channelEnvelope struct {
 	ChannelType ChannelType `json:"type"`
 }
 
-// ReadChannel decodes a channel from the passed in JSON
+// ReadChannels decodes channels from the passed in JSON
 func ReadChannels(data []json.RawMessage) ([]Channel, error) {
 	channels := make([]Channel, len(data))
+	var err error
 	for c := range data {
-		channels[c] = &channel{}
-		err := json.Unmarshal(data[c], channels[c])
+		channels[c], err = ReadChannel(data[c])
 		if err != nil {
 			return nil, err
 		}
 	}
 	return channels, nil
+}
+
+// ReadChannel decodes a channel from the passed in JSON
+func ReadChannel(data json.RawMessage) (Channel, error) {
+	c := &channel{}
+	err := json.Unmarshal(data, c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 // UnmarshalJSON is our custom unmarshalling of a channel

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/goflow/flows"
-	"github.com/nyaruka/goflow/flows/runs"
 	"github.com/nyaruka/goflow/utils"
 )
 
@@ -27,10 +26,6 @@ func (f *flow) UUID() flows.FlowUUID                   { return f.uuid }
 func (f *flow) Nodes() []flows.Node                    { return f.nodes }
 func (f *flow) Translations() flows.FlowTranslations   { return f.translations }
 func (f *flow) GetNode(uuid flows.NodeUUID) flows.Node { return f.nodeMap[uuid] }
-
-func (f *flow) CreateRun(env flows.FlowEnvironment, contact *flows.Contact, parent flows.FlowRun) flows.FlowRun {
-	return runs.NewRun(env, f, contact, parent)
-}
 
 // Validates that structurally we are sane. IE, all required fields are present and
 // all exits with destinations point to valid endpoints.

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -10,8 +10,12 @@ import (
 )
 
 // StartFlow starts the flow for the passed in contact, returning the created FlowRun
-func StartFlow(env flows.SessionEnvironment, flow flows.Flow, contact *flows.Contact, parent flows.FlowRun, callerEvents []flows.Event, extra json.RawMessage, session flows.Session) (flows.Session, error) {
-	if session == nil {
+func StartFlow(env flows.SessionEnvironment, flow flows.Flow, contact *flows.Contact, parent flows.FlowRun, callerEvents []flows.Event, extra json.RawMessage) (flows.Session, error) {
+	// if we have a parent run, then we belong to that session
+	var session flows.Session
+	if parent != nil {
+		session = parent.Session()
+	} else {
 		session = runs.NewSession(env)
 	}
 

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -10,8 +10,10 @@ import (
 )
 
 // StartFlow starts the flow for the passed in contact, returning the created FlowRun
-func StartFlow(env flows.SessionEnvironment, flow flows.Flow, contact *flows.Contact, parent flows.FlowRun, callerEvents []flows.Event, extra json.RawMessage) (flows.Session, error) {
-	session := runs.NewSession(env)
+func StartFlow(env flows.SessionEnvironment, flow flows.Flow, contact *flows.Contact, parent flows.FlowRun, callerEvents []flows.Event, extra json.RawMessage, session flows.Session) (flows.Session, error) {
+	if session == nil {
+		session = runs.NewSession(env)
+	}
 
 	// create our new run
 	run := session.CreateRun(flow, contact, parent)

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -65,7 +65,7 @@ func ResumeFlow(env flows.SessionEnvironment, run flows.FlowRun, callerEvents []
 	// if we ran to completion and have a parent, resume that flow
 	if run.Parent() != nil && run.IsComplete() {
 		event := events.NewFlowExitedEvent(run)
-		parentRun, err := env.GetRun(run.Parent().UUID())
+		parentRun, err := run.Session().GetRun(run.Parent().UUID())
 		if err != nil {
 			run.AddError(step, err)
 			run.Exit(flows.StatusErrored)

--- a/flows/engine/environment.go
+++ b/flows/engine/environment.go
@@ -7,8 +7,8 @@ import (
 	"github.com/nyaruka/goflow/utils"
 )
 
-// NewFlowEnvironment creates and returns a new FlowEnvironment given the passed in environment and flow map
-func NewFlowEnvironment(env utils.Environment, flowList []flows.Flow, channelList []flows.Channel, contactList []*flows.Contact) flows.FlowEnvironment {
+// NewSessionEnvironment creates and returns a new NewSessionEnvironment given the passed in environment and flow map
+func NewSessionEnvironment(env utils.Environment, flowList []flows.Flow, channelList []flows.Channel, contactList []*flows.Contact) flows.SessionEnvironment {
 	flowMap := make(map[flows.FlowUUID]flows.Flow, len(flowList))
 	for _, f := range flowList {
 		flowMap[f.UUID()] = f
@@ -26,10 +26,10 @@ func NewFlowEnvironment(env utils.Environment, flowList []flows.Flow, channelLis
 
 	runMap := make(map[flows.RunUUID]flows.FlowRun)
 
-	return &flowEnvironment{env, flowMap, channelMap, runMap, contactMap}
+	return &sessionEnvironment{env, flowMap, channelMap, runMap, contactMap}
 }
 
-type flowEnvironment struct {
+type sessionEnvironment struct {
 	utils.Environment
 	flows    map[flows.FlowUUID]flows.Flow
 	channels map[flows.ChannelUUID]flows.Channel
@@ -37,7 +37,7 @@ type flowEnvironment struct {
 	contacts map[flows.ContactUUID]*flows.Contact
 }
 
-func (e *flowEnvironment) GetFlow(uuid flows.FlowUUID) (flows.Flow, error) {
+func (e *sessionEnvironment) GetFlow(uuid flows.FlowUUID) (flows.Flow, error) {
 	flow, exists := e.flows[uuid]
 	if exists {
 		return flow, nil
@@ -45,7 +45,7 @@ func (e *flowEnvironment) GetFlow(uuid flows.FlowUUID) (flows.Flow, error) {
 	return nil, fmt.Errorf("unable to find flow with UUID: %s", uuid)
 }
 
-func (e *flowEnvironment) GetChannel(uuid flows.ChannelUUID) (flows.Channel, error) {
+func (e *sessionEnvironment) GetChannel(uuid flows.ChannelUUID) (flows.Channel, error) {
 	channel, exists := e.channels[uuid]
 	if exists {
 		return channel, nil
@@ -53,7 +53,7 @@ func (e *flowEnvironment) GetChannel(uuid flows.ChannelUUID) (flows.Channel, err
 	return nil, fmt.Errorf("unable to find channel with UUID: %s %d", uuid)
 }
 
-func (e *flowEnvironment) GetContact(uuid flows.ContactUUID) (*flows.Contact, error) {
+func (e *sessionEnvironment) GetContact(uuid flows.ContactUUID) (*flows.Contact, error) {
 	contact, exists := e.contacts[uuid]
 	if exists {
 		return contact, nil
@@ -61,7 +61,7 @@ func (e *flowEnvironment) GetContact(uuid flows.ContactUUID) (*flows.Contact, er
 	return nil, fmt.Errorf("unable to find contact with UUID: %s", uuid)
 }
 
-func (e *flowEnvironment) GetRun(uuid flows.RunUUID) (flows.FlowRun, error) {
+func (e *sessionEnvironment) GetRun(uuid flows.RunUUID) (flows.FlowRun, error) {
 	run, exists := e.runs[uuid]
 	if exists {
 		return run, nil
@@ -69,6 +69,6 @@ func (e *flowEnvironment) GetRun(uuid flows.RunUUID) (flows.FlowRun, error) {
 	return nil, fmt.Errorf("unable to find run with UUID: %s", uuid)
 }
 
-func (e *flowEnvironment) AddRun(run flows.FlowRun) {
+func (e *sessionEnvironment) AddRun(run flows.FlowRun) {
 	e.runs[run.UUID()] = run
 }

--- a/flows/engine/environment.go
+++ b/flows/engine/environment.go
@@ -24,16 +24,13 @@ func NewSessionEnvironment(env utils.Environment, flowList []flows.Flow, channel
 		contactMap[c.UUID()] = c
 	}
 
-	runMap := make(map[flows.RunUUID]flows.FlowRun)
-
-	return &sessionEnvironment{env, flowMap, channelMap, runMap, contactMap}
+	return &sessionEnvironment{env, flowMap, channelMap, contactMap}
 }
 
 type sessionEnvironment struct {
 	utils.Environment
 	flows    map[flows.FlowUUID]flows.Flow
 	channels map[flows.ChannelUUID]flows.Channel
-	runs     map[flows.RunUUID]flows.FlowRun
 	contacts map[flows.ContactUUID]*flows.Contact
 }
 
@@ -59,16 +56,4 @@ func (e *sessionEnvironment) GetContact(uuid flows.ContactUUID) (*flows.Contact,
 		return contact, nil
 	}
 	return nil, fmt.Errorf("unable to find contact with UUID: %s", uuid)
-}
-
-func (e *sessionEnvironment) GetRun(uuid flows.RunUUID) (flows.FlowRun, error) {
-	run, exists := e.runs[uuid]
-	if exists {
-		return run, nil
-	}
-	return nil, fmt.Errorf("unable to find run with UUID: %s", uuid)
-}
-
-func (e *sessionEnvironment) AddRun(run flows.FlowRun) {
-	e.runs[run.UUID()] = run
 }

--- a/flows/engine/environment.go
+++ b/flows/engine/environment.go
@@ -8,15 +8,15 @@ import (
 )
 
 // NewFlowEnvironment creates and returns a new FlowEnvironment given the passed in environment and flow map
-func NewFlowEnvironment(env utils.Environment, flowList []flows.Flow, runList []flows.FlowRun, contactList []*flows.Contact) flows.FlowEnvironment {
+func NewFlowEnvironment(env utils.Environment, flowList []flows.Flow, channelList []flows.Channel, contactList []*flows.Contact) flows.FlowEnvironment {
 	flowMap := make(map[flows.FlowUUID]flows.Flow, len(flowList))
 	for _, f := range flowList {
 		flowMap[f.UUID()] = f
 	}
 
-	runMap := make(map[flows.RunUUID]flows.FlowRun, len(runList))
-	for _, r := range runList {
-		runMap[r.UUID()] = r
+	channelMap := make(map[flows.ChannelUUID]flows.Channel, len(channelList))
+	for _, c := range channelList {
+		channelMap[c.UUID()] = c
 	}
 
 	contactMap := make(map[flows.ContactUUID]*flows.Contact, len(contactList))
@@ -24,12 +24,15 @@ func NewFlowEnvironment(env utils.Environment, flowList []flows.Flow, runList []
 		contactMap[c.UUID()] = c
 	}
 
-	return &flowEnvironment{env, flowMap, runMap, contactMap}
+	runMap := make(map[flows.RunUUID]flows.FlowRun)
+
+	return &flowEnvironment{env, flowMap, channelMap, runMap, contactMap}
 }
 
 type flowEnvironment struct {
 	utils.Environment
 	flows    map[flows.FlowUUID]flows.Flow
+	channels map[flows.ChannelUUID]flows.Channel
 	runs     map[flows.RunUUID]flows.FlowRun
 	contacts map[flows.ContactUUID]*flows.Contact
 }
@@ -42,12 +45,12 @@ func (e *flowEnvironment) GetFlow(uuid flows.FlowUUID) (flows.Flow, error) {
 	return nil, fmt.Errorf("unable to find flow with UUID: %s", uuid)
 }
 
-func (e *flowEnvironment) GetRun(uuid flows.RunUUID) (flows.FlowRun, error) {
-	run, exists := e.runs[uuid]
+func (e *flowEnvironment) GetChannel(uuid flows.ChannelUUID) (flows.Channel, error) {
+	channel, exists := e.channels[uuid]
 	if exists {
-		return run, nil
+		return channel, nil
 	}
-	return nil, fmt.Errorf("unable to find run with UUID: %s", uuid)
+	return nil, fmt.Errorf("unable to find channel with UUID: %s %d", uuid)
 }
 
 func (e *flowEnvironment) GetContact(uuid flows.ContactUUID) (*flows.Contact, error) {
@@ -56,4 +59,16 @@ func (e *flowEnvironment) GetContact(uuid flows.ContactUUID) (*flows.Contact, er
 		return contact, nil
 	}
 	return nil, fmt.Errorf("unable to find contact with UUID: %s", uuid)
+}
+
+func (e *flowEnvironment) GetRun(uuid flows.RunUUID) (flows.FlowRun, error) {
+	run, exists := e.runs[uuid]
+	if exists {
+		return run, nil
+	}
+	return nil, fmt.Errorf("unable to find run with UUID: %s", uuid)
+}
+
+func (e *flowEnvironment) AddRun(run flows.FlowRun) {
+	e.runs[run.UUID()] = run
 }

--- a/flows/events/flow_exited.go
+++ b/flows/events/flow_exited.go
@@ -37,9 +37,9 @@ type FlowExitedEvent struct {
 func NewFlowExitedEvent(run flows.FlowRunReference) *FlowExitedEvent {
 	return &FlowExitedEvent{
 		BaseEvent:   NewBaseEvent(),
-		FlowUUID:    run.FlowUUID(),
+		FlowUUID:    run.Flow().UUID(),
 		Status:      run.Status(),
-		ContactUUID: run.ContactUUID(),
+		ContactUUID: run.Contact().UUID(),
 		ExitedOn:    run.ExitedOn(),
 	}
 }

--- a/flows/events/msg_received.go
+++ b/flows/events/msg_received.go
@@ -1,9 +1,8 @@
 package events
 
 import (
-	"fmt"
-
 	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/inputs"
 )
 
 // TypeMsgReceived is a constant for incoming messages
@@ -47,43 +46,10 @@ func NewMsgReceivedEvent(channel flows.ChannelUUID, contact flows.ContactUUID, u
 // Type returns the type of this event
 func (e *MsgReceivedEvent) Type() string { return TypeMsgReceived }
 
-// Resolve resolves the passed in key to a value, returning an error if the key is unknown
-func (e *MsgReceivedEvent) Resolve(key string) interface{} {
-	switch key {
-
-	case "direction":
-		return flows.MsgIn
-
-	case "channel_uuid":
-		return e.ChannelUUID
-
-	case "contact_uuid":
-		return e.ContactUUID
-
-	case "urn":
-		return e.URN
-
-	case "text":
-		return e.Text
-
-	case "created_on":
-		return e.CreatedOn
-
-	}
-	return fmt.Errorf("No such field '%s' on Msg event", key)
-}
-
-// Default returns our default value if evaluated in a context, our text in our case
-func (e *MsgReceivedEvent) Default() interface{} {
-	return e.Text
-}
-
-// String returns our default value if evaluated in a context, our text in our case
-func (e *MsgReceivedEvent) String() string {
-	return e.Text
-}
-
 // Apply applies this event to the given run
 func (e *MsgReceivedEvent) Apply(run flows.FlowRun) {
-	run.SetInput(e)
+	channel, _ := run.Environment().GetChannel(e.ChannelUUID)
+
+	// update this run's input
+	run.SetInput(inputs.NewMsgInput(channel, e.URN, e.Text))
 }

--- a/flows/events/msg_received.go
+++ b/flows/events/msg_received.go
@@ -51,5 +51,5 @@ func (e *MsgReceivedEvent) Apply(run flows.FlowRun) {
 	channel, _ := run.Environment().GetChannel(e.ChannelUUID)
 
 	// update this run's input
-	run.SetInput(inputs.NewMsgInput(channel, e.URN, e.Text))
+	run.SetInput(inputs.NewMsgInput(channel, e.CreatedOn(), e.URN, e.Text))
 }

--- a/flows/events/msg_received.go
+++ b/flows/events/msg_received.go
@@ -26,9 +26,9 @@ const TypeMsgReceived string = "msg_received"
 // @event msg_received
 type MsgReceivedEvent struct {
 	BaseEvent
-	ChannelUUID flows.ChannelUUID `json:"channel_uuid"     validate:"required,uuid4"`
-	URN         flows.URN         `json:"urn"              validate:"required"`
-	ContactUUID flows.ContactUUID `json:"contact_uuid"     validate:"required,uuid4"`
+	ChannelUUID flows.ChannelUUID `json:"channel_uuid" validate:"uuid4"`
+	URN         flows.URN         `json:"urn"          validate:"required"`
+	ContactUUID flows.ContactUUID `json:"contact_uuid" validate:"required,uuid4"`
 	Text        string            `json:"text"`
 }
 

--- a/flows/inputs/base.go
+++ b/flows/inputs/base.go
@@ -12,11 +12,8 @@ type baseInput struct {
 	createdOn time.Time
 }
 
-func (i *baseInput) Channel() flows.Channel           { return i.channel }
-func (i *baseInput) SetChannel(channel flows.Channel) { i.channel = channel }
-
-func (i *baseInput) CreatedOn() time.Time        { return i.createdOn }
-func (i *baseInput) SetCreatedOn(time time.Time) { i.createdOn = time }
+func (i *baseInput) Channel() flows.Channel { return i.channel }
+func (i *baseInput) CreatedOn() time.Time   { return i.createdOn }
 
 // Resolve resolves the passed in key to a value, returning an error if the key is unknown
 func (i *baseInput) Resolve(key string) interface{} {

--- a/flows/inputs/base.go
+++ b/flows/inputs/base.go
@@ -1,0 +1,33 @@
+package inputs
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nyaruka/goflow/flows"
+)
+
+type baseInput struct {
+	channel   flows.Channel
+	createdOn time.Time
+}
+
+func (i *baseInput) Channel() flows.Channel           { return i.channel }
+func (i *baseInput) SetChannel(channel flows.Channel) { i.channel = channel }
+
+func (i *baseInput) CreatedOn() time.Time        { return i.createdOn }
+func (i *baseInput) SetCreatedOn(time time.Time) { i.createdOn = time }
+
+// Resolve resolves the passed in key to a value, returning an error if the key is unknown
+func (i *baseInput) Resolve(key string) interface{} {
+	switch key {
+
+	case "time":
+		return i.createdOn
+
+	case "channel":
+		return i.channel
+	}
+
+	return fmt.Errorf("No such field '%s' on input", key)
+}

--- a/flows/inputs/envelope.go
+++ b/flows/inputs/envelope.go
@@ -9,7 +9,7 @@ import (
 )
 
 type baseInputEnvelope struct {
-	ChannelUUID flows.ChannelUUID `json:"channel_uuid" validate:"required,uuid4"`
+	ChannelUUID flows.ChannelUUID `json:"channel_uuid" validate:"uuid4"`
 	CreatedOn   time.Time         `json:"created_on"   validate:"required"`
 }
 

--- a/flows/inputs/envelope.go
+++ b/flows/inputs/envelope.go
@@ -1,21 +1,24 @@
 package inputs
 
 import (
-	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/nyaruka/goflow/flows"
-	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
 )
 
-func InputFromEnvelope(envelope *utils.TypedEnvelope) (flows.Input, error) {
+type baseInputEnvelope struct {
+	ChannelUUID flows.ChannelUUID `json:"channel_uuid" validate:"required,uuid4"`
+	CreatedOn   time.Time         `json:"created_on"   validate:"required"`
+}
+
+func ReadInput(env flows.FlowEnvironment, envelope *utils.TypedEnvelope) (flows.Input, error) {
 	switch envelope.Type {
 
-	case events.TypeMsgReceived:
-		event := events.MsgReceivedEvent{}
-		err := json.Unmarshal(envelope.Data, &event)
-		return &event, utils.ValidateAllUnlessErr(err, &event)
+	case TypeMsg:
+		input, err := ReadMsgInput(env, envelope)
+		return input, utils.ValidateAllUnlessErr(err, input)
 
 	default:
 		return nil, fmt.Errorf("Unknown input type: %s", envelope.Type)

--- a/flows/inputs/envelope.go
+++ b/flows/inputs/envelope.go
@@ -17,8 +17,7 @@ func ReadInput(env flows.FlowEnvironment, envelope *utils.TypedEnvelope) (flows.
 	switch envelope.Type {
 
 	case TypeMsg:
-		input, err := ReadMsgInput(env, envelope)
-		return input, utils.ValidateAllUnlessErr(err, input)
+		return ReadMsgInput(env, envelope)
 
 	default:
 		return nil, fmt.Errorf("Unknown input type: %s", envelope.Type)

--- a/flows/inputs/envelope.go
+++ b/flows/inputs/envelope.go
@@ -13,7 +13,7 @@ type baseInputEnvelope struct {
 	CreatedOn   time.Time         `json:"created_on"   validate:"required"`
 }
 
-func ReadInput(env flows.FlowEnvironment, envelope *utils.TypedEnvelope) (flows.Input, error) {
+func ReadInput(env flows.SessionEnvironment, envelope *utils.TypedEnvelope) (flows.Input, error) {
 	switch envelope.Type {
 
 	case TypeMsg:

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -3,6 +3,8 @@ package inputs
 import (
 	"encoding/json"
 
+	"time"
+
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 )
@@ -17,8 +19,8 @@ type MsgInput struct {
 }
 
 // NewMsgReceivedEvent creates a new incoming msg event for the passed in channel, contact and string
-func NewMsgInput(channel flows.Channel, urn flows.URN, text string) *MsgInput {
-	return &MsgInput{baseInput: baseInput{channel: channel}, urn: urn, text: text}
+func NewMsgInput(channel flows.Channel, createdOn time.Time, urn flows.URN, text string) *MsgInput {
+	return &MsgInput{baseInput: baseInput{channel: channel, createdOn: createdOn}, urn: urn, text: text}
 }
 
 // Type returns the type of this event
@@ -67,13 +69,19 @@ func ReadMsgInput(env flows.FlowEnvironment, envelope *utils.TypedEnvelope) (*Ms
 		return nil, err
 	}
 
+	err = utils.ValidateAll(i)
+	if err != nil {
+		return nil, err
+	}
+
+	// lookup the channel
 	channel, err := env.GetChannel(i.ChannelUUID)
 	if err != nil {
 		return nil, err
 	}
 
-	input.baseInput.SetChannel(channel)
-	input.baseInput.SetCreatedOn(i.CreatedOn)
+	input.baseInput.channel = channel
+	input.baseInput.createdOn = i.CreatedOn
 	input.urn = i.URN
 	input.text = i.Text
 	return &input, nil

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -1,0 +1,90 @@
+package inputs
+
+import (
+	"encoding/json"
+
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/utils"
+)
+
+// TypeMsg is a constant for incoming messages
+const TypeMsg string = "msg"
+
+type MsgInput struct {
+	baseInput
+	urn  flows.URN
+	text string
+}
+
+// NewMsgReceivedEvent creates a new incoming msg event for the passed in channel, contact and string
+func NewMsgInput(channel flows.Channel, urn flows.URN, text string) *MsgInput {
+	return &MsgInput{baseInput: baseInput{channel: channel}, urn: urn, text: text}
+}
+
+// Type returns the type of this event
+func (i *MsgInput) Type() string { return TypeMsg }
+
+// Resolve resolves the passed in key to a value, returning an error if the key is unknown
+func (i *MsgInput) Resolve(key string) interface{} {
+	switch key {
+
+	case "urn":
+		return i.urn
+
+	case "text":
+		return i.text
+	}
+	return i.baseInput.Resolve(key)
+}
+
+// Default returns our default value if evaluated in a context, our text in our case
+func (i *MsgInput) Default() interface{} {
+	return i.text
+}
+
+// String returns our default value if evaluated in a context, our text in our case
+func (i *MsgInput) String() string {
+	return i.text
+}
+
+var _ flows.Input = (*MsgInput)(nil)
+
+//------------------------------------------------------------------------------------------
+// JSON Encoding / Decoding
+//------------------------------------------------------------------------------------------
+
+type msgInputEnvelope struct {
+	baseInputEnvelope
+	URN  flows.URN `json:"urn"  validate:"required"`
+	Text string    `json:"text" validate:"required"`
+}
+
+func ReadMsgInput(env flows.FlowEnvironment, envelope *utils.TypedEnvelope) (*MsgInput, error) {
+	input := MsgInput{}
+	i := msgInputEnvelope{}
+	err := json.Unmarshal(envelope.Data, &i)
+	if err != nil {
+		return nil, err
+	}
+
+	channel, err := env.GetChannel(i.ChannelUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	input.baseInput.SetChannel(channel)
+	input.baseInput.SetCreatedOn(i.CreatedOn)
+	input.urn = i.URN
+	input.text = i.Text
+	return &input, nil
+}
+
+func (r *MsgInput) MarshalJSON() ([]byte, error) {
+	envelope := msgInputEnvelope{
+		baseInputEnvelope: baseInputEnvelope{ChannelUUID: r.Channel().UUID(), CreatedOn: r.CreatedOn()},
+		URN:               r.urn,
+		Text:              r.text,
+	}
+
+	return json.Marshal(envelope)
+}

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -61,7 +61,7 @@ type msgInputEnvelope struct {
 	Text string    `json:"text" validate:"required"`
 }
 
-func ReadMsgInput(env flows.FlowEnvironment, envelope *utils.TypedEnvelope) (*MsgInput, error) {
+func ReadMsgInput(env flows.SessionEnvironment, envelope *utils.TypedEnvelope) (*MsgInput, error) {
 	input := MsgInput{}
 	i := msgInputEnvelope{}
 	err := json.Unmarshal(envelope.Data, &i)

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -91,8 +91,6 @@ type SessionEnvironment interface {
 	GetFlow(FlowUUID) (Flow, error)
 	GetChannel(ChannelUUID) (Channel, error)
 	GetContact(ContactUUID) (*Contact, error)
-	GetRun(RunUUID) (FlowRun, error)
-	AddRun(FlowRun)
 	utils.Environment
 }
 
@@ -212,6 +210,7 @@ type Session interface {
 
 	CreateRun(Flow, *Contact, FlowRun) FlowRun
 	Runs() []FlowRun
+	GetRun(RunUUID) (FlowRun, error)
 	ActiveRun() FlowRun
 
 	Log() []LogEntry

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -91,8 +91,10 @@ func (r RunStatus) String() string { return string(r) }
 
 type FlowEnvironment interface {
 	GetFlow(FlowUUID) (Flow, error)
-	GetRun(RunUUID) (FlowRun, error)
+	GetChannel(ChannelUUID) (Channel, error)
 	GetContact(ContactUUID) (*Contact, error)
+	GetRun(RunUUID) (FlowRun, error)
+	AddRun(FlowRun)
 	utils.Environment
 }
 
@@ -177,8 +179,11 @@ type Event interface {
 }
 
 type Input interface {
-	Event
 	utils.VariableResolver
+	utils.Typed
+
+	CreatedOn() time.Time
+	Channel() Channel
 }
 
 type Step interface {
@@ -218,21 +223,14 @@ type Session interface {
 // FlowRun represents a single run on a flow by a single contact
 type FlowRun interface {
 	UUID() RunUUID
-	FlowUUID() FlowUUID
-	Flow() Flow
 
 	Hydrate(FlowEnvironment) error
-
-	ContactUUID() ContactUUID
-	Contact() *Contact
-
-	ChannelUUID() ChannelUUID
-	Channel() *Channel
-	SetChannel(*Channel)
-
 	Context() Context
-	Results() *Results
 	Environment() FlowEnvironment
+
+	Flow() Flow
+	Contact() *Contact
+	Results() *Results
 
 	SetExtra(json.RawMessage)
 	Extra() utils.JSONFragment
@@ -276,9 +274,8 @@ type FlowRun interface {
 // FlowRunReference represents a flow run reference within a flow
 type FlowRunReference interface {
 	UUID() RunUUID
-	FlowUUID() FlowUUID
-	ContactUUID() ContactUUID
-	ChannelUUID() ChannelUUID
+	Flow() Flow
+	Contact() *Contact
 
 	Results() *Results
 	Status() RunStatus
@@ -294,6 +291,14 @@ type FlowRunReference interface {
 type ChannelType string
 
 func (ct ChannelType) String() string { return string(ct) }
+
+// Channel represents a channel for sending and receiving messages
+type Channel interface {
+	UUID() ChannelUUID
+	Name() string
+	Address() string
+	Type() ChannelType
+}
 
 // MsgDirection is the direction of a Msg (either in or out)
 type MsgDirection string

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -63,8 +63,6 @@ type Flow interface {
 	GetNode(uuid NodeUUID) Node
 
 	Validate() error
-
-	CreateRun(env FlowEnvironment, contact *Contact, parent FlowRun) FlowRun
 }
 
 // RunStatus represents the current status of the flow run
@@ -89,7 +87,7 @@ const (
 
 func (r RunStatus) String() string { return string(r) }
 
-type FlowEnvironment interface {
+type SessionEnvironment interface {
 	GetFlow(FlowUUID) (Flow, error)
 	GetChannel(ChannelUUID) (Channel, error)
 	GetContact(ContactUUID) (*Contact, error)
@@ -210,9 +208,10 @@ type LogEntry interface {
 
 // Session represents the session of a flow run which may contain many runs
 type Session interface {
-	Runs() []FlowRun
-	AddRun(FlowRun)
+	Environment() SessionEnvironment
 
+	CreateRun(Flow, *Contact, FlowRun) FlowRun
+	Runs() []FlowRun
 	ActiveRun() FlowRun
 
 	Log() []LogEntry
@@ -224,9 +223,9 @@ type Session interface {
 type FlowRun interface {
 	UUID() RunUUID
 
-	Hydrate(FlowEnvironment) error
+	Environment() SessionEnvironment
+	Session() Session
 	Context() Context
-	Environment() FlowEnvironment
 
 	Flow() Flow
 	Contact() *Contact
@@ -234,10 +233,6 @@ type FlowRun interface {
 
 	SetExtra(json.RawMessage)
 	Extra() utils.JSONFragment
-
-	Session() Session
-	SetSession(Session)
-	ResetSession()
 
 	Status() RunStatus
 	Exit(RunStatus)

--- a/flows/runs/context.go
+++ b/flows/runs/context.go
@@ -31,9 +31,6 @@ func (c *context) Validate() error {
 func (c *context) Resolve(key string) interface{} {
 	switch key {
 
-	case "channel":
-		return c.run.Channel()
-
 	case "contact":
 		return c.Contact()
 

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -68,14 +68,8 @@ func (e *runEnvironment) refreshLanguagesCache() {
 type flowRun struct {
 	uuid flows.RunUUID
 
-	contact     *flows.Contact
-	contactUUID flows.ContactUUID
-
-	flow     flows.Flow
-	flowUUID flows.FlowUUID
-
-	channel     *flows.Channel
-	channelUUID flows.ChannelUUID
+	flow    flows.Flow
+	contact *flows.Contact
 
 	extra   json.RawMessage
 	results *flows.Results
@@ -100,64 +94,9 @@ type flowRun struct {
 	exitedOn   *time.Time
 }
 
-func (r *flowRun) UUID() flows.RunUUID            { return r.uuid }
-func (r *flowRun) ContactUUID() flows.ContactUUID { return r.contactUUID }
-func (r *flowRun) Contact() *flows.Contact        { return r.contact }
-
-// Hydrate prepares a deserialized run for executions
-func (r *flowRun) Hydrate(env flows.FlowEnvironment) error {
-	// start with a fresh output if we don't have one
-	if r.session == nil {
-		r.ResetSession()
-	}
-
-	// set our flow
-	runFlow, err := env.GetFlow(r.FlowUUID())
-	if err != nil {
-		return err
-	}
-	r.flow = runFlow
-
-	// make sure we have a contact
-	r.contact, err = env.GetContact(r.ContactUUID())
-	if err != nil {
-		return err
-	}
-
-	// save off our environment
-	r.environment = newRunEnvironment(env, r)
-
-	// build our context
-	r.context = NewContextForContact(r.contact, r)
-
-	// populate our run references
-	if r.parent != nil {
-		parent, err := env.GetRun(r.parent.UUID())
-		if err != nil {
-			return err
-		}
-		r.parent = newReferenceFromRun(parent.(*flowRun))
-	}
-
-	if r.child != nil {
-		child, err := env.GetRun(r.child.UUID())
-		if err != nil {
-			return err
-		}
-		r.child = newReferenceFromRun(child.(*flowRun))
-	}
-
-	return nil
-}
-
-func (r *flowRun) FlowUUID() flows.FlowUUID       { return r.flowUUID }
-func (r *flowRun) Flow() flows.Flow               { return r.flow }
-func (r *flowRun) ChannelUUID() flows.ChannelUUID { return r.channelUUID }
-func (r *flowRun) Channel() *flows.Channel        { return r.channel }
-func (r *flowRun) SetChannel(channel *flows.Channel) {
-	r.channelUUID = channel.UUID()
-	r.channel = channel
-}
+func (r *flowRun) UUID() flows.RunUUID     { return r.uuid }
+func (r *flowRun) Flow() flows.Flow        { return r.flow }
+func (r *flowRun) Contact() *flows.Contact { return r.contact }
 
 func (r *flowRun) Context() flows.Context             { return r.context }
 func (r *flowRun) Environment() flows.FlowEnvironment { return r.environment }
@@ -267,15 +206,13 @@ func NewRun(env flows.FlowEnvironment, flow flows.Flow, contact *flows.Contact, 
 	now := time.Now().UTC()
 
 	r := &flowRun{
-		uuid:        flows.RunUUID(uuid.NewV4().String()),
-		flowUUID:    flow.UUID(),
-		contactUUID: contact.UUID(),
-		results:     flows.NewResults(),
-		contact:     contact,
-		flow:        flow,
-		status:      flows.StatusActive,
-		createdOn:   now,
-		modifiedOn:  now,
+		uuid:       flows.RunUUID(uuid.NewV4().String()),
+		flow:       flow,
+		contact:    contact,
+		results:    flows.NewResults(),
+		status:     flows.StatusActive,
+		createdOn:  now,
+		modifiedOn: now,
 	}
 
 	r.environment = newRunEnvironment(env, r)
@@ -301,9 +238,6 @@ func NewRun(env flows.FlowEnvironment, flow flows.Flow, contact *flows.Contact, 
 func (r *flowRun) Resolve(key string) interface{} {
 	switch key {
 
-	case "channel":
-		return r.Channel()
-
 	case "contact":
 		return r.Contact()
 
@@ -312,6 +246,9 @@ func (r *flowRun) Resolve(key string) interface{} {
 
 	case "flow":
 		return r.Flow()
+
+	case "input":
+		return r.Input()
 
 	case "status":
 		return r.Status()
@@ -352,14 +289,14 @@ type runReference struct {
 func (r *runReference) Resolve(key string) interface{} {
 	switch key {
 
-	case "channel_uuid":
-		return r.ChannelUUID()
+	case "contact":
+		return r.Contact()
 
-	case "contact_uuid":
-		return r.ContactUUID()
+	case "flow":
+		return r.Flow()
 
-	case "flow_uuid":
-		return r.FlowUUID()
+	case "input":
+		return r.Input()
 
 	case "status":
 		return r.Status()
@@ -388,10 +325,10 @@ func (r *runReference) String() string {
 	return string(r.Status())
 }
 
-func (r *runReference) UUID() flows.RunUUID            { return r.uuid }
-func (r *runReference) FlowUUID() flows.FlowUUID       { return r.run.flowUUID }
-func (r *runReference) ContactUUID() flows.ContactUUID { return r.run.contactUUID }
-func (r *runReference) ChannelUUID() flows.ChannelUUID { return r.run.channelUUID }
+func (r *runReference) UUID() flows.RunUUID     { return r.uuid }
+func (r *runReference) Flow() flows.Flow        { return r.run.flow }
+func (r *runReference) Contact() *flows.Contact { return r.run.contact }
+func (r *runReference) Input() flows.Input      { return r.run.input }
 
 func (r *runReference) Results() *flows.Results { return r.run.results }
 func (r *runReference) Status() flows.RunStatus { return r.run.status }
@@ -413,22 +350,11 @@ func newReferenceFromRun(r *flowRun) *runReference {
 // JSON Encoding / Decoding
 //------------------------------------------------------------------------------------------
 
-// ReadRun decodes a run from the passed in JSON
-func ReadRun(data json.RawMessage) (flows.FlowRun, error) {
-	run := &flowRun{}
-	err := json.Unmarshal(data, run)
-	if err == nil {
-		// err = run.Validate()
-	}
-	return run, err
-}
-
 type runEnvelope struct {
-	UUID    flows.RunUUID     `json:"uuid"`
-	Flow    flows.FlowUUID    `json:"flow_uuid"`
-	Channel flows.ChannelUUID `json:"channel_uuid"`
-	Contact flows.ContactUUID `json:"contact_uuid"`
-	Path    []*step           `json:"path"`
+	UUID        flows.RunUUID     `json:"uuid"`
+	FlowUUID    flows.FlowUUID    `json:"flow_uuid"`
+	ContactUUID flows.ContactUUID `json:"contact_uuid"`
+	Path        []*step           `json:"path"`
 
 	Status flows.RunStatus `json:"status"`
 
@@ -449,19 +375,18 @@ type runEnvelope struct {
 	ExitedOn   *time.Time `json:"exited_on"`
 }
 
-func (r *flowRun) UnmarshalJSON(data []byte) error {
+// ReadRun decodes a run from the passed in JSON
+func ReadRun(env flows.FlowEnvironment, data json.RawMessage) (flows.FlowRun, error) {
+	r := &flowRun{}
 	var envelope runEnvelope
 	var err error
 
 	err = json.Unmarshal(data, &envelope)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	r.uuid = envelope.UUID
-	r.contactUUID = envelope.Contact
-	r.flowUUID = envelope.Flow
-	r.channelUUID = envelope.Channel
 	r.status = envelope.Status
 	r.createdOn = envelope.CreatedOn
 	r.modifiedOn = envelope.ModifiedOn
@@ -469,6 +394,15 @@ func (r *flowRun) UnmarshalJSON(data []byte) error {
 	r.timesOutOn = envelope.TimesOutOn
 	r.exitedOn = envelope.ExitedOn
 	r.extra = envelope.Extra
+
+	r.flow, err = env.GetFlow(envelope.FlowUUID)
+	if err != nil {
+		return nil, err
+	}
+	r.contact, err = env.GetContact(envelope.ContactUUID)
+	if err != nil {
+		return nil, err
+	}
 
 	if envelope.Parent != "" {
 		r.parent = &runReference{uuid: envelope.Parent}
@@ -478,16 +412,16 @@ func (r *flowRun) UnmarshalJSON(data []byte) error {
 	}
 
 	if envelope.Input != nil {
-		r.input, err = inputs.InputFromEnvelope(envelope.Input)
+		r.input, err = inputs.ReadInput(env, envelope.Input)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if envelope.Wait != nil {
 		r.wait, err = waits.WaitFromEnvelope(envelope.Wait)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -507,7 +441,42 @@ func (r *flowRun) UnmarshalJSON(data []byte) error {
 		r.path[i] = step
 	}
 
-	return err
+	// add ourselves to the environment and save it off
+	env.AddRun(r)
+	r.environment = newRunEnvironment(env, r)
+
+	return r, nil
+}
+
+// Hydrate initializes a previously serialized run so that is ready for execution
+func (r *flowRun) Hydrate(env flows.FlowEnvironment) error {
+
+	// start with a fresh output if we don't have one
+	if r.session == nil {
+		r.ResetSession()
+	}
+
+	// build our context
+	r.context = NewContextForContact(r.contact, r)
+
+	// resolve our parent/child run references
+	if r.parent != nil {
+		parent, err := env.GetRun(r.parent.UUID())
+		if err != nil {
+			return err
+		}
+		r.parent = newReferenceFromRun(parent.(*flowRun))
+	}
+
+	if r.child != nil {
+		child, err := env.GetRun(r.child.UUID())
+		if err != nil {
+			return err
+		}
+		r.child = newReferenceFromRun(child.(*flowRun))
+	}
+
+	return nil
 }
 
 func (r *flowRun) MarshalJSON() ([]byte, error) {
@@ -515,9 +484,8 @@ func (r *flowRun) MarshalJSON() ([]byte, error) {
 	var err error
 
 	re.UUID = r.uuid
-	re.Flow = r.FlowUUID()
-	re.Contact = r.ContactUUID()
-	re.Channel = r.ChannelUUID()
+	re.FlowUUID = r.flow.UUID()
+	re.ContactUUID = r.contact.UUID()
 
 	re.Status = r.status
 	re.CreatedOn = r.createdOn

--- a/flows/runs/session.go
+++ b/flows/runs/session.go
@@ -84,7 +84,7 @@ type sessionEnvelope struct {
 
 // ReadSession decodes a session from the passed in JSON
 func ReadSession(env flows.SessionEnvironment, data json.RawMessage) (flows.Session, error) {
-	s := &session{}
+	s := NewSession(env)
 	var envelope sessionEnvelope
 	var err error
 
@@ -93,14 +93,12 @@ func ReadSession(env flows.SessionEnvironment, data json.RawMessage) (flows.Sess
 		return nil, err
 	}
 
-	s.runs = make([]flows.FlowRun, len(envelope.Runs))
 	for i := range envelope.Runs {
 		run, err := ReadRun(s, envelope.Runs[i])
-		s.addRun(run)
-		s.runs[i] = run
 		if err != nil {
 			return nil, err
 		}
+		s.addRun(run)
 	}
 
 	// once all runs are read, we can resolve references between runs


### PR DESCRIPTION
This wasn't supposed to turn into a refactor but you know how things go. Currently the engine starts up something like:

1. flows + contacts loaded
2. FlowEnvironment created from the flows + runs + contacts
3. Session created from that
4. Runs created and assigned a session, also added to the FlowEnvironment

But this PR reworks things so that:

1. flows + channels + contacts loaded
2. SessionEnvironment created from the flows + channels + contacts (i.e. dependencies)
3. Session created from that
4. Runs created from the session (i.e. no such thing as a session-less run)

This means things in the session don't have to store UUIDs for flows, contacts and channels, and resolve those later to real objects - they can resolve them as they're being unmarshaled.

Arguably we need to go one step further and have SessionEnvironment do the loading of flows + channels + contacts in the order channels &rarr; contacts &rarr; flows so that we can resolve the dependencies between those as they are loaded (e.g. contact will have a channel)