### PR TITLE
Numeric test fixes

### DIFF
--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -435,12 +435,24 @@ func createCase(baseLanguage utils.Language, exitMap map[string]flows.Exit, r le
 	case "eq", "gt", "gte", "lt", "lte":
 		test := stringTest{}
 		err = json.Unmarshal(r.Test.Data, &test)
-		arguments = []string{test.Test}
+		migratedTest, err := excellent.MigrateTemplate(test.Test)
+		if err != nil {
+			return routers.Case{}, err
+		}
+		arguments = []string{migratedTest}
 
 	case "between":
 		test := betweenTest{}
 		err = json.Unmarshal(r.Test.Data, &test)
-		arguments = []string{test.Min, test.Max}
+		migratedMin, err := excellent.MigrateTemplate(test.Min)
+		if err != nil {
+			return routers.Case{}, err
+		}
+		migratedMax, err := excellent.MigrateTemplate(test.Max)
+		if err != nil {
+			return routers.Case{}, err
+		}
+		arguments = []string{migratedMin, migratedMax}
 
 	// tests against a single localized string
 	case "contains", "contains_any", "contains_phrase", "contains_only_phrase", "regex", "starts":

--- a/flows/definition/testdata/test_migrations.json
+++ b/flows/definition/testdata/test_migrations.json
@@ -2,13 +2,13 @@
     {
         "legacy_test": {
             "type": "between",
-            "min": "12",
+            "min": "@contact.age",
             "max": "34"
         },
         "expected_case": {
             "uuid": "������������������������������������",
             "type": "has_number_between",
-            "arguments": ["12", "34"],
+            "arguments": ["@contact.fields.age", "34"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
         "expected_localization": {}
@@ -165,12 +165,12 @@
     {
         "legacy_test": {
             "type": "eq",
-            "test": "12"
+            "test": "@contact.age"
         },
         "expected_case": {
             "uuid": "������������������������������������",
             "type": "has_number_eq",
-            "arguments": ["12"],
+            "arguments": ["@contact.fields.age"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
         "expected_localization": {}
@@ -178,12 +178,12 @@
     {
         "legacy_test": {
             "type": "gt",
-            "test": "12"
+            "test": "@contact.age"
         },
         "expected_case": {
             "uuid": "������������������������������������",
             "type": "has_number_gt",
-            "arguments": ["12"],
+            "arguments": ["@contact.fields.age"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
         "expected_localization": {}
@@ -191,12 +191,12 @@
     {
         "legacy_test": {
             "type": "gte",
-            "test": "12"
+            "test": "@contact.age"
         },
         "expected_case": {
             "uuid": "������������������������������������",
             "type": "has_number_gte",
-            "arguments": ["12"],
+            "arguments": ["@contact.fields.age"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
         "expected_localization": {}
@@ -217,12 +217,12 @@
     {
         "legacy_test": {
             "type": "lt",
-            "test": "12"
+            "test": "@contact.age"
         },
         "expected_case": {
             "uuid": "������������������������������������",
             "type": "has_number_lt",
-            "arguments": ["12"],
+            "arguments": ["@contact.fields.age"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
         "expected_localization": {}
@@ -230,12 +230,12 @@
     {
         "legacy_test": {
             "type": "lte",
-            "test": "12"
+            "test": "@contact.age"
         },
         "expected_case": {
             "uuid": "������������������������������������",
             "type": "has_number_lte",
-            "arguments": ["12"],
+            "arguments": ["@contact.fields.age"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
         "expected_localization": {}

--- a/utils/conversions.go
+++ b/utils/conversions.go
@@ -404,10 +404,14 @@ func ToDecimal(env Environment, val interface{}) (decimal.Decimal, error) {
 
 	case string:
 		// common SMS foibles
-		val = strings.ToLower(val)
-		val = strings.Replace(val, "o", "0", -1)
-		val = strings.Replace(val, "l", "1", -1)
-		return decimal.NewFromString(val)
+		subbed := strings.ToLower(val)
+		subbed = strings.Replace(subbed, "o", "0", -1)
+		subbed = strings.Replace(subbed, "l", "1", -1)
+		parsed, err := decimal.NewFromString(subbed)
+		if err != nil {
+			return decimal.Zero, fmt.Errorf("Cannot convert '%s' to a decimal", val)
+		}
+		return parsed, nil
 	}
 
 	asString, err := ToString(env, val)


### PR DESCRIPTION
* Migrate templates found in arguments to numeric tests
* Use original string in decimal parsing errors (I was seeing a weird error about not being able to parse `"@c0ntact..."`)