### PR TITLE
Flow stack for detecting loops

### DIFF
--- a/flows/actions/start_flow.go
+++ b/flows/actions/start_flow.go
@@ -42,18 +42,7 @@ func (a *StartFlowAction) Validate(assets flows.Assets) error {
 // Execute runs our action
 func (a *StartFlowAction) Execute(run flows.FlowRun, step flows.Step) error {
 
-	// get the set of active flows in the current run stack
-	activeFlows := make(map[flows.FlowUUID]bool)
-	for r := run; ; {
-		activeFlows[r.Flow().UUID()] = true
-		if r.Parent() != nil {
-			r, _ = r.Session().GetRun(r.Parent().UUID())
-		} else {
-			break
-		}
-	}
-
-	if activeFlows[a.FlowUUID] {
+	if run.Session().Stack().HasFlow(a.FlowUUID) {
 		run.AddFatalError(step, a, fmt.Errorf("flow loop detected, stopping execution before starting flow: %s", a.FlowUUID))
 		return nil
 	}

--- a/flows/actions/start_flow.go
+++ b/flows/actions/start_flow.go
@@ -42,7 +42,7 @@ func (a *StartFlowAction) Validate(assets flows.Assets) error {
 // Execute runs our action
 func (a *StartFlowAction) Execute(run flows.FlowRun, step flows.Step) error {
 
-	if run.Session().Stack().HasFlow(a.FlowUUID) {
+	if run.Session().FlowOnStack(a.FlowUUID) {
 		run.AddFatalError(step, a, fmt.Errorf("flow loop detected, stopping execution before starting flow: %s", a.FlowUUID))
 		return nil
 	}

--- a/flows/engine/flow_stack.go
+++ b/flows/engine/flow_stack.go
@@ -49,7 +49,7 @@ func (s *flowStack) hasVisited(nodeUUID flows.NodeUUID) bool {
 	return s.stack[len(s.stack)-1].visitedNodes[nodeUUID]
 }
 
-func (s *flowStack) HasFlow(flowUUID flows.FlowUUID) bool {
+func (s *flowStack) hasFlow(flowUUID flows.FlowUUID) bool {
 	for _, f := range s.stack {
 		if f.flow.UUID() == flowUUID {
 			return true

--- a/flows/engine/flow_stack.go
+++ b/flows/engine/flow_stack.go
@@ -1,0 +1,61 @@
+package engine
+
+import (
+	"github.com/nyaruka/goflow/flows"
+)
+
+type flowFrame struct {
+	flow         flows.Flow
+	visitedNodes map[flows.NodeUUID]bool
+}
+
+type flowStack struct {
+	stack []*flowFrame
+}
+
+// creates a new empty flow stack
+func newFlowStack() *flowStack {
+	return &flowStack{stack: make([]*flowFrame, 0)}
+}
+
+// creates a new flow stack based on the ancestry of the given run
+func flowStackFromRun(run flows.FlowRun) *flowStack {
+	s := newFlowStack()
+	ancestors := run.Ancestors()
+	for a := len(ancestors) - 1; a >= 0; a-- {
+		s.push(ancestors[a].Flow())
+	}
+	s.push(run.Flow())
+	return s
+}
+
+// creates a new frame for the given flow and pushes it onto the stack
+func (s *flowStack) push(flow flows.Flow) {
+	s.stack = append(s.stack, &flowFrame{flow: flow, visitedNodes: make(map[flows.NodeUUID]bool)})
+}
+
+// pops the current frame off the stack
+func (s *flowStack) pop() {
+	s.stack = s.stack[:len(s.stack)-1]
+}
+
+// records the given node as visited in the current frame
+func (s *flowStack) visit(nodeUUID flows.NodeUUID) {
+	s.stack[len(s.stack)-1].visitedNodes[nodeUUID] = true
+}
+
+// checks whether the given node has already been visited in the current frame
+func (s *flowStack) hasVisited(nodeUUID flows.NodeUUID) bool {
+	return s.stack[len(s.stack)-1].visitedNodes[nodeUUID]
+}
+
+func (s *flowStack) HasFlow(flowUUID flows.FlowUUID) bool {
+	for _, f := range s.stack {
+		if f.flow.UUID() == flowUUID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *flowStack) depth() int { return len(s.stack) }

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -218,10 +218,6 @@ type LogEntry interface {
 	Event() Event
 }
 
-type FlowStack interface {
-	HasFlow(FlowUUID) bool
-}
-
 // Session represents the session of a flow run which may contain many runs
 type Session interface {
 	Assets() Assets
@@ -235,7 +231,7 @@ type Session interface {
 	Status() SessionStatus
 	SetTrigger(Flow, FlowRun)
 	Wait() Wait
-	Stack() FlowStack
+	FlowOnStack(FlowUUID) bool
 
 	StartFlow(FlowUUID, []Event) error
 	Resume([]Event) error

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -218,6 +218,10 @@ type LogEntry interface {
 	Event() Event
 }
 
+type FlowStack interface {
+	HasFlow(FlowUUID) bool
+}
+
 // Session represents the session of a flow run which may contain many runs
 type Session interface {
 	Assets() Assets
@@ -231,6 +235,7 @@ type Session interface {
 	Status() SessionStatus
 	SetTrigger(Flow, FlowRun)
 	Wait() Wait
+	Stack() FlowStack
 
 	StartFlow(FlowUUID, []Event) error
 	Resume([]Event) error
@@ -282,6 +287,7 @@ type FlowRun interface {
 
 	Child() FlowRunReference
 	Parent() FlowRunReference
+	Ancestors() []FlowRunReference
 
 	CreatedOn() time.Time
 	ExpiresOn() *time.Time

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -140,6 +140,25 @@ func (r *flowRun) SetStatus(status flows.RunStatus) {
 func (r *flowRun) Parent() flows.FlowRunReference { return r.parent }
 func (r *flowRun) Child() flows.FlowRunReference  { return r.child }
 
+func (r *flowRun) Ancestors() []flows.FlowRunReference {
+	ancestors := make([]flows.FlowRunReference, 0)
+	if r.parent != nil {
+		runRef := r.parent.(*runReference)
+		ancestors = append(ancestors, runRef)
+
+		for {
+			if runRef.run.parent != nil {
+				runRef := runRef.run.parent.(*runReference)
+				ancestors = append(ancestors, runRef)
+			} else {
+				break
+			}
+		}
+	}
+
+	return ancestors
+}
+
 func (r *flowRun) Input() flows.Input         { return r.input }
 func (r *flowRun) SetInput(input flows.Input) { r.input = input }
 


### PR DESCRIPTION
Currently the logic for avoid flow loops doesn't allow something like flow A calling into flow B twice without a wait because we'll hit the same nodes in B twice. This PR introduces a "flow stack" which tracks triggered flows and visited nodes. 