### PR TITLE
Migrating legacy webhook rulesets, take II

### DIFF
--- a/excellent/tests.go
+++ b/excellent/tests.go
@@ -27,11 +27,12 @@ import (
 
 // XTESTS is our mapping of the excellent test names to their actual functions
 var XTESTS = map[string]XFunction{
-	"has_error":          HasError,
-	"has_value":          HasValue,
-	"has_group":          HasGroup,
-	"has_run_status":     HasRunStatus,
-	"has_webhook_status": HasWebhookStatus,
+	"has_error":                 HasError,
+	"has_value":                 HasValue,
+	"has_group":                 HasGroup,
+	"has_run_status":            HasRunStatus,
+	"has_webhook_status":        HasWebhookStatus,
+	"has_legacy_webhook_status": HasLegacyWebhookStatus,
 
 	"has_phrase":      HasPhrase,
 	"has_only_phrase": HasOnlyPhrase,
@@ -225,6 +226,39 @@ func HasWebhookStatus(env utils.Environment, args ...interface{}) interface{} {
 
 	if utils.RequestResponseStatus(strings.ToLower(status)) == rr.Status() {
 		return XTestResult{true, rr.Status()}
+	}
+
+	return XFalseResult
+}
+
+// HasLegacyWebhookStatus returns whether the passed in webhook response, `response`, has the passed in legacy status.
+// Unlike HasWebhookStatus the returned match from this test is the response body.
+//
+// Valid legacy webhook statuses are "success" and "failure".
+//
+//  @(has_legacy_webhook_status(webhook, "success")) -> true
+//  @(has_legacy_webhook_status(webhook, "failure")) -> false
+//
+// @test has_legacy_webhook_status(response)
+func HasLegacyWebhookStatus(env utils.Environment, args ...interface{}) interface{} {
+	if len(args) != 2 {
+		return fmt.Errorf("HAS_LEGACY_WEBHOOK_STATUS takes exactly two arguments, got %d", len(args))
+	}
+
+	// first parameter needs to be a request response
+	rr, isRR := args[0].(*utils.RequestResponse)
+	if !isRR {
+		return fmt.Errorf("HAS_LEGACY_WEBHOOK_STATUS must be called with webhook as first argument")
+	}
+
+	status, err := utils.ToString(env, args[1])
+	if err != nil {
+		return fmt.Errorf("HAS_LEGACY_WEBHOOK_STATUS must be called with a string as second argument")
+	}
+	status = strings.ToLower(status)
+
+	if (status == "success" && rr.Status() == utils.RRSuccess) || (status == "failure" && (rr.Status() == utils.RRResponseError || rr.Status() == utils.RRConnectionError)) {
+		return XTestResult{true, rr.Body()}
 	}
 
 	return XFalseResult

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -252,7 +252,7 @@ var testTypeMappings = map[string]string{
 	"phone":                "has_phone",
 	"regex":                "has_pattern",
 	"starts":               "has_beginning",
-	"webhook_status":       "has_webhook_status",
+	"webhook_status":       "has_legacy_webhook_status",
 }
 
 func createAction(baseLanguage utils.Language, a legacyAction, fieldMap map[string]flows.FieldUUID, translations *flowTranslations) (flows.Action, error) {
@@ -502,11 +502,7 @@ func createCase(baseLanguage utils.Language, exitMap map[string]flows.Exit, r le
 	case "webhook_status":
 		test := webhookTest{}
 		err = json.Unmarshal(r.Test.Data, &test)
-		if test.Status == "success" {
-			arguments = []string{string(utils.RRSuccess)}
-		} else {
-			arguments = []string{string(utils.RRResponseError)}
-		}
+		arguments = []string{test.Status}
 
 	default:
 		return routers.Case{}, fmt.Errorf("Migration of '%s' tests no supported", r.Test.Type)
@@ -645,14 +641,6 @@ func createRuleNode(lang utils.Language, r legacyRuleSet, translations *flowTran
 				Headers:    migratedHeaders,
 			},
 		}
-
-		// add additional case for "connection_error" and map to same exit as "response_error"
-		cases = append(cases, routers.Case{
-			UUID:      flows.UUID(uuid.NewV4().String()),
-			Type:      "has_webhook_status",
-			Arguments: []string{"connection_error"},
-			ExitUUID:  exits[1].UUID(),
-		})
 
 		// subflow rulesets operate on the child flow status
 		node.router = routers.NewSwitchRouter(defaultExit, "@run.webhook", cases, resultName)

--- a/flows/definition/testdata/ruleset_migrations.json
+++ b/flows/definition/testdata/ruleset_migrations.json
@@ -356,20 +356,14 @@
 		        "cases": [
 		            {
 		                "uuid": "������������������������������������",
-		                "type": "has_webhook_status",
+		                "type": "has_legacy_webhook_status",
 		                "arguments": ["success"],
 		                "exit_uuid": "7fab0ddd-3e4d-4541-84df-8470e05ead16"
 		            },
 		            {
 		                "uuid": "������������������������������������",
-		                "type": "has_webhook_status",
-		                "arguments": ["response_error"],
-		                "exit_uuid": "f3e4cb68-408f-4435-b337-82826e928875"
-		            },
-		            {
-		                "uuid": "������������������������������������",
-		                "type": "has_webhook_status",
-		                "arguments": ["connection_error"],
+		                "type": "has_legacy_webhook_status",
+		                "arguments": ["failure"],
 		                "exit_uuid": "f3e4cb68-408f-4435-b337-82826e928875"
 		            }
 		        ]

--- a/flows/definition/testdata/test_migrations.json
+++ b/flows/definition/testdata/test_migrations.json
@@ -350,7 +350,7 @@
         },
         "expected_case": {
             "uuid": "������������������������������������",
-            "type": "has_webhook_status",
+            "type": "has_legacy_webhook_status",
             "arguments": ["success"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
@@ -363,8 +363,8 @@
         },
         "expected_case": {
             "uuid": "������������������������������������",
-            "type": "has_webhook_status",
-            "arguments": ["response_error"],
+            "type": "has_legacy_webhook_status",
+            "arguments": ["failure"],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },
         "expected_localization": {}


### PR DESCRIPTION
To mimic legacy behaviour we have to set the response body as the flow result... cleanest way to do this is with a different test altogether