### PR TITLE
Group assets and actions

### DIFF
--- a/cmd/docgen/run.go
+++ b/cmd/docgen/run.go
@@ -34,7 +34,16 @@ var assetsDef = `
 				"actions": []
 			}]
 		}
-	]
+	},
+	{
+		"type": "group",
+		"url": "http://testserver/assets/group",
+		"content": [
+			{"uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d", "name": "Testers"},
+			{"uuid": "1e1ce1e1-9288-4504-869e-022d1003c72a", "name": "Customers"}
+		],
+		"is_set": true
+	}
 ]
 `
 
@@ -48,6 +57,12 @@ var emptyDef = `
 			"name": "EmptyFlow",
 			"nodes": []
 		}
+	},
+	{
+		"type": "group",
+		"url": "http://testserver/assets/group",
+		"content": [],
+		"is_set": true
 	}
 ]
 `
@@ -57,10 +72,7 @@ var contactDef = `
 	"name": "Ryan Lewis",
 	"uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
 	"urns": ["tel:%2B12065551212", "email:foo@bar.com"],
-	"groups": [{
-		"uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
-		"name": "Registered Users"
-	}],
+	"groups": ["b7cf0d83-f1c9-411c-96fd-c511a4cfa86d"],
 	"fields": {
 		"activation_token": {
 			"field_uuid": "ee46f9c4-b094-4e1b-ab0d-d4e65b4a99f1",
@@ -80,7 +92,11 @@ func createExampleSession(assetsDef string) (flows.Session, error) {
 	}
 
 	// create our engine session
-	assetURLs := map[engine.AssetItemType]string{"flow": "http://testserver/assets/flow"}
+	assetURLs := map[engine.AssetItemType]string{
+		"channel": "http://testserver/assets/channel",
+		"flow":    "http://testserver/assets/flow",
+		"group":   "http://testserver/assets/group",
+	}
 	session := engine.NewSession(assetCache, assetURLs)
 
 	// create our contact

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -43,6 +43,7 @@ var serverURL = ""
 var assetURLs = map[engine.AssetItemType]string{
 	"channel": "http://testserver/assets/channel",
 	"flow":    "http://testserver/assets/flow",
+	"group":   "http://testserver/assets/group",
 }
 
 func init() {

--- a/cmd/flowrunner/testdata/flows/all_actions.json
+++ b/cmd/flowrunner/testdata/flows/all_actions.json
@@ -113,6 +113,17 @@
         }
     },
     {
+        "type": "group",
+        "url": "http://testserver/assets/group",
+        "content": [
+          {
+            "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817",
+            "name": "Survey Audience"
+          }
+        ],
+        "is_set": true
+      },
+    {
         "type": "channel",
         "url": "http://testserver/assets/channel/57f1078f-88aa-46f4-a59a-948a5739c03d",
         "content": {

--- a/cmd/flowrunner/testdata/flows/all_actions_test.json
+++ b/cmd/flowrunner/testdata/flows/all_actions_test.json
@@ -23,11 +23,8 @@
           "action_uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
           "event": {
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "groups": [
-              {
-                "name": "Survey Audience",
-                "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
-              }
+            "group_uuids": [
+              "2aad21f6-30b7-42c5-bd7f-1b720c154817"
             ],
             "type": "add_to_group"
           },
@@ -79,11 +76,8 @@
           "action_uuid": "6d1346c0-48d8-4108-9c58-e45a1eb0ff7a",
           "event": {
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "groups": [
-              {
-                "name": "Survey Audience",
-                "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
-              }
+            "group_uuids": [
+              "2aad21f6-30b7-42c5-bd7f-1b720c154817"
             ],
             "type": "remove_from_group"
           },
@@ -195,7 +189,6 @@
               "value": "Male"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -246,11 +239,8 @@
                   },
                   {
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "groups": [
-                      {
-                        "name": "Survey Audience",
-                        "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
-                      }
+                    "group_uuids": [
+                      "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                     ],
                     "type": "add_to_group"
                   },
@@ -282,11 +272,8 @@
                   },
                   {
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "groups": [
-                      {
-                        "name": "Survey Audience",
-                        "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
-                      }
+                    "group_uuids": [
+                      "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                     ],
                     "type": "remove_from_group"
                   },

--- a/cmd/flowrunner/testdata/flows/brochure.json
+++ b/cmd/flowrunner/testdata/flows/brochure.json
@@ -95,7 +95,7 @@
     "url": "http://testserver/assets/group",
     "content": [
       {
-        "uuid": "b3fa763e-474b-49df-b4d6-15e86507668f",
+        "uuid": "7be2f40b-38a0-4b06-9e6d-522dca592cc8",
         "name": "Registered Users"
       }
     ],

--- a/cmd/flowrunner/testdata/flows/brochure.json
+++ b/cmd/flowrunner/testdata/flows/brochure.json
@@ -91,6 +91,17 @@
     }
   },
   {
+    "type": "group",
+    "url": "http://testserver/assets/group",
+    "content": [
+      {
+        "uuid": "b3fa763e-474b-49df-b4d6-15e86507668f",
+        "name": "Registered Users"
+      }
+    ],
+    "is_set": true
+  },
+  {
     "type": "channel",
     "url": "http://testserver/assets/channel/57f1078f-88aa-46f4-a59a-948a5739c03d",
     "content": {

--- a/cmd/flowrunner/testdata/flows/brochure_test.json
+++ b/cmd/flowrunner/testdata/flows/brochure_test.json
@@ -164,6 +164,9 @@
               "value": "Ben"
             }
           },
+          "group_uuids": [
+            "7be2f40b-38a0-4b06-9e6d-522dca592cc8"
+          ],
           "language": "eng",
           "name": "Ryan Lewis",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/brochure_test.json
+++ b/cmd/flowrunner/testdata/flows/brochure_test.json
@@ -45,7 +45,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -138,11 +137,8 @@
           "action_uuid": "b3fa763e-474b-49df-b4d6-15e86507668f",
           "event": {
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "groups": [
-              {
-                "name": "Registered Users",
-                "uuid": "7be2f40b-38a0-4b06-9e6d-522dca592cc8"
-              }
+            "group_uuids": [
+              "7be2f40b-38a0-4b06-9e6d-522dca592cc8"
             ],
             "type": "add_to_group"
           },
@@ -168,12 +164,6 @@
               "value": "Ben"
             }
           },
-          "groups": [
-            {
-              "name": "Registered Users",
-              "uuid": "7be2f40b-38a0-4b06-9e6d-522dca592cc8"
-            }
-          ],
           "language": "eng",
           "name": "Ryan Lewis",
           "timezone": "America/Guayaquil",
@@ -261,11 +251,8 @@
                   },
                   {
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "groups": [
-                      {
-                        "name": "Registered Users",
-                        "uuid": "7be2f40b-38a0-4b06-9e6d-522dca592cc8"
-                      }
+                    "group_uuids": [
+                      "7be2f40b-38a0-4b06-9e6d-522dca592cc8"
                     ],
                     "type": "add_to_group"
                   },

--- a/cmd/flowrunner/testdata/flows/date_parse_test.json
+++ b/cmd/flowrunner/testdata/flows/date_parse_test.json
@@ -45,7 +45,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -151,7 +150,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/default_result_test.json
+++ b/cmd/flowrunner/testdata/flows/default_result_test.json
@@ -44,7 +44,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -162,7 +161,6 @@
               "value": "Ryan"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ryan Lewis",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/empty_test.json
+++ b/cmd/flowrunner/testdata/flows/empty_test.json
@@ -15,7 +15,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/node_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/node_loop_test.json
@@ -36,7 +36,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/subflow_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_loop_test.json
@@ -66,7 +66,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/subflow_other_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_other_test.json
@@ -94,7 +94,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -241,7 +240,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -457,7 +455,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -724,7 +721,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -1042,7 +1038,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/subflow_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_test.json
@@ -64,7 +64,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -195,7 +194,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/two_questions_test.json
+++ b/cmd/flowrunner/testdata/flows/two_questions_test.json
@@ -55,7 +55,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -164,7 +163,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "fra",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -324,7 +322,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "fra",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/cmd/flowrunner/testdata/flows/webhook_persists_test.json
+++ b/cmd/flowrunner/testdata/flows/webhook_persists_test.json
@@ -67,7 +67,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",
@@ -193,7 +192,6 @@
               "value": "Ben"
             }
           },
-          "groups": [],
           "language": "eng",
           "name": "Ben Haggerty",
           "timezone": "America/Guayaquil",

--- a/excellent/tests.go
+++ b/excellent/tests.go
@@ -310,7 +310,7 @@ func HasGroup(env utils.Environment, args ...interface{}) interface{} {
 	}
 
 	// iterate through the groups looking for one with the same UUID as passed in
-	group := contact.Groups().FindGroup(flows.GroupUUID(groupUUID))
+	group := contact.Groups().FindByUUID(flows.GroupUUID(groupUUID))
 	if group != nil {
 		return XTestResult{true, group}
 	}

--- a/flows/actions/add_to_group.go
+++ b/flows/actions/add_to_group.go
@@ -1,6 +1,9 @@
 package actions
 
 import (
+	"fmt"
+
+	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -43,8 +46,29 @@ func (a *AddToGroupAction) Execute(run flows.FlowRun, step flows.Step) error {
 	if contact != nil {
 		groupUUIDs := make([]flows.GroupUUID, 0, len(a.Groups))
 		for _, group := range a.Groups {
-			if contact.Groups().FindByUUID(group.UUID) == nil {
+			if group.UUID != "" && contact.Groups().FindByUUID(group.UUID) == nil {
+				// group is a fixed group with a UUID, and contact doesn't already belong to it
 				groupUUIDs = append(groupUUIDs, group.UUID)
+			} else {
+				// group is an expression that evaluates to an existing group's name
+				allGroups, err := run.Session().Assets().GetGroupSet()
+				if err != nil {
+					return err
+				}
+
+				// evaluate the expression to get the group name
+				evaluatedGroupName, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), group.Name)
+				if err != nil {
+					run.AddError(step, a, err)
+				} else {
+					// look up the set of all groups to see if such a group exists
+					addGroup := allGroups.FindByName(evaluatedGroupName)
+					if addGroup == nil {
+						run.AddError(step, a, fmt.Errorf("no such group with name '%s'", evaluatedGroupName))
+					} else if contact.Groups().FindByUUID(addGroup.UUID()) == nil {
+						groupUUIDs = append(groupUUIDs, addGroup.UUID())
+					}
+				}
 			}
 		}
 		if len(groupUUIDs) > 0 {

--- a/flows/actions/add_to_group.go
+++ b/flows/actions/add_to_group.go
@@ -43,10 +43,9 @@ func (a *AddToGroupAction) Execute(run flows.FlowRun, step flows.Step) error {
 	if contact != nil {
 		groupUUIDs := make([]flows.GroupUUID, 0, len(a.Groups))
 		for _, group := range a.Groups {
-			if contact.Groups().FindByUUID(group.UUID) != nil {
+			if contact.Groups().FindByUUID(group.UUID) == nil {
 				groupUUIDs = append(groupUUIDs, group.UUID)
 			}
-
 		}
 		if len(groupUUIDs) > 0 {
 			run.ApplyEvent(step, a, events.NewAddToGroupEvent(groupUUIDs))

--- a/flows/actions/add_to_group.go
+++ b/flows/actions/add_to_group.go
@@ -25,7 +25,7 @@ const TypeAddToGroup string = "add_to_group"
 // @action add_to_group
 type AddToGroupAction struct {
 	BaseAction
-	Groups []*flows.Group `json:"groups"    validate:"required,min=1"`
+	Groups []*flows.GroupReference `json:"groups" validate:"required,min=1"`
 }
 
 // Type returns the type of this action
@@ -41,15 +41,15 @@ func (a *AddToGroupAction) Execute(run flows.FlowRun, step flows.Step) error {
 	// only generate event if contact's groups change
 	contact := run.Contact()
 	if contact != nil {
-		groups := make([]*flows.Group, 0, len(a.Groups))
+		groupUUIDs := make([]flows.GroupUUID, 0, len(a.Groups))
 		for _, group := range a.Groups {
-			if !contact.InGroup(group) {
-				groups = append(groups, group)
+			if contact.Groups().FindByUUID(group.UUID) != nil {
+				groupUUIDs = append(groupUUIDs, group.UUID)
 			}
 
 		}
-		if len(groups) > 0 {
-			run.ApplyEvent(step, a, events.NewGroupEvent(groups))
+		if len(groupUUIDs) > 0 {
+			run.ApplyEvent(step, a, events.NewAddToGroupEvent(groupUUIDs))
 		}
 	}
 

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -1,6 +1,9 @@
 package actions
 
 import (
+	"fmt"
+
+	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -14,3 +17,44 @@ func NewBaseAction(uuid flows.ActionUUID) BaseAction {
 }
 
 func (a *BaseAction) UUID() flows.ActionUUID { return a.UUID_ }
+
+// helper function for actions that have a set of group references that must be resolved to actual groups
+func resolveGroups(run flows.FlowRun, step flows.Step, action flows.Action, references []*flows.GroupReference) ([]*flows.Group, error) {
+	groupSet, err := run.Session().Assets().GetGroupSet()
+	if err != nil {
+		return nil, err
+	}
+
+	groups := make([]*flows.Group, 0, len(references))
+
+	for _, ref := range references {
+		var group *flows.Group
+
+		if ref.UUID != "" {
+			// group is a fixed group with a UUID
+			group = groupSet.FindByUUID(ref.UUID)
+			if group == nil {
+				return nil, fmt.Errorf("no such group with UUID '%s'", ref.UUID)
+			}
+		} else {
+			// group is an expression that evaluates to an existing group's name
+			// evaluate the expression to get the group name
+			evaluatedGroupName, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), ref.Name)
+			if err != nil {
+				run.AddError(step, action, err)
+			} else {
+				// look up the set of all groups to see if such a group exists
+				group = groupSet.FindByName(evaluatedGroupName)
+				if group == nil {
+					run.AddError(step, action, fmt.Errorf("no such group with name '%s'", evaluatedGroupName))
+				}
+			}
+		}
+
+		if group != nil {
+			groups = append(groups, group)
+		}
+	}
+
+	return groups, nil
+}

--- a/flows/actions/remove_from_group.go
+++ b/flows/actions/remove_from_group.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"fmt"
 
-	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -29,7 +28,7 @@ const TypeRemoveFromGroup string = "remove_from_group"
 // @action remove_from_group
 type RemoveFromGroupAction struct {
 	BaseAction
-	Groups []*flows.GroupReference `json:"groups" validate:"dive"`
+	Groups []*flows.GroupReference `json:"groups" validate:"required,min=1"`
 }
 
 // Type returns the type of this action
@@ -44,46 +43,33 @@ func (a *RemoveFromGroupAction) Validate(assets flows.SessionAssets) error {
 func (a *RemoveFromGroupAction) Execute(run flows.FlowRun, step flows.Step) error {
 	// only generate event if contact's groups change
 	contact := run.Contact()
-	if contact != nil {
-		groupUUIDs := make([]flows.GroupUUID, 0)
+	if contact == nil {
+		return nil
+	}
 
-		// no groups in our action means remove all
-		if len(a.Groups) == 0 {
-			for _, group := range contact.Groups() {
-				groupUUIDs = append(groupUUIDs, group.UUID())
-			}
-		} else {
-			for _, group := range a.Groups {
-				if group.UUID != "" && contact.Groups().FindByUUID(group.UUID) != nil {
-					// group is a fixed group with a UUID, and contact does belong to it
-					groupUUIDs = append(groupUUIDs, group.UUID)
-				} else {
-					// group is an expression that evaluates to an existing group's name
-					allGroups, err := run.Session().Assets().GetGroupSet()
-					if err != nil {
-						return err
-					}
+	groups, err := resolveGroups(run, step, a, a.Groups)
+	if err != nil {
+		return err
+	}
 
-					// evaluate the expression to get the group name
-					evaluatedGroupName, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), group.Name)
-					if err != nil {
-						run.AddError(step, a, err)
-					} else {
-						// look up the set of all groups to see if such a group exists
-						addGroup := allGroups.FindByName(evaluatedGroupName)
-						if addGroup == nil {
-							run.AddError(step, a, fmt.Errorf("no such group with name '%s'", evaluatedGroupName))
-						} else if contact.Groups().FindByUUID(addGroup.UUID()) != nil {
-							groupUUIDs = append(groupUUIDs, addGroup.UUID())
-						}
-					}
-				}
-			}
+	groupUUIDs := make([]flows.GroupUUID, 0, len(groups))
+	for _, group := range groups {
+		// ignore group if contact isn't actually in it
+		if contact.Groups().FindByUUID(group.UUID()) == nil {
+			continue
 		}
 
-		if len(groupUUIDs) > 0 {
-			run.ApplyEvent(step, a, events.NewRemoveFromGroupEvent(groupUUIDs))
+		// error if group is dynamic
+		if group.IsDynamic() {
+			run.AddError(step, a, fmt.Errorf("can't manually remove contact from dynamic group '%s' (%s)", group.Name(), group.UUID()))
+			continue
 		}
+
+		groupUUIDs = append(groupUUIDs, group.UUID())
+	}
+
+	if len(groupUUIDs) > 0 {
+		run.ApplyEvent(step, a, events.NewRemoveFromGroupEvent(groupUUIDs))
 	}
 
 	return nil

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -33,7 +33,7 @@ type SendMsgAction struct {
 	Attachments []string                  `json:"attachments"`
 	URNs        []flows.URN               `json:"urns,omitempty"`
 	Contacts    []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
-	Groups      []*flows.Group            `json:"groups,omitempty"   validate:"dive"`
+	Groups      []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
 }
 
 // Type returns the type of this action
@@ -71,7 +71,7 @@ func (a *SendMsgAction) Execute(run flows.FlowRun, step flows.Step) error {
 	}
 
 	for _, group := range a.Groups {
-		run.ApplyEvent(step, a, events.NewSendMsgToGroup(group.UUID(), text, attachments))
+		run.ApplyEvent(step, a, events.NewSendMsgToGroup(group.UUID, text, attachments))
 	}
 	return nil
 }

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -97,8 +97,8 @@ type legacyGroupReference struct {
 	Name string          `json:"name"`
 }
 
-func (g *legacyGroupReference) Migrate() *flows.Group {
-	return flows.NewGroup(g.UUID, g.Name)
+func (g *legacyGroupReference) Migrate() *flows.GroupReference {
+	return flows.NewGroupReference(g.UUID, g.Name)
 }
 
 type legacyVariable struct {
@@ -352,7 +352,7 @@ func createAction(baseLanguage utils.Language, a legacyAction, translations *flo
 		for i, contact := range a.Contacts {
 			contacts[i] = contact.Migrate()
 		}
-		groups := make([]*flows.Group, len(a.Groups))
+		groups := make([]*flows.GroupReference, len(a.Groups))
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}
@@ -367,7 +367,7 @@ func createAction(baseLanguage utils.Language, a legacyAction, translations *flo
 		}, nil
 
 	case "add_group":
-		groups := make([]*flows.Group, len(a.Groups))
+		groups := make([]*flows.GroupReference, len(a.Groups))
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}
@@ -377,7 +377,7 @@ func createAction(baseLanguage utils.Language, a legacyAction, translations *flo
 			BaseAction: actions.NewBaseAction(a.UUID),
 		}, nil
 	case "del_group":
-		groups := make([]*flows.Group, len(a.Groups))
+		groups := make([]*flows.GroupReference, len(a.Groups))
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -3,6 +3,7 @@ package definition
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/flows"
@@ -93,12 +94,40 @@ func (c *legacyContactReference) Migrate() *flows.ContactReference {
 }
 
 type legacyGroupReference struct {
-	UUID flows.GroupUUID `json:"uuid"`
-	Name string          `json:"name"`
+	UUID flows.GroupUUID
+	Name string
 }
 
 func (g *legacyGroupReference) Migrate() *flows.GroupReference {
 	return flows.NewGroupReference(g.UUID, g.Name)
+}
+
+func (g *legacyGroupReference) UnmarshalJSON(data []byte) error {
+	// group reference may be a string
+	if data[0] == '"' {
+		var groupNameExpression string
+		if err := json.Unmarshal(data, &groupNameExpression); err != nil {
+			return err
+		}
+
+		// if it starts with @ then it's an expression
+		if strings.HasPrefix(groupNameExpression, "@") {
+			groupNameExpression, _ = excellent.MigrateTemplate(groupNameExpression)
+		}
+
+		g.Name = groupNameExpression
+		return nil
+	}
+
+	// or a JSON object with UUID/Name properties
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	g.UUID = flows.GroupUUID(raw["uuid"].(string))
+	g.Name = raw["name"].(string)
+	return nil
 }
 
 type legacyVariable struct {

--- a/flows/definition/testdata/action_migrations.json
+++ b/flows/definition/testdata/action_migrations.json
@@ -4,14 +4,16 @@
             "type": "add_group",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "groups": [
-                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"}
+                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"},
+                "@contact.district"
             ]
         },
         "expected_action": {
             "type": "add_to_group",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "groups": [
-                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"}
+                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"},
+                {"name": "@contact.fields.district"}
             ]
         },
         "expected_localization": {}
@@ -74,14 +76,16 @@
             "type": "del_group",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "groups": [
-                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"}
+                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"},
+                "@contact.district"
             ]
         },
         "expected_action": {
             "type": "remove_from_group",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "groups": [
-                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"}
+                {"uuid": "3eca24b7-6313-4f30-870f-f7b948e54b1e", "name": "Testers"},
+                {"name": "@contact.fields.district"}
             ]
         },
         "expected_localization": {}

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -140,7 +140,7 @@ func (s *sessionAssets) GetGroup(uuid flows.GroupUUID) (*flows.Group, error) {
 		return nil, err
 	}
 	group := groups.FindByUUID(uuid)
-	if group != nil {
+	if group == nil {
 		return nil, fmt.Errorf("no such group with uuid '%s'", uuid)
 	}
 	return group, nil

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -134,13 +134,25 @@ func (s *sessionAssets) GetFlow(uuid flows.FlowUUID) (flows.Flow, error) {
 	return flow, nil
 }
 
-func (s *sessionAssets) GetGroups() ([]flows.Group, error) {
+func (s *sessionAssets) GetGroup(uuid flows.GroupUUID) (*flows.Group, error) {
+	groups, err := s.GetGroupSet()
+	if err != nil {
+		return nil, err
+	}
+	group := groups.FindByUUID(uuid)
+	if group != nil {
+		return nil, fmt.Errorf("no such group with uuid '%s'", uuid)
+	}
+	return group, nil
+}
+
+func (s *sessionAssets) GetGroupSet() (*flows.GroupSet, error) {
 	url := s.getAssetSetURL(assetItemTypeGroup)
 	asset, err := s.cache.getAsset(url, assetTypeSet, assetItemTypeGroup)
 	if err != nil {
 		return nil, err
 	}
-	groups, isType := asset.([]flows.Group)
+	groups, isType := asset.(*flows.GroupSet)
 	if !isType {
 		return nil, fmt.Errorf("asset cache contains asset with wrong type")
 	}
@@ -200,36 +212,19 @@ func (c *AssetCache) Include(data json.RawMessage) error {
 
 // reads an asset from the given raw JSON data
 func readAsset(data json.RawMessage, aType assetType, itemType AssetItemType) (interface{}, error) {
-	var itemReader func(data json.RawMessage) (interface{}, error)
+	var assetReader func(data json.RawMessage) (interface{}, error)
 
-	switch itemType {
-	case assetItemTypeChannel:
-		itemReader = func(data json.RawMessage) (interface{}, error) { return flows.ReadChannel(data) }
-	case assetItemTypeFlow:
-		itemReader = func(data json.RawMessage) (interface{}, error) { return definition.ReadFlow(data) }
-	case assetItemTypeGroup:
-		// TODO: need to separate groups from group refs in flows
-	default:
-		return nil, fmt.Errorf("unknown asset type: %s", itemType)
+	if aType == assetTypeObject && itemType == assetItemTypeChannel {
+		assetReader = func(data json.RawMessage) (interface{}, error) { return flows.ReadChannel(data) }
+	} else if aType == assetTypeObject && itemType == assetItemTypeFlow {
+		assetReader = func(data json.RawMessage) (interface{}, error) { return definition.ReadFlow(data) }
+	} else if aType == assetTypeObject && itemType == assetItemTypeGroup {
+		assetReader = func(data json.RawMessage) (interface{}, error) { return flows.ReadGroup(data) }
+	} else if aType == assetTypeSet && itemType == assetItemTypeGroup {
+		assetReader = func(data json.RawMessage) (interface{}, error) { return flows.ReadGroupSet(data) }
+	} else {
+		return nil, fmt.Errorf("unsupported asset type: %s of %s", aType, itemType)
 	}
 
-	if aType == assetTypeSet {
-		var envelopes []json.RawMessage
-		if err := json.Unmarshal(data, &envelopes); err != nil {
-			return nil, err
-		}
-
-		assets := make([]interface{}, len(envelopes))
-		var err error
-		for e := range envelopes {
-			if assets[e], err = itemReader(data); err != nil {
-				return nil, err
-			}
-		}
-
-		return assets, nil
-	}
-
-	// asset is a single object
-	return itemReader(data)
+	return assetReader(data)
 }

--- a/flows/events/add_to_group.go
+++ b/flows/events/add_to_group.go
@@ -42,8 +42,6 @@ func (e *AddToGroupEvent) Apply(run flows.FlowRun) error {
 	for _, groupUUID := range e.GroupUUIDs {
 		group := groupSet.FindByUUID(groupUUID)
 
-		// TODO groups which evaluate to a name match
-
 		if group != nil {
 			run.Contact().AddGroup(group)
 		}

--- a/flows/events/add_to_group.go
+++ b/flows/events/add_to_group.go
@@ -11,24 +11,21 @@ const TypeAddToGroup string = "add_to_group"
 //   {
 //     "type": "add_to_group",
 //     "created_on": "2006-01-02T15:04:05Z",
-//     "groups": [{
-//	     "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
-//       "name": "Survey Audience"
-//     }]
+//     "group_uuids": ["b7cf0d83-f1c9-411c-96fd-c511a4cfa86d"]
 //   }
 // ```
 //
 // @event add_to_group
 type AddToGroupEvent struct {
 	BaseEvent
-	Groups []*flows.Group `json:"groups"  validate:"required,min=1,dive,uuid4"`
+	GroupUUIDs []flows.GroupUUID `json:"group_uuids" validate:"required,min=1,dive,uuid4"`
 }
 
-// NewGroupEvent returns a new group event
-func NewGroupEvent(groups []*flows.Group) *AddToGroupEvent {
+// NewAddToGroupEvent returns a new add to group event
+func NewAddToGroupEvent(groups []flows.GroupUUID) *AddToGroupEvent {
 	return &AddToGroupEvent{
-		BaseEvent: NewBaseEvent(),
-		Groups:    groups,
+		BaseEvent:  NewBaseEvent(),
+		GroupUUIDs: groups,
 	}
 }
 
@@ -37,8 +34,19 @@ func (e *AddToGroupEvent) Type() string { return TypeAddToGroup }
 
 // Apply applies this event to the given run
 func (e *AddToGroupEvent) Apply(run flows.FlowRun) error {
-	for _, group := range e.Groups {
-		run.Contact().AddGroup(group.UUID(), group.Name())
+	groupSet, err := run.Session().Assets().GetGroupSet()
+	if err != nil {
+		return err
+	}
+
+	for _, groupUUID := range e.GroupUUIDs {
+		group := groupSet.FindByUUID(groupUUID)
+
+		// TODO groups which evaluate to a name match
+
+		if group != nil {
+			run.Contact().AddGroup(group)
+		}
 	}
 	return nil
 }

--- a/flows/events/remove_from_group.go
+++ b/flows/events/remove_from_group.go
@@ -42,6 +42,7 @@ func (e *RemoveFromGroupEvent) Apply(run flows.FlowRun) error {
 
 	for _, groupUUID := range e.GroupUUIDs {
 		group := groupSet.FindByUUID(groupUUID)
+
 		if group != nil {
 			run.Contact().RemoveGroup(group)
 		}

--- a/flows/group.go
+++ b/flows/group.go
@@ -11,7 +11,7 @@ import (
 
 // GroupReference is a reference to group used in a flow action or event
 type GroupReference struct {
-	UUID GroupUUID `json:"uuid" validate:"omitempty,uuid4"`
+	UUID GroupUUID `json:"uuid,omitempty" validate:"omitempty,uuid4"`
 	Name string    `json:"name"`
 }
 

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -99,7 +99,8 @@ func (r RunStatus) String() string { return string(r) }
 type SessionAssets interface {
 	GetChannel(ChannelUUID) (Channel, error)
 	GetFlow(FlowUUID) (Flow, error)
-	GetGroups() ([]Group, error)
+	GetGroup(GroupUUID) (*Group, error)
+	GetGroupSet() (*GroupSet, error)
 }
 
 type Flow interface {

--- a/utils/json.go
+++ b/utils/json.go
@@ -22,6 +22,12 @@ func UnmarshalAndValidate(data []byte, obj interface{}, objName string) error {
 	return nil
 }
 
+func UnmarshalArray(data json.RawMessage) ([]json.RawMessage, error) {
+	var items []json.RawMessage
+	err := json.Unmarshal(data, &items)
+	return items, err
+}
+
 // EmptyJSONFragment is a fragment which has no values
 var EmptyJSONFragment = JSONFragment{}
 


### PR DESCRIPTION
**Groups as assets**

Flows can request a single group (`Group`) or the set of all groups (`GroupSet`) as assets. As an optimization, we only ever fetch the set of all groups, and use that to find individual groups.

**Groups in flows**

These are now modelled as `GroupReference`, similar to `ContactReference`. They're either an object with UUID and name, or a name value which is an expression which evaluates to an existing group (see https://github.com/rapidpro/rapidpro/issues/627).

**Groups on contacts**

These are all just UUIDs now, tho they are still loaded as group objects at session read time. This will likely have to change in the future if we want to contacts to be treated as assets sometimes (e.g. the contact of a parent run if it differs from the current contact).

**Groups on events**

Likewise these are all just UUIDs which keeps `add_to_group` and `remove_from_group` consistent with other events like `send_msg`.