### PR TITLE
Asset server authentication

### DIFF
--- a/cmd/docgen/run.go
+++ b/cmd/docgen/run.go
@@ -87,7 +87,7 @@ func createExampleSession(assetsDef string) (flows.Session, error) {
 	}
 
 	// create our engine session
-	session := engine.NewSession(assetCache, engine.NewTestAssetServer())
+	session := engine.NewSession(assetCache, engine.NewMockAssetServer())
 
 	// create our contact
 	contact, err := flows.ReadContact(session, json.RawMessage(contactDef))

--- a/cmd/docgen/run.go
+++ b/cmd/docgen/run.go
@@ -87,14 +87,7 @@ func createExampleSession(assetsDef string) (flows.Session, error) {
 	}
 
 	// create our engine session
-	assetURLs := engine.AssetTypeURLs{
-		"channel":            "http://testserver/assets/channel",
-		"field":              "http://testserver/assets/field",
-		"flow":               "http://testserver/assets/flow",
-		"group":              "http://testserver/assets/group",
-		"location_hierarchy": "http://testserver/assets/location_hierarchy",
-	}
-	session := engine.NewSession(assetCache, assetURLs)
+	session := engine.NewSession(assetCache, engine.NewTestAssetServer())
 
 	// create our contact
 	contact, err := flows.ReadContact(session, json.RawMessage(contactDef))

--- a/cmd/docgen/run.go
+++ b/cmd/docgen/run.go
@@ -81,7 +81,7 @@ var contactDef = `
 
 func createExampleSession(assetsDef string) (flows.Session, error) {
 	// read our assets
-	assetCache := engine.NewAssetCache(100, 5)
+	assetCache := engine.NewAssetCache(100, 5, "testing/1.0")
 	if err := assetCache.Include(json.RawMessage(assetsDef)); err != nil {
 		return nil, err
 	}

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -174,7 +174,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Error reading assets file: ", err)
 	}
-	assetCache := engine.NewAssetCache(100, 5)
+	assetCache := engine.NewAssetCache(100, 5, "testing/1.0")
 	if err := assetCache.Include(json.RawMessage(assetsJSON)); err != nil {
 		log.Fatal("Error reading assets: ", err)
 	}

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -184,7 +184,7 @@ func main() {
 	la, _ := time.LoadLocation("America/Los_Angeles")
 	env.SetTimezone(la)
 
-	session := engine.NewSession(assetCache, engine.NewTestAssetServer())
+	session := engine.NewSession(assetCache, engine.NewMockAssetServer())
 
 	contactJSON, err := ioutil.ReadFile(*contactFile)
 	if err != nil {
@@ -244,7 +244,7 @@ func main() {
 		callerEvents = append(callerEvents, []flows.Event{event})
 
 		// rebuild our session
-		session, err = engine.ReadSession(assetCache, engine.NewTestAssetServer(), outJSON)
+		session, err = engine.ReadSession(assetCache, engine.NewMockAssetServer(), outJSON)
 		if err != nil {
 			log.Fatalf("Error unmarshalling output: %s", err)
 		}

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -184,11 +184,7 @@ func main() {
 	la, _ := time.LoadLocation("America/Los_Angeles")
 	env.SetTimezone(la)
 
-	assetURLs := engine.AssetTypeURLs{
-		"channel": "http://testserver/assets/channel",
-		"flow":    "http://testserver/assets/flow",
-	}
-	session := engine.NewSession(assetCache, assetURLs)
+	session := engine.NewSession(assetCache, engine.NewTestAssetServer())
 
 	contactJSON, err := ioutil.ReadFile(*contactFile)
 	if err != nil {
@@ -248,7 +244,7 @@ func main() {
 		callerEvents = append(callerEvents, []flows.Event{event})
 
 		// rebuild our session
-		session, err = engine.ReadSession(assetCache, assetURLs, outJSON)
+		session, err = engine.ReadSession(assetCache, engine.NewTestAssetServer(), outJSON)
 		if err != nil {
 			log.Fatalf("Error unmarshalling output: %s", err)
 		}

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -95,7 +95,7 @@ func runFlow(env utils.Environment, assetsFilename string, contactFilename strin
 		return runResult{}, fmt.Errorf("Error reading test assets '%s': %s", assetsFilename, err)
 	}
 
-	session := engine.NewSession(assetCache, engine.NewTestAssetServer())
+	session := engine.NewSession(assetCache, engine.NewMockAssetServer())
 
 	contactJSON, err := readFile("contacts/", contactFilename)
 	if err != nil {
@@ -132,7 +132,7 @@ func runFlow(env utils.Environment, assetsFilename string, contactFilename strin
 		}
 		outputs = append(outputs, &Output{outJSON, marshalEventLog(session.Log())})
 
-		session, err = engine.ReadSession(assetCache, engine.NewTestAssetServer(), outJSON)
+		session, err = engine.ReadSession(assetCache, engine.NewMockAssetServer(), outJSON)
 		if err != nil {
 			return runResult{}, fmt.Errorf("Error marshalling output: %s", err)
 		}
@@ -277,11 +277,11 @@ func TestFlows(t *testing.T) {
 				actualOutput := runResult.outputs[i]
 				expectedOutput := expectedOutputs[i]
 
-				actualSession, err := engine.ReadSession(runResult.assetCache, engine.NewTestAssetServer(), actualOutput.Session)
+				actualSession, err := engine.ReadSession(runResult.assetCache, engine.NewMockAssetServer(), actualOutput.Session)
 				if err != nil {
 					t.Errorf("Error unmarshalling session running flow '%s': %s\n", test.assets, err)
 				}
-				expectedSession, err := engine.ReadSession(runResult.assetCache, engine.NewTestAssetServer(), expectedOutput.Session)
+				expectedSession, err := engine.ReadSession(runResult.assetCache, engine.NewMockAssetServer(), expectedOutput.Session)
 				if err != nil {
 					t.Errorf("Error unmarshalling expected session running flow '%s': %s\n", test.assets, err)
 				}

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -87,7 +87,7 @@ func runFlow(env utils.Environment, assetsFilename string, contactFilename strin
 	// rewrite the URL on any webhook actions
 	testAssetsJSONStr := strings.Replace(string(testAssetsJSON), "http://localhost", serverURL, -1)
 
-	assetCache := engine.NewAssetCache(100, 5)
+	assetCache := engine.NewAssetCache(100, 5, "testing/1.0")
 	if err := assetCache.Include(defaultAssetsJSON); err != nil {
 		return runResult{}, fmt.Errorf("Error reading default assets '%s': %s", assetsFilename, err)
 	}

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -43,14 +43,6 @@ var flowTests = []struct {
 var writeOutput bool
 var serverURL = ""
 
-var assetURLs = engine.AssetTypeURLs{
-	"channel": "http://testserver/assets/channel",
-	"field":   "http://testserver/assets/field",
-	"flow":    "http://testserver/assets/flow",
-	"group":   "http://testserver/assets/group",
-	"label":   "http://testserver/assets/label",
-}
-
 func init() {
 	flag.BoolVar(&writeOutput, "write", false, "whether to rewrite TestFlow output")
 }
@@ -103,7 +95,7 @@ func runFlow(env utils.Environment, assetsFilename string, contactFilename strin
 		return runResult{}, fmt.Errorf("Error reading test assets '%s': %s", assetsFilename, err)
 	}
 
-	session := engine.NewSession(assetCache, assetURLs)
+	session := engine.NewSession(assetCache, engine.NewTestAssetServer())
 
 	contactJSON, err := readFile("contacts/", contactFilename)
 	if err != nil {
@@ -140,7 +132,7 @@ func runFlow(env utils.Environment, assetsFilename string, contactFilename strin
 		}
 		outputs = append(outputs, &Output{outJSON, marshalEventLog(session.Log())})
 
-		session, err = engine.ReadSession(assetCache, assetURLs, outJSON)
+		session, err = engine.ReadSession(assetCache, engine.NewTestAssetServer(), outJSON)
 		if err != nil {
 			return runResult{}, fmt.Errorf("Error marshalling output: %s", err)
 		}
@@ -285,11 +277,11 @@ func TestFlows(t *testing.T) {
 				actualOutput := runResult.outputs[i]
 				expectedOutput := expectedOutputs[i]
 
-				actualSession, err := engine.ReadSession(runResult.assetCache, assetURLs, actualOutput.Session)
+				actualSession, err := engine.ReadSession(runResult.assetCache, engine.NewTestAssetServer(), actualOutput.Session)
 				if err != nil {
 					t.Errorf("Error unmarshalling session running flow '%s': %s\n", test.assets, err)
 				}
-				expectedSession, err := engine.ReadSession(runResult.assetCache, assetURLs, expectedOutput.Session)
+				expectedSession, err := engine.ReadSession(runResult.assetCache, engine.NewTestAssetServer(), expectedOutput.Session)
 				if err != nil {
 					t.Errorf("Error unmarshalling expected session running flow '%s': %s\n", test.assets, err)
 				}

--- a/cmd/flowserver/config.go
+++ b/cmd/flowserver/config.go
@@ -12,6 +12,8 @@ type FlowServerConfig struct {
 
 	AssetCacheSize  int64 `default:"1000"`
 	AssetCachePrune int   `default:"100"`
+
+	Version string `default:"Dev"`
 }
 
 // NewConfigWithPath returns a new instance of Loader to read from the given configuration file using our config options

--- a/cmd/flowserver/main.go
+++ b/cmd/flowserver/main.go
@@ -24,12 +24,17 @@ import (
 	"github.com/nyaruka/goflow/utils"
 )
 
-var version = "dev"
+var version = "Dev"
 
 func main() {
 	m := NewConfigWithPath("flowserver.toml")
 	config := new(FlowServerConfig)
 	m.MustLoad(config)
+
+	// if we have a custom version, use it
+	if version != "Dev" {
+		config.Version = version
+	}
 
 	logger := logrus.New()
 	lg.RedirectStdlogOutput(logger)

--- a/cmd/flowserver/server.go
+++ b/cmd/flowserver/server.go
@@ -123,10 +123,10 @@ func (r *sessionResponse) MarshalJSON() ([]byte, error) {
 }
 
 type startRequest struct {
-	Assets    *json.RawMessage       `json:"assets"`
-	AssetURLs engine.AssetTypeURLs   `json:"asset_urls" validate:"required"`
-	Trigger   *utils.TypedEnvelope   `json:"trigger" validate:"required"`
-	Events    []*utils.TypedEnvelope `json:"events"`
+	Assets      *json.RawMessage       `json:"assets"`
+	AssetServer *engine.AssetServer    `json:"asset_server" validate:"required"`
+	Trigger     *utils.TypedEnvelope   `json:"trigger" validate:"required"`
+	Events      []*utils.TypedEnvelope `json:"events"`
 }
 
 func (s *FlowServer) handleStart(w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -156,7 +156,7 @@ func (s *FlowServer) handleStart(w http.ResponseWriter, r *http.Request) (interf
 	}
 
 	// build our session
-	session := engine.NewSession(s.assetCache, start.AssetURLs)
+	session := engine.NewSession(s.assetCache, start.AssetServer)
 
 	// read our trigger
 	trigger, err := triggers.ReadTrigger(session, start.Trigger)
@@ -180,10 +180,10 @@ func (s *FlowServer) handleStart(w http.ResponseWriter, r *http.Request) (interf
 }
 
 type resumeRequest struct {
-	Assets    json.RawMessage        `json:"assets"`
-	AssetURLs engine.AssetTypeURLs   `json:"asset_urls" validate:"required"`
-	Session   json.RawMessage        `json:"session" validate:"required"`
-	Events    []*utils.TypedEnvelope `json:"events" validate:"required,min=1"`
+	Assets      json.RawMessage        `json:"assets"`
+	AssetServer *engine.AssetServer    `json:"asset_server" validate:"required"`
+	Session     json.RawMessage        `json:"session" validate:"required"`
+	Events      []*utils.TypedEnvelope `json:"events" validate:"required,min=1"`
 }
 
 func (s *FlowServer) handleResume(w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -211,7 +211,7 @@ func (s *FlowServer) handleResume(w http.ResponseWriter, r *http.Request) (inter
 	}
 
 	// read our session
-	session, err := engine.ReadSession(s.assetCache, resume.AssetURLs, resume.Session)
+	session, err := engine.ReadSession(s.assetCache, resume.AssetServer, resume.Session)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/flowserver/server.go
+++ b/cmd/flowserver/server.go
@@ -124,7 +124,7 @@ func (r *sessionResponse) MarshalJSON() ([]byte, error) {
 
 type startRequest struct {
 	Assets      *json.RawMessage       `json:"assets"`
-	AssetServer *engine.AssetServer    `json:"asset_server" validate:"required"`
+	AssetServer json.RawMessage        `json:"asset_server" validate:"required"`
 	Trigger     *utils.TypedEnvelope   `json:"trigger" validate:"required"`
 	Events      []*utils.TypedEnvelope `json:"events"`
 }
@@ -155,8 +155,14 @@ func (s *FlowServer) handleStart(w http.ResponseWriter, r *http.Request) (interf
 		}
 	}
 
+	// read and validate our asset server
+	assetServer, err := engine.ReadAssetServer(start.AssetServer)
+	if err != nil {
+		return nil, err
+	}
+
 	// build our session
-	session := engine.NewSession(s.assetCache, start.AssetServer)
+	session := engine.NewSession(s.assetCache, assetServer)
 
 	// read our trigger
 	trigger, err := triggers.ReadTrigger(session, start.Trigger)
@@ -180,8 +186,8 @@ func (s *FlowServer) handleStart(w http.ResponseWriter, r *http.Request) (interf
 }
 
 type resumeRequest struct {
-	Assets      json.RawMessage        `json:"assets"`
-	AssetServer *engine.AssetServer    `json:"asset_server" validate:"required"`
+	Assets      *json.RawMessage       `json:"assets"`
+	AssetServer json.RawMessage        `json:"asset_server" validate:"required"`
 	Session     json.RawMessage        `json:"session" validate:"required"`
 	Events      []*utils.TypedEnvelope `json:"events" validate:"required,min=1"`
 }
@@ -205,13 +211,21 @@ func (s *FlowServer) handleResume(w http.ResponseWriter, r *http.Request) (inter
 		return nil, err
 	}
 
-	// read and validate our assets
-	if err = s.assetCache.Include(resume.Assets); err != nil {
+	// include any embedded assets
+	if resume.Assets != nil {
+		if err = s.assetCache.Include(*resume.Assets); err != nil {
+			return nil, err
+		}
+	}
+
+	// read and validate our asset server
+	assetServer, err := engine.ReadAssetServer(resume.AssetServer)
+	if err != nil {
 		return nil, err
 	}
 
 	// read our session
-	session, err := engine.ReadSession(s.assetCache, resume.AssetServer, resume.Session)
+	session, err := engine.ReadSession(s.assetCache, assetServer, resume.Session)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/flowserver/server.go
+++ b/cmd/flowserver/server.go
@@ -82,7 +82,8 @@ func NewFlowServer(config *FlowServerConfig, logger *logrus.Logger) *FlowServer 
 
 // Start starts the flow server
 func (s *FlowServer) Start() {
-	s.assetCache = engine.NewAssetCache(s.config.AssetCacheSize, s.config.AssetCachePrune)
+	fetchUserAgent := fmt.Sprintf("flowserver/%s", s.config.Version)
+	s.assetCache = engine.NewAssetCache(s.config.AssetCacheSize, s.config.AssetCachePrune, fetchUserAgent)
 
 	go func() {
 		err := s.httpServer.ListenAndServe()

--- a/cmd/flowserver/server_test.go
+++ b/cmd/flowserver/server_test.go
@@ -181,11 +181,11 @@ var startRequestTemplate = `{
 type ServerTestSuite struct {
 	suite.Suite
 	flowServer  *FlowServer
-	assetServer *engine.AssetServer
+	assetServer engine.AssetServer
 }
 
 func (ts *ServerTestSuite) SetupSuite() {
-	ts.assetServer = engine.NewTestAssetServer()
+	ts.assetServer = engine.NewMockAssetServer()
 
 	ts.flowServer = NewFlowServer(NewTestConfig(), logrus.New())
 	ts.flowServer.Start()
@@ -254,9 +254,14 @@ func (ts *ServerTestSuite) buildResumeRequest(assetsJSON string, session flows.S
 		ts.Require().NoError(err)
 	}
 
+	assets := json.RawMessage(assetsJSON)
+	assetServer, _ := json.Marshal(engine.NewMockAssetServer())
+
+	fmt.Printf("===================================================\n%s\n", string(assetServer))
+
 	request := &resumeRequest{
-		Assets:      json.RawMessage(assetsJSON),
-		AssetServer: engine.NewTestAssetServer(),
+		Assets:      &assets,
+		AssetServer: assetServer,
 		Session:     sessionJSON,
 		Events:      eventEnvelopes,
 	}

--- a/flows/engine/assets_test.go
+++ b/flows/engine/assets_test.go
@@ -17,7 +17,7 @@ func TestAssetCache(t *testing.T) {
 		"uuid": "f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4",
 		"name": "Spam"
 	}`)
-	cache := NewAssetCache(100, 10)
+	cache := NewAssetCache(100, 10, "testing/1.0")
 
 	asset, err := cache.getSetAsset(server, assetType("pizza"))
 	assert.EqualError(t, err, "asset type 'pizza' not supported by asset server")
@@ -55,7 +55,7 @@ func TestAssetServer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "http://testserver/assets/group/2aad21f6-30b7-42c5-bd7f-1b720c154817", url)
 
-	asset, err := server.fetchAsset(url, assetTypeGroup, false)
+	asset, err := server.fetchAsset(url, assetTypeGroup, false, "testing/1.0")
 	assert.NoError(t, err)
 	assert.Equal(t, server.mockedRequests, []string{"http://testserver/assets/group/2aad21f6-30b7-42c5-bd7f-1b720c154817"})
 
@@ -73,7 +73,7 @@ func TestSessionAssets(t *testing.T) {
 			"name": "Survey Audience"
 		}
 	]`)
-	cache := NewAssetCache(100, 10)
+	cache := NewAssetCache(100, 10, "testing/1.0")
 	sessionAssets := NewSessionAssets(cache, server)
 
 	group, err := sessionAssets.GetGroup(flows.GroupUUID("2aad21f6-30b7-42c5-bd7f-1b720c154817"))
@@ -90,7 +90,7 @@ func TestFlowValidation(t *testing.T) {
 	assert.NoError(t, err)
 
 	// build our session
-	assetCache := NewAssetCache(100, 5)
+	assetCache := NewAssetCache(100, 5, "testing/1.0")
 	err = assetCache.Include(assetsJSON)
 	assert.NoError(t, err)
 

--- a/flows/engine/assets_test.go
+++ b/flows/engine/assets_test.go
@@ -8,14 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testAssetURLs = AssetTypeURLs{
-	"channel": "http://testserver/assets/channel",
-	"field":   "http://testserver/assets/field",
-	"flow":    "http://testserver/assets/flow",
-	"group":   "http://testserver/assets/group",
-	"label":   "http://testserver/assets/label",
-}
-
 func TestFlowValidation(t *testing.T) {
 	assetsJSON, err := ioutil.ReadFile("testdata/assets.json")
 	assert.NoError(t, err)
@@ -25,7 +17,7 @@ func TestFlowValidation(t *testing.T) {
 	err = assetCache.Include(assetsJSON)
 	assert.NoError(t, err)
 
-	session := NewSession(assetCache, testAssetURLs)
+	session := NewSession(assetCache, NewTestAssetServer())
 	flow, err := session.Assets().GetFlow("76f0a02f-3b75-4b86-9064-e9195e1b3a02")
 	assert.NoError(t, err)
 

--- a/flows/engine/assets_test.go
+++ b/flows/engine/assets_test.go
@@ -1,12 +1,89 @@
 package engine
 
 import (
+	"encoding/json"
+	"github.com/nyaruka/goflow/flows"
 	"io/ioutil"
+	"reflect"
 	"testing"
 
 	"github.com/nyaruka/goflow/flows/actions"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAssetCache(t *testing.T) {
+	server := NewMockAssetServer().(*mockAssetServer)
+	server.mockResponses["http://testserver/assets/label/f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4"] = json.RawMessage(`{
+		"uuid": "f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4",
+		"name": "Spam"
+	}`)
+	cache := NewAssetCache(100, 10)
+
+	asset, err := cache.getSetAsset(server, assetType("pizza"))
+	assert.EqualError(t, err, "asset type 'pizza' not supported by asset server")
+
+	asset, err = cache.getItemAsset(server, assetTypeLabel, "f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4")
+	assert.NoError(t, err)
+	assert.Equal(t, server.mockedRequests, []string{"http://testserver/assets/label/f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4"})
+
+	label, isLabel := asset.(*flows.Label)
+	assert.True(t, isLabel, "expecting label but got something of type %s", reflect.TypeOf(asset))
+	assert.Equal(t, flows.LabelUUID("f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4"), label.UUID())
+	assert.Equal(t, "Spam", label.Name())
+
+	// check that we can refetch without making another server request
+	asset, err = cache.getItemAsset(server, assetTypeLabel, "f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4")
+	assert.NoError(t, err)
+	assert.Equal(t, server.mockedRequests, []string{"http://testserver/assets/label/f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4"})
+}
+
+func TestAssetServer(t *testing.T) {
+	server := NewMockAssetServer().(*mockAssetServer)
+	server.mockResponses["http://testserver/assets/group/2aad21f6-30b7-42c5-bd7f-1b720c154817"] = json.RawMessage(`{
+		"uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817",
+		"name": "Survey Audience"
+	}`)
+
+	url, err := server.getSetAssetURL(assetType("pizza"))
+	assert.EqualError(t, err, "asset type 'pizza' not supported by asset server")
+
+	url, err = server.getSetAssetURL(assetTypeGroup)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://testserver/assets/group", url)
+
+	url, err = server.getItemAssetURL(assetTypeGroup, "2aad21f6-30b7-42c5-bd7f-1b720c154817")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://testserver/assets/group/2aad21f6-30b7-42c5-bd7f-1b720c154817", url)
+
+	asset, err := server.fetchAsset(url, assetTypeGroup, false)
+	assert.NoError(t, err)
+	assert.Equal(t, server.mockedRequests, []string{"http://testserver/assets/group/2aad21f6-30b7-42c5-bd7f-1b720c154817"})
+
+	group, isGroup := asset.(*flows.Group)
+	assert.True(t, isGroup, "expecting group but got something of type %s", reflect.TypeOf(asset))
+	assert.Equal(t, flows.GroupUUID("2aad21f6-30b7-42c5-bd7f-1b720c154817"), group.UUID())
+	assert.Equal(t, "Survey Audience", group.Name())
+}
+
+func TestSessionAssets(t *testing.T) {
+	server := NewMockAssetServer().(*mockAssetServer)
+	server.mockResponses["http://testserver/assets/group"] = json.RawMessage(`[
+		{
+			"uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817",
+			"name": "Survey Audience"
+		}
+	]`)
+	cache := NewAssetCache(100, 10)
+	sessionAssets := NewSessionAssets(cache, server)
+
+	group, err := sessionAssets.GetGroup(flows.GroupUUID("2aad21f6-30b7-42c5-bd7f-1b720c154817"))
+	assert.NoError(t, err)
+	assert.Equal(t, flows.GroupUUID("2aad21f6-30b7-42c5-bd7f-1b720c154817"), group.UUID())
+	assert.Equal(t, "Survey Audience", group.Name())
+
+	// requesting a group actually fetches and caches the entire group set
+	assert.Equal(t, server.mockedRequests, []string{"http://testserver/assets/group"})
+}
 
 func TestFlowValidation(t *testing.T) {
 	assetsJSON, err := ioutil.ReadFile("testdata/assets.json")
@@ -17,7 +94,7 @@ func TestFlowValidation(t *testing.T) {
 	err = assetCache.Include(assetsJSON)
 	assert.NoError(t, err)
 
-	session := NewSession(assetCache, NewTestAssetServer())
+	session := NewSession(assetCache, NewMockAssetServer())
 	flow, err := session.Assets().GetFlow("76f0a02f-3b75-4b86-9064-e9195e1b3a02")
 	assert.NoError(t, err)
 

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -38,7 +38,7 @@ type session struct {
 }
 
 // NewSession creates a new session
-func NewSession(assetCache *AssetCache, assetServer *AssetServer) flows.Session {
+func NewSession(assetCache *AssetCache, assetServer AssetServer) flows.Session {
 	return &session{
 		env:        utils.NewDefaultEnvironment(),
 		assets:     NewSessionAssets(assetCache, assetServer),
@@ -436,7 +436,7 @@ type sessionEnvelope struct {
 }
 
 // ReadSession decodes a session from the passed in JSON
-func ReadSession(assetCache *AssetCache, assetServer *AssetServer, data json.RawMessage) (flows.Session, error) {
+func ReadSession(assetCache *AssetCache, assetServer AssetServer, data json.RawMessage) (flows.Session, error) {
 	var envelope sessionEnvelope
 	var err error
 

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -38,10 +38,10 @@ type session struct {
 }
 
 // NewSession creates a new session
-func NewSession(cache *AssetCache, assetURLs AssetTypeURLs) flows.Session {
+func NewSession(assetCache *AssetCache, assetServer *AssetServer) flows.Session {
 	return &session{
 		env:        utils.NewDefaultEnvironment(),
-		assets:     NewSessionAssets(cache, assetURLs),
+		assets:     NewSessionAssets(assetCache, assetServer),
 		status:     flows.SessionStatusActive,
 		log:        []flows.LogEntry{},
 		runsByUUID: make(map[flows.RunUUID]flows.FlowRun),
@@ -436,7 +436,7 @@ type sessionEnvelope struct {
 }
 
 // ReadSession decodes a session from the passed in JSON
-func ReadSession(cache *AssetCache, assetURLs AssetTypeURLs, data json.RawMessage) (flows.Session, error) {
+func ReadSession(assetCache *AssetCache, assetServer *AssetServer, data json.RawMessage) (flows.Session, error) {
 	var envelope sessionEnvelope
 	var err error
 
@@ -444,7 +444,7 @@ func ReadSession(cache *AssetCache, assetURLs AssetTypeURLs, data json.RawMessag
 		return nil, err
 	}
 
-	s := NewSession(cache, assetURLs).(*session)
+	s := NewSession(assetCache, assetServer).(*session)
 	s.status = envelope.Status
 
 	// read our environment


### PR DESCRIPTION
Addresses #127. Flow server requests now take an asset_server component which configures authentication as well the asset type URLs, e.g.

```json
"asset_server": {
  "auth_header": "Token 12345678901234567890",
  "type_urls": {
    "flow": "http://testserver/assets/flow",
    "group": "http://testserver/assets/group"
  }
}
```

Have also tried to simplify the cache+server asset stuff and have added a mocked asset server to enable better testing.