### PR TITLE
Bulk send events

### DIFF
--- a/cmd/flowrunner/testdata/flows/all_actions.json
+++ b/cmd/flowrunner/testdata/flows/all_actions.json
@@ -56,7 +56,7 @@
                             "type": "send_email",
                             "subject": "Here is your activation token",
                             "body": "Hi @contact.fields.first_name, Your activation token is @contact.fields.activation_token, your coupon is @run.extra.coupons.0.code",
-                            "emails": [
+                            "addresses": [
                                 "@contact.urns.mailto"
                             ]
                         },

--- a/cmd/flowrunner/testdata/flows/all_actions_test.json
+++ b/cmd/flowrunner/testdata/flows/all_actions_test.json
@@ -95,9 +95,11 @@
         {
           "action_uuid": "4f452fb8-f0aa-442d-865b-a2b629c09c21",
           "event": {
+            "addresses": [
+              "ben@macklemore"
+            ],
             "body": "Hi Ben, Your activation token is XXX-YYY-ZZZ, your coupon is AAA-BBB-CCC",
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "email": "ben@macklemore",
             "subject": "Here is your activation token",
             "type": "send_email"
           },
@@ -464,9 +466,11 @@
                     "value": "XXX-YYY-ZZZ"
                   },
                   {
+                    "addresses": [
+                      "ben@macklemore"
+                    ],
                     "body": "Hi Ben, Your activation token is XXX-YYY-ZZZ, your coupon is AAA-BBB-CCC",
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "email": "ben@macklemore",
                     "subject": "Here is your activation token",
                     "type": "send_email"
                   },

--- a/cmd/flowrunner/testdata/flows/all_actions_test.json
+++ b/cmd/flowrunner/testdata/flows/all_actions_test.json
@@ -177,7 +177,9 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi Ben Haggerty, are you ready?",
             "type": "send_msg",
-            "urn": "tel:+12065551212"
+            "urns": [
+              "tel:+12065551212"
+            ]
           },
           "step_uuid": ""
         },
@@ -188,10 +190,12 @@
               "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Azuay"
             ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "group": {
-              "name": "Survey Audience",
-              "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
-            },
+            "groups": [
+              {
+                "name": "Survey Audience",
+                "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
+              }
+            ],
             "text": "Hi Ben Haggerty, are you ready for these attachments?",
             "type": "send_msg"
           },
@@ -214,10 +218,12 @@
         {
           "action_uuid": "f01d693b-2af2-49fb-9e38-146eb00937e9",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi Ben Haggerty, are you ready to complete today's survey?",
             "type": "send_msg"
@@ -230,37 +236,12 @@
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "This is a message to each of Ben Haggerty's urns.",
             "type": "send_msg",
-            "urn": "tel:+12065551212"
-          },
-          "step_uuid": ""
-        },
-        {
-          "action_uuid": "d98c1e02-69df-4f95-8b89-8587a57ae0c3",
-          "event": {
-            "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "text": "This is a message to each of Ben Haggerty's urns.",
-            "type": "send_msg",
-            "urn": "facebook:1122334455667788"
-          },
-          "step_uuid": ""
-        },
-        {
-          "action_uuid": "d98c1e02-69df-4f95-8b89-8587a57ae0c3",
-          "event": {
-            "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "text": "This is a message to each of Ben Haggerty's urns.",
-            "type": "send_msg",
-            "urn": "mailto:ben@macklemore"
-          },
-          "step_uuid": ""
-        },
-        {
-          "action_uuid": "d98c1e02-69df-4f95-8b89-8587a57ae0c3",
-          "event": {
-            "created_on": "2000-01-01T00:00:00.000000000-00:00",
-            "text": "This is a message to each of Ben Haggerty's urns.",
-            "type": "send_msg",
-            "urn": "twitter:ben_haggerty"
+            "urns": [
+              "tel:+12065551212",
+              "facebook:1122334455667788",
+              "mailto:ben@macklemore",
+              "twitter:ben_haggerty"
+            ]
           },
           "step_uuid": ""
         },
@@ -270,10 +251,12 @@
             "attachments": [
               "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Azuay"
             ],
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "This is a reply with attachments",
             "type": "send_msg"
@@ -536,17 +519,21 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty, are you ready?",
                     "type": "send_msg",
-                    "urn": "tel:+12065551212"
+                    "urns": [
+                      "tel:+12065551212"
+                    ]
                   },
                   {
                     "attachments": [
                       "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Azuay"
                     ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "group": {
-                      "name": "Survey Audience",
-                      "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
-                    },
+                    "groups": [
+                      {
+                        "name": "Survey Audience",
+                        "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
+                      }
+                    ],
                     "text": "Hi Ben Haggerty, are you ready for these attachments?",
                     "type": "send_msg"
                   },
@@ -561,10 +548,12 @@
                     "type": "remove_from_group"
                   },
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty, are you ready to complete today's survey?",
                     "type": "send_msg"
@@ -573,34 +562,23 @@
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is a message to each of Ben Haggerty's urns.",
                     "type": "send_msg",
-                    "urn": "tel:+12065551212"
-                  },
-                  {
-                    "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "text": "This is a message to each of Ben Haggerty's urns.",
-                    "type": "send_msg",
-                    "urn": "facebook:1122334455667788"
-                  },
-                  {
-                    "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "text": "This is a message to each of Ben Haggerty's urns.",
-                    "type": "send_msg",
-                    "urn": "mailto:ben@macklemore"
-                  },
-                  {
-                    "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "text": "This is a message to each of Ben Haggerty's urns.",
-                    "type": "send_msg",
-                    "urn": "twitter:ben_haggerty"
+                    "urns": [
+                      "tel:+12065551212",
+                      "facebook:1122334455667788",
+                      "mailto:ben@macklemore",
+                      "twitter:ben_haggerty"
+                    ]
                   },
                   {
                     "attachments": [
                       "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Azuay"
                     ],
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is a reply with attachments",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/brochure_test.json
+++ b/cmd/flowrunner/testdata/flows/brochure_test.json
@@ -25,10 +25,12 @@
         {
           "action_uuid": "9d9290a7-3713-4c22-8821-4af0a64c0821",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi! What is your name?",
             "type": "send_msg"
@@ -83,10 +85,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi! What is your name?",
                     "type": "send_msg"
@@ -170,10 +174,12 @@
         {
           "action_uuid": "605e3486-503d-481c-94f7-cd553f196a8a",
           "event": {
-            "contact": {
-              "name": "Ryan Lewis",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ryan Lewis",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Great, you are Ryan Lewis, thanks for joining!",
             "type": "send_msg"
@@ -231,10 +237,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi! What is your name?",
                     "type": "send_msg"
@@ -302,10 +310,12 @@
                     "type": "add_to_group"
                   },
                   {
-                    "contact": {
-                      "name": "Ryan Lewis",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ryan Lewis",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Great, you are Ryan Lewis, thanks for joining!",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/date_parse_test.json
+++ b/cmd/flowrunner/testdata/flows/date_parse_test.json
@@ -25,10 +25,12 @@
         {
           "action_uuid": "e97cd6d5-3354-4dbd-85bc-6c1f87849eec",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi Ben Haggerty! When were you born, enter in format yyyy.MM.dd",
             "type": "send_msg"
@@ -83,10 +85,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty! When were you born, enter in format yyyy.MM.dd",
                     "type": "send_msg"
@@ -150,10 +154,12 @@
         {
           "action_uuid": "d2a4052a-3fa9-4608-ab3e-5b9631440447",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Awesome, you were born on 06-23-1977 at 15:34",
             "type": "send_msg"
@@ -212,10 +218,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty! When were you born, enter in format yyyy.MM.dd",
                     "type": "send_msg"
@@ -267,10 +275,12 @@
                     "value": "1977-06-23T15:34:00.000000-05:00"
                   },
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Awesome, you were born on 06-23-1977 at 15:34",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/default_result_test.json
+++ b/cmd/flowrunner/testdata/flows/default_result_test.json
@@ -25,10 +25,12 @@
         {
           "action_uuid": "d3cd8da7-55f2-4bd3-9a0c-efc93c99e498",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "What is your name?",
             "type": "send_msg"
@@ -82,10 +84,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "What is your name?",
                     "type": "send_msg"
@@ -166,10 +170,12 @@
         {
           "action_uuid": "aafb505c-603d-4025-864d-471345ed237d",
           "event": {
-            "contact": {
-              "name": "Ryan Lewis",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ryan Lewis",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Great, pleased to meet you Ryan",
             "type": "send_msg"
@@ -224,10 +230,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "What is your name?",
                     "type": "send_msg"
@@ -293,10 +301,12 @@
                     "value": "Ryan"
                   },
                   {
-                    "contact": {
-                      "name": "Ryan Lewis",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ryan Lewis",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Great, pleased to meet you Ryan",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/dynamic_groups_test.json
+++ b/cmd/flowrunner/testdata/flows/dynamic_groups_test.json
@@ -34,10 +34,12 @@
         {
           "action_uuid": "f01d693b-2af2-49fb-9e38-146eb00937e9",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Current groups: Males, Old Men",
             "type": "send_msg"
@@ -57,10 +59,12 @@
         {
           "action_uuid": "5bc4894f-9ef4-430e-a040-e688fd2dd578",
           "event": {
-            "contact": {
-              "name": "Jim Smith",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Jim Smith",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Current groups: Males, Old Men, People called Jim",
             "type": "send_msg"
@@ -83,10 +87,12 @@
         {
           "action_uuid": "279b0215-c9d5-4a90-b7df-f371812bcc78",
           "event": {
-            "contact": {
-              "name": "Jim Smith",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Jim Smith",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Current groups: Males, People called Jim, Youth",
             "type": "send_msg"
@@ -164,10 +170,12 @@
                     "value": "64"
                   },
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Current groups: Males, Old Men",
                     "type": "send_msg"
@@ -179,10 +187,12 @@
                     "value": "Jim Smith"
                   },
                   {
-                    "contact": {
-                      "name": "Jim Smith",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Jim Smith",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Current groups: Males, Old Men, People called Jim",
                     "type": "send_msg"
@@ -197,10 +207,12 @@
                     "value": "17"
                   },
                   {
-                    "contact": {
-                      "name": "Jim Smith",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Jim Smith",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Current groups: Males, People called Jim, Youth",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/node_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/node_loop_test.json
@@ -8,10 +8,12 @@
         {
           "action_uuid": "9d9290a7-3713-4c22-8821-4af0a64c0821",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi! What is your name?",
             "type": "send_msg"
@@ -67,10 +69,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi! What is your name?",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/subflow_loop_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_loop_test.json
@@ -8,10 +8,12 @@
         {
           "action_uuid": "49f6c984-620f-4d9b-98c4-8ead1d1ef4f6",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "This is the parent flow",
             "type": "send_msg"
@@ -34,10 +36,12 @@
         {
           "action_uuid": "e5a03dde-3b2f-4603-b5d0-d927f6bcc361",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "This is the child flow",
             "type": "send_msg"
@@ -103,10 +107,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is the parent flow",
                     "type": "send_msg"
@@ -146,10 +152,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is the child flow",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/subflow_other_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_other_test.json
@@ -76,10 +76,12 @@
         {
           "action_uuid": "ac403443-4e93-4127-8b03-469598cd7ae2",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi there, let's go to the child.",
             "type": "send_msg"
@@ -102,10 +104,12 @@
         {
           "action_uuid": "9b3d32d4-aa6c-44e0-95cd-92117c67738f",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Welcome to the child, say yes or no!",
             "type": "send_msg"
@@ -159,10 +163,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi there, let's go to the child.",
                     "type": "send_msg"
@@ -205,10 +211,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Welcome to the child, say yes or no!",
                     "type": "send_msg"
@@ -266,10 +274,12 @@
         {
           "action_uuid": "ef6b42af-9751-4120-972c-e60771904dd2",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Nope, that's neither.",
             "type": "send_msg"
@@ -323,10 +333,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi there, let's go to the child.",
                     "type": "send_msg"
@@ -377,10 +389,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Welcome to the child, say yes or no!",
                     "type": "send_msg"
@@ -431,10 +445,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Nope, that's neither.",
                     "type": "send_msg"
@@ -500,10 +516,12 @@
         {
           "action_uuid": "7d17e71a-2967-4dbb-86a4-eda028aca38a",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "You said yes",
             "type": "send_msg"
@@ -513,10 +531,12 @@
         {
           "action_uuid": "54b10283-9863-4edf-abfa-705cf24a64fc",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hooray, you did it and said yes. Say yes or no!",
             "type": "send_msg"
@@ -570,10 +590,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi there, let's go to the child.",
                     "type": "send_msg"
@@ -606,10 +628,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hooray, you did it and said yes. Say yes or no!",
                     "type": "send_msg"
@@ -655,10 +679,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Welcome to the child, say yes or no!",
                     "type": "send_msg"
@@ -709,10 +735,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Nope, that's neither.",
                     "type": "send_msg"
@@ -763,10 +791,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "You said yes",
                     "type": "send_msg"
@@ -821,10 +851,12 @@
         {
           "action_uuid": "27442755-3d94-499f-97d5-a9409ab83b67",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Nope, that's neither",
             "type": "send_msg"
@@ -886,10 +918,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi there, let's go to the child.",
                     "type": "send_msg"
@@ -922,10 +956,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hooray, you did it and said yes. Say yes or no!",
                     "type": "send_msg"
@@ -976,10 +1012,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Nope, that's neither",
                     "type": "send_msg"
@@ -1033,10 +1071,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Welcome to the child, say yes or no!",
                     "type": "send_msg"
@@ -1087,10 +1127,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Nope, that's neither.",
                     "type": "send_msg"
@@ -1141,10 +1183,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "You said yes",
                     "type": "send_msg"
@@ -1199,10 +1243,12 @@
         {
           "action_uuid": "bd387e9c-1ea9-49c8-a292-858d8a23a2d0",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "All Done! You said yes in the child and no here.",
             "type": "send_msg"
@@ -1257,10 +1303,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi there, let's go to the child.",
                     "type": "send_msg"
@@ -1293,10 +1341,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hooray, you did it and said yes. Say yes or no!",
                     "type": "send_msg"
@@ -1347,10 +1397,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Nope, that's neither",
                     "type": "send_msg"
@@ -1401,10 +1453,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "All Done! You said yes in the child and no here.",
                     "type": "send_msg"
@@ -1447,10 +1501,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Welcome to the child, say yes or no!",
                     "type": "send_msg"
@@ -1501,10 +1557,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Nope, that's neither.",
                     "type": "send_msg"
@@ -1555,10 +1613,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "You said yes",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/subflow_test.json
+++ b/cmd/flowrunner/testdata/flows/subflow_test.json
@@ -25,10 +25,12 @@
         {
           "action_uuid": "49f6c984-620f-4d9b-98c4-8ead1d1ef4f6",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "This is the parent flow",
             "type": "send_msg"
@@ -51,10 +53,12 @@
         {
           "action_uuid": "e5a03dde-3b2f-4603-b5d0-d927f6bcc361",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "What is your name?",
             "type": "send_msg"
@@ -108,10 +112,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is the parent flow",
                     "type": "send_msg"
@@ -145,10 +151,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "What is your name?",
                     "type": "send_msg"
@@ -197,10 +205,12 @@
         {
           "action_uuid": "d63929fe-e999-42ef-abf1-4b281f58891e",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Got it!",
             "type": "send_msg"
@@ -210,10 +220,12 @@
         {
           "action_uuid": "5d51eae6-be0f-4cc7-9402-150aa1ed80a1",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Flow succeeded, they said Ryan Lewis",
             "type": "send_msg"
@@ -260,10 +272,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is the parent flow",
                     "type": "send_msg"
@@ -287,10 +301,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Flow succeeded, they said Ryan Lewis",
                     "type": "send_msg"
@@ -324,10 +340,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "What is your name?",
                     "type": "send_msg"
@@ -369,10 +387,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Got it!",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/triggered_test.json
+++ b/cmd/flowrunner/testdata/flows/triggered_test.json
@@ -8,10 +8,12 @@
         {
           "action_uuid": "e97cd6d5-3354-4dbd-85bc-6c1f87849eec",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi Ben Haggerty you were started in this flow by Bob from the 'Parent Flow' flow. He is from Esmeraldas and is aged 33.",
             "type": "send_msg"
@@ -58,10 +60,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty you were started in this flow by Bob from the 'Parent Flow' flow. He is from Esmeraldas and is aged 33.",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/two_questions_test.json
+++ b/cmd/flowrunner/testdata/flows/two_questions_test.json
@@ -42,10 +42,12 @@
         {
           "action_uuid": "e97cd6d5-3354-4dbd-85bc-6c1f87849eec",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Hi Ben Haggerty! What is your favorite color? (red/blue) Your number is +12065551212",
             "type": "send_msg"
@@ -100,10 +102,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty! What is your favorite color? (red/blue) Your number is +12065551212",
                     "type": "send_msg"
@@ -164,10 +168,12 @@
         {
           "action_uuid": "d2a4052a-3fa9-4608-ab3e-5b9631440447",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Blue! Bien sur! Quelle est votes soda preferee? (pepsi/coke)",
             "type": "send_msg"
@@ -230,10 +236,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty! What is your favorite color? (red/blue) Your number is +12065551212",
                     "type": "send_msg"
@@ -282,10 +290,12 @@
                     "value": "fra"
                   },
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Blue! Bien sur! Quelle est votes soda preferee? (pepsi/coke)",
                     "type": "send_msg"
@@ -357,10 +367,12 @@
         {
           "action_uuid": "0a8467eb-911a-41db-8101-ccf415c48e6a",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "Parfait, vous avez finis et tu aimes Coke",
             "type": "send_msg"
@@ -415,10 +427,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Hi Ben Haggerty! What is your favorite color? (red/blue) Your number is +12065551212",
                     "type": "send_msg"
@@ -467,10 +481,12 @@
                     "value": "fra"
                   },
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Blue! Bien sur! Quelle est votes soda preferee? (pepsi/coke)",
                     "type": "send_msg"
@@ -522,10 +538,12 @@
                     "url": "http://127.0.0.1:49999/?cmd=success"
                   },
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "Parfait, vous avez finis et tu aimes Coke",
                     "type": "send_msg"

--- a/cmd/flowrunner/testdata/flows/webhook_persists_test.json
+++ b/cmd/flowrunner/testdata/flows/webhook_persists_test.json
@@ -25,10 +25,12 @@
         {
           "action_uuid": "59cee8f1-ed9e-453e-bc17-6f1996e959d0",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "This is the first message.",
             "type": "send_msg"
@@ -51,10 +53,12 @@
         {
           "action_uuid": "8453e418-03ec-40a0-935f-d757cd2ab075",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "The status is true. Send something",
             "type": "send_msg"
@@ -108,10 +112,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is the first message.",
                     "type": "send_msg"
@@ -144,10 +150,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "The status is true. Send something",
                     "type": "send_msg"
@@ -202,10 +210,12 @@
         {
           "action_uuid": "09cd20fb-9a8a-49a2-9c98-fac728c35300",
           "event": {
-            "contact": {
-              "name": "Ben Haggerty",
-              "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-            },
+            "contacts": [
+              {
+                "name": "Ben Haggerty",
+                "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+              }
+            ],
             "created_on": "2000-01-01T00:00:00.000000000-00:00",
             "text": "The status is now true",
             "type": "send_msg"
@@ -260,10 +270,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "This is the first message.",
                     "type": "send_msg"
@@ -296,10 +308,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "The status is true. Send something",
                     "type": "send_msg"
@@ -342,10 +356,12 @@
                 "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
                 "events": [
                   {
-                    "contact": {
-                      "name": "Ben Haggerty",
-                      "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
-                    },
+                    "contacts": [
+                      {
+                        "name": "Ben Haggerty",
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                      }
+                    ],
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "text": "The status is now true",
                     "type": "send_msg"

--- a/flows/actions/reply.go
+++ b/flows/actions/reply.go
@@ -41,12 +41,11 @@ func (a *ReplyAction) Execute(run flows.FlowRun, step flows.Step, log flows.Even
 	evaluatedText, evaluatedAttachments := a.evaluateMessage(run, step, log)
 
 	urns := run.Contact().URNs()
+
 	if a.AllURNs && len(urns) > 0 {
-		for _, urn := range urns {
-			log.Add(events.NewSendMsgToURN(urn, evaluatedText, evaluatedAttachments))
-		}
+		log.Add(events.NewSendMsgEvent(evaluatedText, evaluatedAttachments, urns, nil, nil))
 	} else {
-		log.Add(events.NewSendMsgToContact(run.Contact().Reference(), evaluatedText, evaluatedAttachments))
+		log.Add(events.NewSendMsgToContactEvent(evaluatedText, evaluatedAttachments, run.Contact().Reference()))
 	}
 
 	return nil

--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -11,7 +11,8 @@ import (
 // TypeSendEmail is our type for the email action
 const TypeSendEmail string = "send_email"
 
-// EmailAction can be used to send an email to one or more recipients. The subject, body and emails can all contain templates.
+// EmailAction can be used to send an email to one or more recipients. The subject, body and addresses
+// can all contain expressions.
 //
 // A `send_email` event will be created for each email address.
 //
@@ -19,18 +20,18 @@ const TypeSendEmail string = "send_email"
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
 //     "type": "send_email",
+//     "addresses": ["@contact.urns.email"],
 //     "subject": "Here is your activation token",
-//     "body": "Your activation token is @contact.fields.activation_token",
-//     "emails": ["@contact.urns.email"]
+//     "body": "Your activation token is @contact.fields.activation_token"
 //   }
 // ```
 //
 // @action send_email
 type EmailAction struct {
 	BaseAction
-	Emails  []string `json:"emails"   validate:"required,min=1"`
-	Subject string   `json:"subject"  validate:"required"`
-	Body    string   `json:"body"     validate:"required"`
+	Addresses []string `json:"addresses" validate:"required,min=1"`
+	Subject   string   `json:"subject" validate:"required"`
+	Body      string   `json:"body" validate:"required"`
 }
 
 // Type returns the type of this action
@@ -43,30 +44,41 @@ func (a *EmailAction) Validate(assets flows.SessionAssets) error {
 
 // Execute creates the email events
 func (a *EmailAction) Execute(run flows.FlowRun, step flows.Step, log flows.EventLog) error {
-	for _, email := range a.Emails {
-		email, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), email)
-		if err != nil {
-			log.Add(events.NewErrorEvent(err))
-		}
-		if email == "" {
-			log.Add(events.NewErrorEvent(fmt.Errorf("send_email email evaluated to empty string, skipping")))
-			continue
-		}
-
-		subject, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), a.Subject)
-		if err != nil {
-			log.Add(events.NewErrorEvent(err))
-		}
-		if subject == "" {
-			log.Add(events.NewErrorEvent(fmt.Errorf("send_email subject evaluated to empty string, skipping")))
-			continue
-		}
-
-		body, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), a.Body)
-		if err != nil {
-			log.Add(events.NewErrorEvent(err))
-		}
-		log.Add(events.NewSendEmailEvent(email, subject, body))
+	subject, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), a.Subject)
+	if err != nil {
+		log.Add(events.NewErrorEvent(err))
 	}
+	if subject == "" {
+		log.Add(events.NewErrorEvent(fmt.Errorf("send_email subject evaluated to empty string, skipping")))
+		return nil
+	}
+
+	body, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), a.Body)
+	if err != nil {
+		log.Add(events.NewErrorEvent(err))
+	}
+	if body == "" {
+		log.Add(events.NewErrorEvent(fmt.Errorf("send_email body evaluated to empty string, skipping")))
+		return nil
+	}
+
+	evaluatedAddresses := make([]string, 0)
+
+	for _, address := range a.Addresses {
+		evaluatedAddress, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), address)
+		if err != nil {
+			log.Add(events.NewErrorEvent(err))
+		}
+		if evaluatedAddress == "" {
+			log.Add(events.NewErrorEvent(fmt.Errorf("send_email address evaluated to empty string, skipping")))
+			continue
+		}
+		evaluatedAddresses = append(evaluatedAddresses, evaluatedAddress)
+	}
+
+	if len(evaluatedAddresses) > 0 {
+		log.Add(events.NewSendEmailEvent(evaluatedAddresses, subject, body))
+	}
+
 	return nil
 }

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -44,17 +44,7 @@ func (a *SendMsgAction) Validate(assets flows.SessionAssets) error {
 func (a *SendMsgAction) Execute(run flows.FlowRun, step flows.Step, log flows.EventLog) error {
 	evaluatedText, evaluatedAttachments := a.evaluateMessage(run, step, log)
 
-	// create events for each URN
-	for _, urn := range a.URNs {
-		log.Add(events.NewSendMsgToURN(urn, evaluatedText, evaluatedAttachments))
-	}
+	log.Add(events.NewSendMsgEvent(evaluatedText, evaluatedAttachments, a.URNs, a.Contacts, a.Groups))
 
-	for _, contact := range a.Contacts {
-		log.Add(events.NewSendMsgToContact(contact, evaluatedText, evaluatedAttachments))
-	}
-
-	for _, group := range a.Groups {
-		log.Add(events.NewSendMsgToGroup(group, evaluatedText, evaluatedAttachments))
-	}
 	return nil
 }

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -364,7 +364,7 @@ func createAction(baseLanguage utils.Language, a legacyAction, translations *flo
 		return &actions.EmailAction{
 			Subject:    migratedSubject,
 			Body:       migratedBody,
-			Emails:     migratedEmails,
+			Addresses:  migratedEmails,
 			BaseAction: actions.NewBaseAction(a.UUID),
 		}, nil
 

--- a/flows/definition/testdata/migrations/actions.json
+++ b/flows/definition/testdata/migrations/actions.json
@@ -102,7 +102,7 @@
         "expected_action": {
             "type": "send_email",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
-            "emails": ["bob@nyaruka.com", "@contact.fields.supervisor"],
+            "addresses": ["bob@nyaruka.com", "@contact.fields.supervisor"],
             "subject": "Subject @run.input",
             "body": "Body @run.input"
         },

--- a/flows/events/send_email.go
+++ b/flows/events/send_email.go
@@ -11,7 +11,7 @@ const TypeSendEmail string = "send_email"
 //   {
 //     "type": "send_email",
 //     "created_on": "2006-01-02T15:04:05Z",
-//     "email": "foo@bar.com",
+//     "addresses": ["foo@bar.com"],
 //     "subject": "Your activation token",
 //     "body": "Your activation token is AAFFKKEE"
 //   }
@@ -20,18 +20,18 @@ const TypeSendEmail string = "send_email"
 // @event send_email
 type SendEmailEvent struct {
 	BaseEvent
-	Email   string `json:"email"   validate:"required"`
-	Subject string `json:"subject" validate:"required"`
-	Body    string `json:"body"`
+	Addresses []string `json:"addresses" validate:"required,min=1"`
+	Subject   string   `json:"subject" validate:"required"`
+	Body      string   `json:"body"`
 }
 
 // NewSendEmailEvent returns a new email event with the passed in subject, body and emails
-func NewSendEmailEvent(email string, subject string, body string) *SendEmailEvent {
+func NewSendEmailEvent(addresses []string, subject string, body string) *SendEmailEvent {
 	return &SendEmailEvent{
 		BaseEvent: NewBaseEvent(),
+		Addresses: addresses,
 		Subject:   subject,
 		Body:      body,
-		Email:     email,
 	}
 }
 

--- a/flows/events/send_msg.go
+++ b/flows/events/send_msg.go
@@ -8,45 +8,50 @@ import (
 // TypeSendMsg is a constant for incoming messages
 const TypeSendMsg string = "send_msg"
 
-// SendMsgEvent events are created for each outgoing message. They represent an MT message to a
-// contact, urn or group.
+// SendMsgEvent events are created for outgoing messages.
 //
 // ```
 //   {
 //     "type": "send_msg",
 //     "created_on": "2006-01-02T15:04:05Z",
-//     "urn": "tel:+12065551212",
-//     "contact_uuid": "0e06f977-cbb7-475f-9d0b-a0c4aaec7f6a",
 //     "text": "hi, what's up",
-//     "attachments": []
+//     "attachments": [],
+//     "urns": ["tel:+12065551212"],
+//     "contacts": [{"uuid": "0e06f977-cbb7-475f-9d0b-a0c4aaec7f6a", "name": "Bob"}]
 //   }
 // ```
 //
 // @event send_msg
 type SendMsgEvent struct {
 	BaseEvent
-	URN         urns.URN                `json:"urn,omitempty" validate:"omitempty,urn"`
-	Contact     *flows.ContactReference `json:"contact,omitempty"`
-	Group       *flows.GroupReference   `json:"group,omitempty"`
-	Text        string                  `json:"text"                      validate:"required"`
-	Attachments []string                `json:"attachments,omitempty"`
+	Text        string                    `json:"text"`
+	Attachments []string                  `json:"attachments,omitempty"`
+	URNs        []urns.URN                `json:"urns,omitempty" validate:"dive,urn"`
+	Contacts    []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
+	Groups      []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
 }
 
-// NewSendMsgToContact creates a new outgoing msg event for the passed in channel, contact and string
-func NewSendMsgToContact(contact *flows.ContactReference, text string, attachments []string) *SendMsgEvent {
-	event := SendMsgEvent{BaseEvent: NewBaseEvent(), Contact: contact, Text: text, Attachments: attachments}
+// NewSendMsgToContactEvent creates a new outgoing msg event to a single contact
+func NewSendMsgToContactEvent(text string, attachments []string, contact *flows.ContactReference) *SendMsgEvent {
+	event := SendMsgEvent{
+		BaseEvent:   NewBaseEvent(),
+		Text:        text,
+		Attachments: attachments,
+		Contacts:    []*flows.ContactReference{contact},
+	}
 	return &event
 }
 
-// NewSendMsgToURN creates a new outgoing msg event for the passed in channel, urn and string
-func NewSendMsgToURN(urn urns.URN, text string, attachments []string) *SendMsgEvent {
-	event := SendMsgEvent{BaseEvent: NewBaseEvent(), URN: urn, Text: text, Attachments: attachments}
-	return &event
-}
-
-// NewSendMsgToGroup creates a new outgoing msg event for the passed in channel, group and string
-func NewSendMsgToGroup(group *flows.GroupReference, text string, attachments []string) *SendMsgEvent {
-	event := SendMsgEvent{BaseEvent: NewBaseEvent(), Group: group, Text: text, Attachments: attachments}
+// NewSendMsgEvent creates a new outgoing msg event for the given recipients
+func NewSendMsgEvent(text string, attachments []string, urns []urns.URN, contacts []*flows.ContactReference, groups []*flows.GroupReference) *SendMsgEvent {
+	event := SendMsgEvent{
+		BaseEvent:   NewBaseEvent(),
+		Text:        text,
+		Attachments: attachments,
+		URNs:        urns,
+		Contacts:    contacts,
+		Groups:      groups,
+	}
 	return &event
 }
 


### PR DESCRIPTION
Changes how `send_email` and `send_msg` actions work so they generate a single event with multiple recipients. This is consistent with `start_session` and makes it easier for the caller to handle these as broadcasts.