### PR TITLE
Migrating VariableContactActions

### DIFF
--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -3,10 +3,10 @@ package actions
 import (
 	"fmt"
 
-	"github.com/nyaruka/goflow/flows/events"
-
+	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/events"
 )
 
 type eventLog struct {
@@ -139,30 +139,22 @@ func (a *BaseAction) resolveLabels(run flows.FlowRun, step flows.Step, reference
 	return labels, nil
 }
 
-// BaseMsgAction is our base action for message that generate message events
-type BaseMsgAction struct {
-	BaseAction
+// MsgAction is our mixin for an action that generates message events
+type MsgAction struct {
 	Text        string   `json:"text"`
 	Attachments []string `json:"attachments"`
 }
 
-func NewBaseMsgAction(uuid flows.ActionUUID, text string, attachments []string) BaseMsgAction {
-	return BaseMsgAction{
-		BaseAction:  BaseAction{UUID_: uuid},
-		Text:        text,
-		Attachments: attachments,
-	}
-}
-
-func (a *BaseMsgAction) evaluateMessage(run flows.FlowRun, step flows.Step, log flows.EventLog) (string, []string) {
-
-	localizedText := run.GetText(flows.UUID(a.UUID()), "text", a.Text)
+func (a *MsgAction) evaluateMessage(b *BaseAction, run flows.FlowRun, step flows.Step, log flows.EventLog) (string, []string) {
+	// localize and evaluate the message text
+	localizedText := run.GetText(flows.UUID(b.UUID()), "text", a.Text)
 	evaluatedText, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), localizedText)
 	if err != nil {
 		log.Add(events.NewErrorEvent(err))
 	}
 
-	translatedAttachments := run.GetTextArray(flows.UUID(a.UUID()), "attachments", a.Attachments)
+	// localize and evaluate the message attachments
+	translatedAttachments := run.GetTextArray(flows.UUID(b.UUID()), "attachments", a.Attachments)
 	evaluatedAttachments := make([]string, 0, len(a.Attachments))
 	for n := range translatedAttachments {
 		evaluatedAttachment, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), translatedAttachments[n])
@@ -176,4 +168,64 @@ func (a *BaseMsgAction) evaluateMessage(run flows.FlowRun, step flows.Step, log 
 	}
 
 	return evaluatedText, evaluatedAttachments
+}
+
+// ContactsAndGroupsAction is our mixin for an action that operates on other contacts and groups
+type ContactsAndGroupsAction struct {
+	URNs       []urns.URN                `json:"urns,omitempty"`
+	Contacts   []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
+	Groups     []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
+	LegacyVars []string                  `json:"legacy_vars,omitempty"`
+}
+
+func (a *ContactsAndGroupsAction) resolveContactsAndGroups(b *BaseAction, run flows.FlowRun, step flows.Step, log flows.EventLog) ([]urns.URN, []*flows.ContactReference, []*flows.GroupReference, error) {
+	// copy URNs
+	urnList := make([]urns.URN, 0, len(a.URNs))
+	for _, urn := range a.URNs {
+		urnList = append(urnList, urn)
+	}
+
+	// copy contact references
+	contactRefs := make([]*flows.ContactReference, 0, len(a.Contacts))
+	for _, contactRef := range a.Contacts {
+		contactRefs = append(contactRefs, contactRef)
+	}
+
+	// resolve group references
+	groups, err := b.resolveGroups(run, step, a.Groups, log)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	groupRefs := make([]*flows.GroupReference, 0, len(groups))
+	for _, group := range groups {
+		groupRefs = append(groupRefs, group.Reference())
+	}
+
+	// get the list of all groups
+	groupSet, err := run.Session().Assets().GetGroupSet()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// evaluate the legacy variables
+	for _, legacyVar := range a.LegacyVars {
+		evaluatedLegacyVar, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), legacyVar)
+		if err != nil {
+			log.Add(events.NewErrorEvent(err))
+		}
+
+		if uuidRegex.MatchString(evaluatedLegacyVar) {
+			// if variable evaluates to a UUID, we assume it's a contact UUID
+			contactRefs = append(contactRefs, flows.NewContactReference(flows.ContactUUID(evaluatedLegacyVar), ""))
+
+		} else if groupByName := groupSet.FindByName(evaluatedLegacyVar); groupByName != nil {
+			// next up we look for a group with a matching name
+			groupRefs = append(groupRefs, groupByName.Reference())
+		} else {
+			// if that fails, assume this is a phone number, and let the caller worry about validation
+			urnList = append(urnList, urns.NewURNFromParts(urns.TelScheme, evaluatedLegacyVar, ""))
+		}
+	}
+
+	return urnList, contactRefs, groupRefs, nil
 }

--- a/flows/actions/reply.go
+++ b/flows/actions/reply.go
@@ -24,7 +24,8 @@ const TypeReply string = "reply"
 //
 // @action reply
 type ReplyAction struct {
-	BaseMsgAction
+	BaseAction
+	MsgAction
 	AllURNs bool `json:"all_urns,omitempty"`
 }
 
@@ -38,7 +39,7 @@ func (a *ReplyAction) Validate(assets flows.SessionAssets) error {
 
 // Execute runs this action
 func (a *ReplyAction) Execute(run flows.FlowRun, step flows.Step, log flows.EventLog) error {
-	evaluatedText, evaluatedAttachments := a.evaluateMessage(run, step, log)
+	evaluatedText, evaluatedAttachments := a.evaluateMessage(&a.BaseAction, run, step, log)
 
 	urns := run.Contact().URNs()
 

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -381,8 +381,39 @@ func createAction(baseLanguage utils.Language, a legacyAction, translations *flo
 		}, nil
 	case "flow":
 		return &actions.StartFlowAction{
-			Flow:       a.Flow.Migrate(),
 			BaseAction: actions.NewBaseAction(a.UUID),
+			Flow:       a.Flow.Migrate(),
+		}, nil
+	case "trigger-flow":
+		contacts := make([]*flows.ContactReference, len(a.Contacts))
+		for i, contact := range a.Contacts {
+			contacts[i] = contact.Migrate()
+		}
+		groups := make([]*flows.GroupReference, len(a.Groups))
+		for i, group := range a.Groups {
+			groups[i] = group.Migrate()
+		}
+		var emptyContact bool
+		variables := make([]string, 0, len(a.Variables))
+		for _, variable := range a.Variables {
+			if variable.ID == "@new_contact" {
+				emptyContact = true
+			} else {
+				migratedVar, _ := excellent.MigrateTemplate(variable.ID)
+				variables = append(variables, migratedVar)
+			}
+		}
+
+		return &actions.StartSessionAction{
+			BaseAction: actions.NewBaseAction(a.UUID),
+			Flow:       a.Flow.Migrate(),
+			ContactsAndGroupsAction: actions.ContactsAndGroupsAction{
+				URNs:       []urns.URN{},
+				Contacts:   contacts,
+				Groups:     groups,
+				LegacyVars: variables,
+			},
+			EmptyContact: emptyContact,
 		}, nil
 	case "reply", "send":
 		msg := make(map[utils.Language]string)
@@ -413,8 +444,12 @@ func createAction(baseLanguage utils.Language, a legacyAction, translations *flo
 
 		if a.Type == "reply" {
 			return &actions.ReplyAction{
-				BaseMsgAction: actions.NewBaseMsgAction(a.UUID, migratedText, attachments),
-				AllURNs:       a.SendAll,
+				BaseAction: actions.NewBaseAction(a.UUID),
+				MsgAction: actions.MsgAction{
+					Text:        migratedText,
+					Attachments: attachments,
+				},
+				AllURNs: a.SendAll,
 			}, nil
 		}
 
@@ -426,12 +461,24 @@ func createAction(baseLanguage utils.Language, a legacyAction, translations *flo
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}
+		variables := make([]string, 0, len(a.Variables))
+		for _, variable := range a.Variables {
+			migratedVar, _ := excellent.MigrateTemplate(variable.ID)
+			variables = append(variables, migratedVar)
+		}
 
 		return &actions.SendMsgAction{
-			BaseMsgAction: actions.NewBaseMsgAction(a.UUID, migratedText, attachments),
-			URNs:          []urns.URN{},
-			Contacts:      contacts,
-			Groups:        groups,
+			BaseAction: actions.NewBaseAction(a.UUID),
+			MsgAction: actions.MsgAction{
+				Text:        migratedText,
+				Attachments: attachments,
+			},
+			ContactsAndGroupsAction: actions.ContactsAndGroupsAction{
+				URNs:       []urns.URN{},
+				Contacts:   contacts,
+				Groups:     groups,
+				LegacyVars: variables,
+			},
 		}, nil
 
 	case "add_group":

--- a/flows/definition/testdata/migrations/actions.json
+++ b/flows/definition/testdata/migrations/actions.json
@@ -256,6 +256,10 @@
             "groups": [
                 {"uuid": "1a8c1313-4126-41ad-80ac-f9a2d0b708ec", "name": "Testers"},
                 {"uuid": "c746a9c9-8b31-49d2-aa55-a515d2c02968", "name": "Spammers"}
+            ],
+            "legacy_vars": [
+                "@contact.fields.support_group",
+                "+12223334444"
             ]
         },
         "expected_localization": {
@@ -277,6 +281,64 @@
             "type": "start_flow",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "flow": {"uuid": "879ace1b-740b-45f1-9198-c2f2f08a825f", "name": "Registration"}
+        },
+        "expected_localization": {}
+    },
+    {
+        "legacy_action": {
+            "type": "trigger-flow",
+            "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
+            "flow": {"uuid": "879ace1b-740b-45f1-9198-c2f2f08a825f", "name": "Registration"},
+            "variables": [
+                {"id": "+12223334444"}
+            ]
+        },
+        "expected_action": {
+            "type": "start_session",
+            "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
+            "legacy_vars": [
+                "+12223334444"
+            ],
+            "flow": {"uuid": "879ace1b-740b-45f1-9198-c2f2f08a825f", "name": "Registration"}
+        },
+        "expected_localization": {}
+    },
+    {
+        "legacy_action": {
+            "type": "trigger-flow",
+            "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
+            "flow": {"uuid": "879ace1b-740b-45f1-9198-c2f2f08a825f", "name": "Registration"},
+            "contacts": [
+                {"uuid": "879ace1b-740b-45f1-9198-c2f2f08a825f"},
+                {"uuid": "cd0d8605-5abc-428c-b34b-c6f6e7a3ef42"}
+            ],
+            "groups": [
+                {"uuid": "1a8c1313-4126-41ad-80ac-f9a2d0b708ec", "name": "Testers"},
+                {"uuid": "c746a9c9-8b31-49d2-aa55-a515d2c02968", "name": "Spammers"}
+            ],
+            "variables": [
+                {"id": "@contact.support_group"},
+                {"id": "+12223334444"},
+                {"id": "@new_contact"}
+            ]
+        },
+        "expected_action": {
+            "type": "start_session",
+            "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
+            "contacts": [
+                {"uuid": "879ace1b-740b-45f1-9198-c2f2f08a825f", "name": ""},
+                {"uuid": "cd0d8605-5abc-428c-b34b-c6f6e7a3ef42", "name": ""}
+            ],
+            "groups": [
+                {"uuid": "1a8c1313-4126-41ad-80ac-f9a2d0b708ec", "name": "Testers"},
+                {"uuid": "c746a9c9-8b31-49d2-aa55-a515d2c02968", "name": "Spammers"}
+            ],
+            "legacy_vars": [
+                "@contact.fields.support_group",
+                "+12223334444"
+            ],
+            "flow": {"uuid": "879ace1b-740b-45f1-9198-c2f2f08a825f", "name": "Registration"},
+            "empty_contact": true
         },
         "expected_localization": {}
     }

--- a/flows/events/session_triggered.go
+++ b/flows/events/session_triggered.go
@@ -3,6 +3,7 @@ package events
 import (
 	"encoding/json"
 
+	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -42,20 +43,24 @@ const TypeSessionTriggered string = "session_triggered"
 // @event session_triggered
 type SessionTriggeredEvent struct {
 	BaseEvent
-	Flow     *flows.FlowReference      `json:"flow" validate:"required"`
-	Contacts []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
-	Groups   []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
-	Run      json.RawMessage           `json:"run"`
+	Flow         *flows.FlowReference      `json:"flow" validate:"required"`
+	URNs         []urns.URN                `json:"urns,omitempty" validate:"dive,urn"`
+	Contacts     []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
+	Groups       []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
+	EmptyContact bool                      `json:"empty_contact,omitempty"`
+	Run          json.RawMessage           `json:"run"`
 }
 
 // NewSessionTriggeredEvent returns a new session triggered event
-func NewSessionTriggeredEvent(flow *flows.FlowReference, contacts []*flows.ContactReference, groups []*flows.GroupReference, runSnapshot json.RawMessage) *SessionTriggeredEvent {
+func NewSessionTriggeredEvent(flow *flows.FlowReference, urns []urns.URN, contacts []*flows.ContactReference, groups []*flows.GroupReference, emptyContact bool, runSnapshot json.RawMessage) *SessionTriggeredEvent {
 	return &SessionTriggeredEvent{
-		BaseEvent: NewBaseEvent(),
-		Flow:      flow,
-		Contacts:  contacts,
-		Groups:    groups,
-		Run:       runSnapshot,
+		BaseEvent:    NewBaseEvent(),
+		Flow:         flow,
+		URNs:         urns,
+		Contacts:     contacts,
+		Groups:       groups,
+		EmptyContact: emptyContact,
+		Run:          runSnapshot,
 	}
 }
 

--- a/flows/references.go
+++ b/flows/references.go
@@ -93,18 +93,26 @@ func NewVariableLabelReference(nameMatch string) *LabelReference {
 // Validation
 //------------------------------------------------------------------------------------------
 
+// GroupReferenceValidation validates that the given group reference is either a concrete
+// reference or a name matcher
 func GroupReferenceValidation(sl validator.StructLevel) {
 	ref := sl.Current().Interface().(GroupReference)
-	if len(ref.UUID) != 0 && len(ref.NameMatch) != 0 {
-		sl.ReportError(ref.UUID, "UUID", "uuid", "uuidornamematch", "")
-		sl.ReportError(ref.NameMatch, "NameMatch", "name_match", "uuidornamematch", "")
+	if !xor(string(ref.UUID), ref.NameMatch) {
+		sl.ReportError(ref.UUID, "UUID", "uuid", "mutually_exclusive", "name_match")
+		sl.ReportError(ref.NameMatch, "NameMatch", "name_match", "mutually_exclusive", "uuid")
 	}
 }
 
+// LabelReferenceValidation validates that the given label reference is either a concrete
+// reference or a name matcher
 func LabelReferenceValidation(sl validator.StructLevel) {
 	ref := sl.Current().Interface().(LabelReference)
-	if len(ref.UUID) != 0 && len(ref.NameMatch) != 0 {
-		sl.ReportError(ref.UUID, "UUID", "uuid", "uuidornamematch", "")
-		sl.ReportError(ref.NameMatch, "NameMatch", "name_match", "uuidornamematch", "")
+	if !xor(string(ref.UUID), ref.NameMatch) {
+		sl.ReportError(ref.UUID, "UUID", "uuid", "mutually_exclusive", "name_match")
+		sl.ReportError(ref.NameMatch, "NameMatch", "name_match", "mutually_exclusive", "uuid")
 	}
+}
+
+func xor(s1 string, s2 string) bool {
+	return (len(s1) > 0) != (len(s2) > 0)
 }

--- a/flows/references_test.go
+++ b/flows/references_test.go
@@ -1,0 +1,43 @@
+package flows
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+import "github.com/nyaruka/goflow/utils"
+
+func TestReferenceValidation(t *testing.T) {
+	// channel references must always be concrete
+	assert.NoError(t, utils.Validate(&ChannelReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Nexmo"}))
+	assert.EqualError(t, utils.Validate(&ChannelReference{Name: "Nexmo"}), "field 'uuid' is required")
+
+	// contact references must always be concrete
+	assert.NoError(t, utils.Validate(&ContactReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Bob"}))
+	assert.EqualError(t, utils.Validate(&ContactReference{Name: "Bob"}), "field 'uuid' is required")
+
+	// group references can be concrete or a name match template
+	assert.NoError(t, utils.Validate(&GroupReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Testers"}))
+	assert.NoError(t, utils.Validate(&GroupReference{NameMatch: "@contact.fields.district"}))
+
+	// but they can't be neither or both of those things
+	assert.EqualError(t,
+		utils.Validate(&GroupReference{}),
+		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
+	)
+	assert.EqualError(t,
+		utils.Validate(&GroupReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Bob", NameMatch: "@contact.fields.district"}),
+		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
+	)
+
+	// label references can be concrete or a name match template
+	assert.NoError(t, utils.Validate(&LabelReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Spam"}))
+	assert.NoError(t, utils.Validate(&LabelReference{NameMatch: "@contact.fields.district"}))
+
+	// but they can't be neither or both of those things
+	assert.EqualError(t,
+		utils.Validate(&LabelReference{}),
+		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
+	)
+	assert.EqualError(t,
+		utils.Validate(&LabelReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Spam", NameMatch: "@contact.fields.district"}),
+		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
+	)
+}

--- a/utils/validator.go
+++ b/utils/validator.go
@@ -84,6 +84,8 @@ func validate(obj interface{}, objName string) error {
 			problem = fmt.Sprintf("must have a minimum of %s items", fieldErr.Param())
 		case "max":
 			problem = fmt.Sprintf("must have a maximum of %s items", fieldErr.Param())
+		case "mutually_exclusive":
+			problem = fmt.Sprintf("is mutually exclusive with '%s'", fieldErr.Param())
 		default:
 			problem = fmt.Sprintf("failed tag '%s'", fieldErr.Tag())
 		}


### PR DESCRIPTION
- Rework send_msg and start_session actions so they support legacy expressions as a workaround for now
- Infer types (group name vs contact UUID) at action execution time
- Improve error messages on reference types