### PR TITLE
Fix quick replies when language translations are missing

### DIFF
--- a/flows/definition/legacy_test.go
+++ b/flows/definition/legacy_test.go
@@ -304,9 +304,11 @@ func TestTranslations(t *testing.T) {
 	translations := []map[utils.Language]string{
 		{"eng": "Yes", "fra": "Oui"},
 		{"eng": "No", "fra": "Non"},
+		{"eng": "Maybe"},
+		{"eng": "Never", "fra": "Jamas"},
 	}
 	assert.Equal(t, map[utils.Language][]string{
-		"eng": {"Yes", "No"},
-		"fra": {"Oui", "Non"},
+		"eng": {"Yes", "No", "Maybe", "Never"},
+		"fra": {"Oui", "Non", "", "Jamas"},
 	}, transformTranslations(translations))
 }

--- a/flows/definition/testdata/migrations/actions.json
+++ b/flows/definition/testdata/migrations/actions.json
@@ -155,7 +155,8 @@
             }, 
             "quick_replies": [
                 {"eng": "Yes", "fra": "Oui"},
-                {"eng": "No", "fra": "Non"}
+                {"eng": "No", "fra": "Non"},
+                {"eng": "Maybe"}
             ],
             "send_all": true
         },
@@ -164,7 +165,7 @@
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352", 
             "text": "Do you still live in @contact.fields.city?", 
             "attachments": ["image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=@contact.fields.age"],
-            "quick_replies": ["Yes", "No"],
+            "quick_replies": ["Yes", "No", "Maybe"],
             "all_urns": true
         },
         "expected_localization": {
@@ -172,7 +173,7 @@
                 "5a4d00aa-807e-44af-9693-64b9fdedd352": {
                     "attachments": ["image/jpeg:http://s3.amazon.com/bucket/test_fr.jpg?a=@contact.fields.age"],
                     "text": ["Vous habitez toujours à @contact.fields.city"],
-                    "quick_replies": ["Oui", "Non"]
+                    "quick_replies": ["Oui", "Non", ""]
                 }
             }
         }

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -270,9 +270,19 @@ func (r *flowRun) GetTextArray(uuid flows.UUID, key string, native []string) []s
 		translations := r.Flow().Translations().GetLanguageTranslations(lang)
 		if translations != nil {
 			textArray := translations.GetTextArray(uuid, key)
-			if textArray != nil && len(textArray) == len(native) {
-				return textArray
+			if textArray == nil {
+				return native
 			}
+
+			merged := make([]string, len(native))
+			for s := range native {
+				if textArray[s] != "" {
+					merged[s] = textArray[s]
+				} else {
+					merged[s] = native[s]
+				}
+			}
+			return merged
 		}
 	}
 	return native


### PR DESCRIPTION
It's possible to have some replies not translated (e.g. `[{"eng": "Yes", "fra": "Oui"}, {"eng": "No"}]`) in which case we need to merge the translated replies we do have with the native ones.