### PR TITLE
Tweaks to match RapidPro

### DIFF
--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/nyaruka/goflow/excellent"
@@ -53,6 +54,9 @@ func (a *EmailAction) Execute(run flows.FlowRun, step flows.Step, log flows.Even
 		log.Add(events.NewErrorEvent(fmt.Errorf("send_email subject evaluated to empty string, skipping")))
 		return nil
 	}
+
+	// make sure the subject is single line - replace '\t\n\r\f\v' to ' '
+	subject = regexp.MustCompile(`\s+`).ReplaceAllString(subject, " ")
 
 	body, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), a.Body, false)
 	if err != nil {

--- a/flows/actions/update_contact.go
+++ b/flows/actions/update_contact.go
@@ -27,7 +27,7 @@ const TypeUpdateContact string = "update_contact"
 type UpdateContactAction struct {
 	BaseAction
 	FieldName string `json:"field_name"    validate:"required,eq=name|eq=language"`
-	Value     string `json:"value"         validate:"required"`
+	Value     string `json:"value"`
 }
 
 // Type returns the type of this action
@@ -35,8 +35,8 @@ func (a *UpdateContactAction) Type() string { return TypeUpdateContact }
 
 // Validate validates our action is valid and has all the assets it needs
 func (a *UpdateContactAction) Validate(assets flows.SessionAssets) error {
-	// check language is valid
-	if a.FieldName == "language" {
+	// check language is valid if specified
+	if a.FieldName == "language" && a.Value != "" {
 		if _, err := utils.ParseLanguage(a.Value); err != nil {
 			return err
 		}

--- a/flows/actions/update_contact.go
+++ b/flows/actions/update_contact.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
+	"strings"
 )
 
 // TypeUpdateContact is the type for our update contact action
@@ -53,6 +54,7 @@ func (a *UpdateContactAction) Execute(run flows.FlowRun, step flows.Step, log fl
 	// get our localized value if any
 	template := run.GetText(flows.UUID(a.UUID()), "value", a.Value)
 	value, err := excellent.EvaluateTemplateAsString(run.Environment(), run.Context(), template, false)
+	value = strings.TrimSpace(value)
 
 	// if we received an error, log it
 	if err != nil {

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -548,6 +548,7 @@ func migrateAction(baseLanguage utils.Language, a legacyAction, translations *fl
 		if a.Field == "name" || a.Field == "first_name" {
 			// we can emulate setting only the first name with an expression
 			if a.Field == "first_name" {
+				migratedValue = strings.TrimSpace(migratedValue)
 				migratedValue = fmt.Sprintf("%s @(word_slice(contact.name, 2, -1))", migratedValue)
 			}
 
@@ -562,6 +563,12 @@ func migrateAction(baseLanguage utils.Language, a legacyAction, translations *fl
 		if urns.IsValidScheme(a.Field) {
 			return &actions.AddURNAction{
 				Scheme:     a.Field,
+				Path:       migratedValue,
+				BaseAction: actions.NewBaseAction(a.UUID),
+			}, nil
+		} else if a.Field == "tel_e164" {
+			return &actions.AddURNAction{
+				Scheme:     "tel",
 				Path:       migratedValue,
 				BaseAction: actions.NewBaseAction(a.UUID),
 			}, nil

--- a/flows/events/update_contact.go
+++ b/flows/events/update_contact.go
@@ -44,12 +44,15 @@ func (e *UpdateContactEvent) Apply(run flows.FlowRun) error {
 	if e.FieldName == "name" {
 		run.Contact().SetName(e.Value)
 	} else {
-		lang, err := utils.ParseLanguage(e.Value)
-		if err != nil {
-			return err
+		if e.Value != "" {
+			lang, err := utils.ParseLanguage(e.Value)
+			if err != nil {
+				return err
+			}
+			run.Contact().SetLanguage(lang)
+		} else {
+			run.Contact().SetLanguage(utils.NilLanguage)
 		}
-
-		run.Contact().SetLanguage(lang)
 	}
 
 	return run.Contact().UpdateDynamicGroups(run.Session())


### PR DESCRIPTION
* Allow blank values in update_contact actions (e.g. clear language)
* Migrate old save action with field=tel_e164 to a new add_urn action
* Remove new lines from email subjects
* Some extra whitespace trimming