### PR TITLE
Legacy expression migration fixes

### DIFF
--- a/excellent/legacy.go
+++ b/excellent/legacy.go
@@ -64,6 +64,16 @@ func (v varMapper) Resolve(key string) interface{} {
 	// is it a fixed base item?
 	value, ok := v.baseVars[key]
 	if ok {
+		asVarMapper, isVarMapper := value.(varMapper)
+		if isVarMapper {
+			return &varMapper{
+				base:             fmt.Sprintf("%s.%s", strings.Join(newPath, "."), asVarMapper.base),
+				baseVars:         asVarMapper.baseVars,
+				arbitraryNesting: asVarMapper.arbitraryNesting,
+				arbitraryVars:    asVarMapper.arbitraryVars,
+			}
+		}
+
 		newPath = append(newPath, value.(string))
 		return strings.Join(newPath, ".")
 	}
@@ -172,13 +182,21 @@ func newRootVarMapper() vars {
 			},
 		},
 		"parent": varMapper{
-			base: "parent.results",
+			base: "parent",
+			baseVars: map[string]interface{}{
+				"contact": contact,
+			},
+			arbitraryNesting: "results",
 			arbitraryVars: map[string]interface{}{
 				"category": "category_localized",
 			},
 		},
 		"child": varMapper{
-			base: "child.results",
+			base: "child",
+			baseVars: map[string]interface{}{
+				"contact": contact,
+			},
+			arbitraryNesting: "results",
 			arbitraryVars: map[string]interface{}{
 				"category": "category_localized",
 			},

--- a/excellent/legacy_test.go
+++ b/excellent/legacy_test.go
@@ -9,22 +9,27 @@ type testTemplate struct {
 	new string
 }
 
-// TestThis
 func TestTranslate(t *testing.T) {
 	var tests = []testTemplate{
 
 		// contact variables
 		{old: "@contact", new: "@contact"},
-		{old: "@contact.first_name", new: "@contact.first_name"},
+		{old: "@contact.uuid", new: "@contact.uuid"},
 		{old: "@contact.name", new: "@contact.name"},
+		{old: "@contact.first_name", new: "@contact.first_name"},
+		{old: "@contact.blerg", new: "@contact.fields.blerg"},
+
+		// contact URN variables
 		{old: "@contact.tel", new: "@(format_urn(contact.urns.tel))"},
+		{old: "@contact.tel.display", new: "@(format_urn(contact.urns.tel))"},
+		{old: "@contact.tel.scheme", new: "@contact.urns.tel.0.scheme"},
+		{old: "@contact.tel.path", new: "@contact.urns.tel.0.path"},
+		{old: "@contact.tel.urn", new: "@contact.urns.tel.0"},
 		{old: "@contact.tel_e164", new: "@contact.urns.tel.0.path"},
 		{old: "@contact.telegram", new: "@(format_urn(contact.urns.telegram))"},
 		{old: "@contact.twitter", new: "@(format_urn(contact.urns.twitter))"},
 		{old: "@contact.facebook", new: "@(format_urn(contact.urns.facebook))"},
 		{old: "@contact.mailto", new: "@(format_urn(contact.urns.mailto))"},
-		{old: "@contact.uuid", new: "@contact.uuid"},
-		{old: "@contact.blerg", new: "@contact.fields.blerg"},
 
 		// run variables
 		{old: "@flow.blerg", new: "@run.results.blerg"},
@@ -48,11 +53,11 @@ func TestTranslate(t *testing.T) {
 		{old: "@step.contact.age", new: "@contact.fields.age"},
 
 		// dates
+		{old: "@date", new: "@(now())"},
 		{old: "@date.now", new: "@(now())"},
 		{old: "@date.today", new: "@(today())"},
 		{old: "@date.tomorrow", new: "@(tomorrow())"},
 		{old: "@date.yesterday", new: "@(yesterday())"},
-		{old: "@date", new: "@(now())"},
 
 		// variables in parens
 		{old: "@(contact.tel)", new: "@(format_urn(contact.urns.tel))"},

--- a/excellent/legacy_test.go
+++ b/excellent/legacy_test.go
@@ -13,7 +13,7 @@ type testTemplate struct {
 func TestTranslate(t *testing.T) {
 	var tests = []testTemplate{
 
-		// variables
+		// contact variables
 		{old: "@contact", new: "@contact"},
 		{old: "@contact.first_name", new: "@contact.first_name"},
 		{old: "@contact.name", new: "@contact.name"},
@@ -25,10 +25,19 @@ func TestTranslate(t *testing.T) {
 		{old: "@contact.mailto", new: "@(format_urn(contact.urns.mailto))"},
 		{old: "@contact.uuid", new: "@contact.uuid"},
 		{old: "@contact.blerg", new: "@contact.fields.blerg"},
-		{old: "@child.blerg", new: "@child.results.blerg"},
-		{old: "@parent.blerg", new: "@parent.results.blerg"},
+
+		// run variables
 		{old: "@flow.blerg", new: "@run.results.blerg"},
 		{old: "@flow.blerg.category", new: "@run.results.blerg.category_localized"},
+		{old: "@child.blerg", new: "@child.results.blerg"},
+		{old: "@child.contact", new: "@child.contact"},
+		{old: "@child.contact.age", new: "@child.contact.fields.age"},
+		{old: "@parent.blerg", new: "@parent.results.blerg"},
+		{old: "@parent.blerg.category", new: "@parent.results.blerg.category_localized"},
+		{old: "@parent.contact", new: "@parent.contact"},
+		{old: "@parent.contact.name", new: "@parent.contact.name"},
+
+		// input
 		{old: "@step", new: "@run.input"},
 		{old: "@step.value", new: "@run.input"},
 		{old: "@step.text", new: "@run.input.text"},
@@ -37,6 +46,8 @@ func TestTranslate(t *testing.T) {
 		{old: "@step.contact", new: "@contact"},
 		{old: "@step.contact.name", new: "@contact.name"},
 		{old: "@step.contact.age", new: "@contact.fields.age"},
+
+		// dates
 		{old: "@date.now", new: "@(now())"},
 		{old: "@date.today", new: "@(today())"},
 		{old: "@date.tomorrow", new: "@(tomorrow())"},


### PR DESCRIPTION
* Properly migrate `@parent.contact.*` and `@child.contact.*`
* Add support for URN subitems, e.g. `@contact.tel.path`