### PR TITLE
Add support for URNs with channels as query params

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -232,7 +232,7 @@ func main() {
 		scanner.Scan()
 
 		// create our event to resume with
-		msg := inputs.NewMsgInput(flows.InputUUID(utils.NewUUID()), nil, time.Now(), contact.URNs()[0], scanner.Text(), []flows.Attachment{})
+		msg := inputs.NewMsgInput(flows.InputUUID(utils.NewUUID()), nil, time.Now(), contact.URNs()[0].URN, scanner.Text(), []flows.Attachment{})
 		event := events.NewMsgReceivedEvent(msg)
 		event.SetFromCaller(true)
 		callerEvents = append(callerEvents, []flows.Event{event})

--- a/cmd/flowserver/static/start.json
+++ b/cmd/flowserver/static/start.json
@@ -37,7 +37,7 @@
             "timezone": "America/Guayaquil",
             "urns": [
                 "tel:+12065551212",
-                "facebook:macklemore"
+                "facebook:5637322626267272"
             ]
         },
         "flow": {

--- a/flows/actions/reply.go
+++ b/flows/actions/reply.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -43,10 +44,15 @@ func (a *ReplyAction) Validate(assets flows.SessionAssets) error {
 func (a *ReplyAction) Execute(run flows.FlowRun, step flows.Step, log flows.EventLog) error {
 	evaluatedText, evaluatedAttachments, evaluatedQuickReplies := a.evaluateMessage(run, step, a.Text, a.Attachments, a.QuickReplies, log)
 
-	urns := run.Contact().URNs()
+	contactURNs := run.Contact().URNs()
 
-	if a.AllURNs && len(urns) > 0 {
-		log.Add(events.NewBroadcastCreatedEvent(evaluatedText, evaluatedAttachments, evaluatedQuickReplies, urns, nil, nil))
+	if a.AllURNs && len(contactURNs) > 0 {
+		urnObjs := make([]urns.URN, len(contactURNs))
+		for u := range contactURNs {
+			urnObjs[u] = contactURNs[u].URN
+		}
+
+		log.Add(events.NewBroadcastCreatedEvent(evaluatedText, evaluatedAttachments, evaluatedQuickReplies, urnObjs, nil, nil))
 	} else {
 		log.Add(events.NewMsgCreatedEvent(evaluatedText, evaluatedAttachments, evaluatedQuickReplies, run.Contact().Reference()))
 	}

--- a/flows/actions/reply.go
+++ b/flows/actions/reply.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -47,12 +46,7 @@ func (a *ReplyAction) Execute(run flows.FlowRun, step flows.Step, log flows.Even
 	contactURNs := run.Contact().URNs()
 
 	if a.AllURNs && len(contactURNs) > 0 {
-		urnObjs := make([]urns.URN, len(contactURNs))
-		for u := range contactURNs {
-			urnObjs[u] = contactURNs[u].URN
-		}
-
-		log.Add(events.NewBroadcastCreatedEvent(evaluatedText, evaluatedAttachments, evaluatedQuickReplies, urnObjs, nil, nil))
+		log.Add(events.NewBroadcastCreatedEvent(evaluatedText, evaluatedAttachments, evaluatedQuickReplies, contactURNs.RawURNs(false), nil, nil))
 	} else {
 		log.Add(events.NewMsgCreatedEvent(evaluatedText, evaluatedAttachments, evaluatedQuickReplies, run.Contact().Reference()))
 	}

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -31,18 +31,12 @@ func (c *channel) Reference() *ChannelReference { return NewChannelReference(c.u
 // Resolve satisfies our resolver interface
 func (c *channel) Resolve(key string) interface{} {
 	switch key {
-
 	case "uuid":
 		return c.uuid
-
 	case "name":
 		return c.name
-
 	case "address":
 		return c.address
-
-	case "type":
-		return c.channelType
 	}
 
 	return fmt.Errorf("No field '%s' on channel", key)

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -200,7 +200,7 @@ type contactEnvelope struct {
 	Name     string                          `json:"name"`
 	Language utils.Language                  `json:"language"`
 	Timezone string                          `json:"timezone"`
-	URNs     []urns.URN                      `json:"urns"`
+	URNs     []urns.URN                      `json:"urns" validate:"dive,urn"`
 	Groups   []*GroupReference               `json:"groups,omitempty" validate:"dive"`
 	Fields   map[FieldKey]fieldValueEnvelope `json:"fields,omitempty"`
 	Channel  *ChannelReference               `json:"channel,omitempty" validate:"omitempty,dive"`

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -280,7 +280,7 @@ func (c *Contact) MarshalJSON() ([]byte, error) {
 	ce.Name = c.name
 	ce.UUID = c.uuid
 	ce.Language = c.language
-	ce.URNs = c.urns.RawURNs()
+	ce.URNs = c.urns.RawURNs(true)
 	if c.timezone != nil {
 		ce.Timezone = c.timezone.String()
 	}

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -77,7 +77,7 @@ func (c *Contact) URNs() URNList { return c.urns }
 func (c *Contact) AddURN(urn urns.URN) {
 	// TODO normalize and check we're not adding duplicates
 
-	c.urns = append(c.urns, urn)
+	c.urns = append(c.urns, &ContactURN{URN: urn})
 }
 
 // Groups returns the groups that this contact belongs to
@@ -169,7 +169,7 @@ func (c *Contact) ResolveQueryKey(key string) []interface{} {
 		urnsWithScheme := c.urns.WithScheme(key)
 		vals := make([]interface{}, len(urnsWithScheme))
 		for u := range urnsWithScheme {
-			vals[u] = string(urnsWithScheme[u])
+			vals[u] = string(urnsWithScheme[u].URN)
 		}
 		return vals
 	}
@@ -200,7 +200,7 @@ type contactEnvelope struct {
 	Name     string                          `json:"name"`
 	Language utils.Language                  `json:"language"`
 	Timezone string                          `json:"timezone"`
-	URNs     URNList                         `json:"urns"`
+	URNs     []urns.URN                      `json:"urns"`
 	Groups   []*GroupReference               `json:"groups,omitempty" validate:"dive"`
 	Fields   map[FieldKey]fieldValueEnvelope `json:"fields,omitempty"`
 	Channel  *ChannelReference               `json:"channel,omitempty" validate:"omitempty,dive"`
@@ -228,7 +228,9 @@ func ReadContact(session Session, data json.RawMessage) (*Contact, error) {
 	if envelope.URNs == nil {
 		c.urns = make(URNList, 0)
 	} else {
-		c.urns = envelope.URNs
+		if c.urns, err = ReadURNList(session, envelope.URNs); err != nil {
+			return nil, err
+		}
 	}
 
 	if envelope.Groups == nil {
@@ -278,7 +280,7 @@ func (c *Contact) MarshalJSON() ([]byte, error) {
 	ce.Name = c.name
 	ce.UUID = c.uuid
 	ce.Language = c.language
-	ce.URNs = c.urns
+	ce.URNs = c.urns.RawURNs()
 	if c.timezone != nil {
 		ce.Timezone = c.timezone.String()
 	}

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -32,7 +32,15 @@ func TestEvaluateTemplate(t *testing.T) {
 		{"@contact.urns", "tel:+12065551212", false}, // TODO should be list
 		{"@contact.urns.tel", "tel:+12065551212", false},
 		{"@contact.urns.0", "tel:+12065551212", false},
+		{"@contact.urns.0.scheme", "tel", false},
+		{"@contact.urns.0.path", "+12065551212", false},
+		{"@contact.urns.0.display", "", false},
+		{"@contact.urns.0.channel", "Nexmo", false},
+		{"@contact.urns.0.channel.uuid", "57f1078f-88aa-46f4-a59a-948a5739c03d", false},
+		{"@contact.urns.0.channel.name", "Nexmo", false},
+		{"@contact.urns.0.channel.address", "+12345671111", false},
 		{"@contact.urns.1", "facebook:1122334455667788", false},
+		{"@contact.urns.1.channel", "", false},
 		{"@(format_urn(contact.urns.0))", "(206) 555-1212", false},
 		{"@contact.groups", "Survey Audience", false}, // TODO should be list
 		{"@contact.fields.state", "Azuay", false},
@@ -90,6 +98,6 @@ func TestEvaluateTemplate(t *testing.T) {
 			assert.False(t, test.hasError, "Did not receive error evaluating '%s'", test.template)
 		}
 
-		assert.Equal(t, eval, test.expected, "Actual '%s' does not match expected '%s' evaluating template: '%s'", eval, test.expected, test.template)
+		assert.Equal(t, test.expected, eval, "Actual '%s' does not match expected '%s' evaluating template: '%s'", eval, test.expected, test.template)
 	}
 }

--- a/flows/engine/testdata/trigger.json
+++ b/flows/engine/testdata/trigger.json
@@ -40,7 +40,7 @@
                 {"uuid": "d7ff4872-9238-452f-9d38-2f558fea89e0", "name": "Azuay State"}
             ],
             "urns": [
-                "tel:+12065551212",
+                "tel:+12065551212?channel=57f1078f-88aa-46f4-a59a-948a5739c03d",
                 "facebook:1122334455667788",
                 "mailto:ben@macklemore"
             ]

--- a/flows/urns.go
+++ b/flows/urns.go
@@ -87,12 +87,12 @@ func ReadURNList(session Session, rawURNs []urns.URN) (URNList, error) {
 	return l, nil
 }
 
-func (l URNList) RawURNs() []urns.URN {
+func (l URNList) RawURNs(includeChannels bool) []urns.URN {
 	raw := make([]urns.URN, len(l))
 	for u := range l {
 		scheme, path, query, display := l[u].URN.ToParts()
 
-		if l[u].channel != nil {
+		if includeChannels && l[u].channel != nil {
 			query = fmt.Sprintf("channel=%s", l[u].channel.UUID())
 		}
 

--- a/flows/urns_test.go
+++ b/flows/urns_test.go
@@ -1,26 +1,30 @@
-package flows
+package flows_test
 
 import (
 	"testing"
 
-	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestResolve(t *testing.T) {
-	urnList := URNList{"tel:+250781234567", "twitter:134252511151#billy_bob", "tel:+250781111222"}
+	urnList := flows.URNList{
+		&flows.ContactURN{URN: "tel:+250781234567"},
+		&flows.ContactURN{URN: "twitter:134252511151#billy_bob"},
+		&flows.ContactURN{URN: "tel:+250781111222"},
+	}
 
 	testCases := []struct {
 		key      string
 		hasValue bool
 		value    interface{}
 	}{
-		{"0", true, urns.URN("tel:+250781234567")},
-		{"1", true, urns.URN("twitter:134252511151#billy_bob")},
-		{"2", true, urns.URN("tel:+250781111222")},
-		{"3", false, ""}, // index out of range
-		{"tel", true, URNList{"tel:+250781234567", "tel:+250781111222"}},
-		{"twitter", true, URNList{"twitter:134252511151#billy_bob"}},
+		{"0", true, &flows.ContactURN{URN: "tel:+250781234567"}},
+		{"1", true, &flows.ContactURN{URN: "twitter:134252511151#billy_bob"}},
+		{"2", true, &flows.ContactURN{URN: "tel:+250781111222"}},
+		{"3", false, nil}, // index out of range
+		{"tel", true, flows.URNList{&flows.ContactURN{URN: "tel:+250781234567"}, &flows.ContactURN{URN: "tel:+250781111222"}}},
+		{"twitter", true, flows.URNList{&flows.ContactURN{URN: "twitter:134252511151#billy_bob"}}},
 		{"xxxxxx", false, ""}, // not a valid scheme
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Introduces a `ContactURN` as a wrapper for URNs on a contact so we can extract their channel like https://github.com/nyaruka/goflow/compare/new_urns?expand=1#diff-488bb6c851b01295dc4960583fb229d8R38