### PR TITLE
Log actions and events when debug logging is enabled

### DIFF
--- a/cmd/flowserver/main.go
+++ b/cmd/flowserver/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/go-chi/chi/middleware"
 	"github.com/pressly/lg"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	_ "github.com/nyaruka/goflow/cmd/flowserver/statik"
 	"github.com/nyaruka/goflow/utils"
@@ -34,25 +34,24 @@ func main() {
 		config.Version = version
 	}
 
-	level, err := logrus.ParseLevel(config.LogLevel)
+	level, err := log.ParseLevel(config.LogLevel)
 	if err != nil {
-		logrus.Fatalf("Invalid log level '%s'", level)
+		log.Fatalf("Invalid log level '%s'", level)
 	}
 
-	logger := logrus.New()
-	logger.SetLevel(level)
+	log.SetLevel(level)
 
-	lg.RedirectStdlogOutput(logger)
-	lg.DefaultLogger = logger
+	lg.RedirectStdlogOutput(log.StandardLogger())
+	lg.DefaultLogger = log.StandardLogger()
 
-	flowServer := NewFlowServer(config, logger)
+	flowServer := NewFlowServer(config)
 	flowServer.Start()
 
-	logger.WithField("comp", "server").WithField("port", config.Port).WithField("version", version).Info("listening")
+	log.WithField("comp", "server").WithField("port", config.Port).WithField("version", version).Info("listening")
 
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	logrus.WithField("comp", "server").WithField("signal", <-ch).Info("stopping")
+	log.WithField("comp", "server").WithField("signal", <-ch).Info("stopping")
 
 	flowServer.Stop()
 }
@@ -132,7 +131,7 @@ func templateHandler(fs http.FileSystem, handler templateHandlerFunc) http.Handl
 	}
 }
 
-func traceErrors(logger *logrus.Logger) func(next http.Handler) http.Handler {
+func traceErrors() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			body := bytes.Buffer{}
@@ -142,7 +141,7 @@ func traceErrors(logger *logrus.Logger) func(next http.Handler) http.Handler {
 
 			// we are returning an error of some kind, log the incoming request body
 			if ww.Status() != 200 && strings.ToLower(r.Method) == "post" {
-				logger.WithFields(logrus.Fields{
+				log.WithFields(log.Fields{
 					"request_body": body.String(),
 					"status":       ww.Status(),
 					"req_id":       r.Context().Value(middleware.RequestIDKey)}).Error()

--- a/cmd/flowserver/server_test.go
+++ b/cmd/flowserver/server_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -186,7 +185,7 @@ type ServerTestSuite struct {
 func (ts *ServerTestSuite) SetupSuite() {
 	ts.assetServer = engine.NewMockAssetServer()
 
-	ts.flowServer = NewFlowServer(NewDefaultConfig(), logrus.New())
+	ts.flowServer = NewFlowServer(NewDefaultConfig())
 	ts.flowServer.Start()
 
 	// wait for server to come up

--- a/flows/actions/add_urn.go
+++ b/flows/actions/add_urn.go
@@ -59,7 +59,7 @@ func (a *AddURNAction) Execute(run flows.FlowRun, step flows.Step, log flows.Eve
 	// if we don't have a valid URN, log error
 	urn, err := urns.NewURNFromParts(a.Scheme, evaluatedPath, "", "")
 	if err != nil {
-		log.Add(events.NewErrorEvent(fmt.Errorf("invalid URN '%s': %s", string(urn), err.Error())))
+		log.Add(events.NewErrorEvent(fmt.Errorf("unable to add URN '%s:%s': %s", a.Scheme, evaluatedPath, err.Error())))
 		return nil
 	}
 	urn = urn.Normalize("")

--- a/flows/definition/legacy.go
+++ b/flows/definition/legacy.go
@@ -893,7 +893,7 @@ func migrateRuleSet(lang utils.Language, r legacyRuleSet, translations *flowTran
 	case "random":
 		node.router = routers.NewRandomRouter(resultName)
 	default:
-		fmt.Printf("Unable to migrate unrecognized ruleset type: '%s'\n", r.Type)
+		return nil, fmt.Errorf("unrecognized ruleset type: %s", r.Type)
 	}
 
 	node.exits = exits

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -10,11 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/karlseguin/ccache"
-
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/definition"
 	"github.com/nyaruka/goflow/utils"
+
+	"github.com/karlseguin/ccache"
+	log "github.com/sirupsen/logrus"
 )
 
 type assetType string
@@ -173,7 +174,7 @@ func (s *assetServer) getItemAssetURL(itemType assetType, uuid string) (string, 
 
 // fetches an asset by its URL and parses it as the provided type
 func (s *assetServer) fetchAsset(url string, itemType assetType, isSet bool, userAgent string) (interface{}, error) {
-	request, err := http.NewRequest("GET", string(url), nil)
+	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -189,6 +190,10 @@ func (s *assetServer) fetchAsset(url string, itemType assetType, isSet bool, use
 	}
 
 	defer response.Body.Close()
+
+	if log.GetLevel() >= log.DebugLevel {
+		log.WithField("asset_type", string(itemType)).WithField("url", url).Debugf("asset requested")
+	}
 
 	if response.StatusCode != 200 {
 		return nil, fmt.Errorf("asset request returned non-200 response")

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -191,12 +191,10 @@ func (s *assetServer) fetchAsset(url string, itemType assetType, isSet bool, use
 
 	defer response.Body.Close()
 
-	if log.GetLevel() >= log.DebugLevel {
-		log.WithField("asset_type", string(itemType)).WithField("url", url).Debugf("asset requested")
-	}
+	log.WithField("asset_type", string(itemType)).WithField("url", url).Debugf("asset requested")
 
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("asset request returned non-200 response")
+		return nil, fmt.Errorf("asset request returned non-200 response (%d)", response.StatusCode)
 	}
 
 	if response.Header.Get("Content-Type") != "application/json" {

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nyaruka/goflow/flows/triggers"
 	"github.com/nyaruka/goflow/flows/waits"
 	"github.com/nyaruka/goflow/utils"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // used to spawn a new run or sub-flow in the event loop
@@ -331,14 +333,20 @@ func (s *session) visitNode(run flows.FlowRun, node flows.Node, callerEvents []f
 	// execute our node's actions
 	if node.Actions() != nil {
 		for _, action := range node.Actions() {
-			log := actions.NewEventLog()
+			eventLog := actions.NewEventLog()
 
-			if err := action.Execute(run, step, log); err != nil {
+			if err := action.Execute(run, step, eventLog); err != nil {
 				return nil, noDestination, err
 			}
 
+			if log.GetLevel() >= log.DebugLevel {
+				actionEnvelope, _ := utils.EnvelopeFromTyped(action)
+				actionJSON, _ := json.Marshal(actionEnvelope)
+				log.WithField("action_type", action.Type()).WithField("payload", string(actionJSON)).WithField("run", run.UUID()).Debug("action executed")
+			}
+
 			// apply any events that the action generated
-			for _, event := range log.Events() {
+			for _, event := range eventLog.Events() {
 				if err := run.ApplyEvent(step, action, event); err != nil {
 					return nil, noDestination, err
 				}

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -199,7 +199,7 @@ func (r *flowRun) ApplyEvent(s flows.Step, action flows.Action, event flows.Even
 		}
 		eventEnvelope, _ := utils.EnvelopeFromTyped(event)
 		eventJSON, _ := json.Marshal(eventEnvelope)
-		log.WithField("code", event.Type()).WithField("run", r.UUID()).WithField("data", string(eventJSON)).Debugf("%s event applied", origin)
+		log.WithField("event_type", event.Type()).WithField("payload", string(eventJSON)).WithField("run", r.UUID()).Debugf("%s event applied", origin)
 	}
 
 	return nil

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -10,6 +10,8 @@ import (
 	"github.com/nyaruka/goflow/flows/inputs"
 	"github.com/nyaruka/goflow/flows/triggers"
 	"github.com/nyaruka/goflow/utils"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // a run specific environment which allows values to be overridden by the contact
@@ -188,9 +190,17 @@ func (r *flowRun) ApplyEvent(s flows.Step, action flows.Action, event flows.Even
 		r.Session().LogEvent(s, action, event)
 	}
 
-	// eventEnvelope, _ := utils.EnvelopeFromTyped(event)
-	// eventJSON, _ := json.Marshal(eventEnvelope)
-	// fmt.Printf("⚡︎ in run %s: %s\n", r.UUID(), string(eventJSON))
+	if log.GetLevel() >= log.DebugLevel {
+		var origin string
+		if event.FromCaller() {
+			origin = "caller"
+		} else {
+			origin = "engine"
+		}
+		eventEnvelope, _ := utils.EnvelopeFromTyped(event)
+		eventJSON, _ := json.Marshal(eventEnvelope)
+		log.WithField("code", event.Type()).WithField("run", r.UUID()).WithField("data", string(eventJSON)).Debugf("%s event applied", origin)
+	}
 
 	return nil
 }


### PR DESCRIPTION
It's super useful to see the actions and events being applied in the engine.

```
DEBU[0011] caller event applied                          code=msg_received data="{\"type\":\"msg_received\",\"created_on\":\"2018-03-12T14:28:04.526231364Z\",\"msg\":{\"uuid\":\"0fcff8f9-d549-4b03-9edc-a43ec1087cd3\",\"urn\":\"tel:+12065550100\",\"channel\":{\"uuid\":\"03123351-3e00-4268-b8d7-89f916e86afc\",\"name\":\"Test Channel\"},\"text\":\"Trey Anastasio\"}}" run=9a1c091d-75f9-467b-b11d-405cbc8cc4cc
```