### PR TITLE
Rename field_name to property on SetContactProperty action and fix word(..)

### DIFF
--- a/cmd/flowrunner/testdata/flows/all_actions.json
+++ b/cmd/flowrunner/testdata/flows/all_actions.json
@@ -155,7 +155,7 @@
                         {
                             "uuid": "f3581032-e122-45ee-8be7-4f3c955d97f8",
                             "type": "set_contact_property",
-                            "field_name": "language",
+                            "property": "language",
                             "value": "eng"
                         },
                         {

--- a/cmd/flowrunner/testdata/flows/brochure.json
+++ b/cmd/flowrunner/testdata/flows/brochure.json
@@ -67,7 +67,7 @@
                         {
                             "uuid": "455ba297-f6d2-45e6-bf3e-c1ef028b55ae",
                             "type": "set_contact_property",
-                            "field_name": "name",
+                            "property": "name",
                             "value": "@run.input.text"
                         },
                         {

--- a/cmd/flowrunner/testdata/flows/default_result.json
+++ b/cmd/flowrunner/testdata/flows/default_result.json
@@ -48,7 +48,7 @@
                         {
                             "type": "set_contact_property",
                             "uuid": "aafb505c-603d-4025-864d-471345ed236d",
-                            "field_name": "name",
+                            "property": "name",
                             "value": "@run.results.contact_name"
                         },
                         {
@@ -58,7 +58,7 @@
                                 "key": "first_name",
                                 "label": "First Name"
                             },
-                            "value": "@(WORD(run.results.contact_name, 1))"
+                            "value": "@(WORD(run.results.contact_name, 0))"
                         },
                         {
                             "type": "send_msg",

--- a/cmd/flowrunner/testdata/flows/two_questions.json
+++ b/cmd/flowrunner/testdata/flows/two_questions.json
@@ -137,7 +137,7 @@
                         {
                             "uuid": "afd5ac22-2a86-4576-a2c7-715f0bb10194",
                             "type": "set_contact_property",
-                            "field_name": "language",
+                            "property": "language",
                             "value": "fra"
                         },
                         {

--- a/docs/index.html
+++ b/docs/index.html
@@ -620,10 +620,10 @@
 <a class="sourceLine" id="cb40-3" data-line-number="3">@(title(<span class="dv">123</span>)) -&gt; <span class="st">&quot;123&quot;</span></a></code></pre></div>
 <p><a name="functions:word"></a></p>
 <h2 id="wordstring-offset">word(string, offset)</h2>
-<p>word returns the word at the passed in <code>offset</code> for the passed in <code>string</code>, 1 indexed</p>
-<div class="sourceCode" id="cb41"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb41-1" data-line-number="1">@(word(<span class="st">&quot;foo bar&quot;</span>, <span class="dv">1</span>)) -&gt; <span class="st">&quot;foo&quot;</span></a>
-<a class="sourceLine" id="cb41-2" data-line-number="2">@(word(<span class="st">&quot;foo.bar&quot;</span>, <span class="dv">1</span>)) -&gt; <span class="st">&quot;foo&quot;</span></a>
-<a class="sourceLine" id="cb41-3" data-line-number="3">@(word(<span class="st">&quot;one two.three&quot;</span>, <span class="dv">3</span>)) -&gt; <span class="st">&quot;three&quot;</span></a></code></pre></div>
+<p>word returns the word at the passed in <code>offset</code> for the passed in <code>string</code></p>
+<div class="sourceCode" id="cb41"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb41-1" data-line-number="1">@(word(<span class="st">&quot;foo bar&quot;</span>, <span class="dv">0</span>)) -&gt; <span class="st">&quot;foo&quot;</span></a>
+<a class="sourceLine" id="cb41-2" data-line-number="2">@(word(<span class="st">&quot;foo.bar&quot;</span>, <span class="dv">0</span>)) -&gt; <span class="st">&quot;foo&quot;</span></a>
+<a class="sourceLine" id="cb41-3" data-line-number="3">@(word(<span class="st">&quot;one two.three&quot;</span>, <span class="dv">2</span>)) -&gt; <span class="st">&quot;three&quot;</span></a></code></pre></div>
 <p><a name="functions:remove_first_word"></a></p>
 <h2 id="remove_first_wordstring">remove_first_word(string)</h2>
 <p>remove_first_word removes the 1st word of <code>string</code></p>
@@ -1084,8 +1084,8 @@ Event
 </h3>
 <div class="sourceCode" id="cb98"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb98-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb98-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;contact_groups_added&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb98-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:15.36133846Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb98-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;5936a32e-9dac-479d-b3bc-c0c2849b9f15&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb98-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:37.405414422Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb98-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;583b06c3-ee19-4b79-bdc4-de178da6f24a&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb98-5" data-line-number="5">    <span class="dt">&quot;groups&quot;</span><span class="fu">:</span> <span class="ot">[</span></a>
 <a class="sourceLine" id="cb98-6" data-line-number="6">        <span class="fu">{</span></a>
 <a class="sourceLine" id="cb98-7" data-line-number="7">            <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;1e1ce1e1-9288-4504-869e-022d1003c72a&quot;</span><span class="fu">,</span></a>
@@ -1115,15 +1115,15 @@ Event
 <div class="sourceCode" id="cb100"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb100-1" data-line-number="1"><span class="ot">[</span></a>
 <a class="sourceLine" id="cb100-2" data-line-number="2">    <span class="fu">{</span></a>
 <a class="sourceLine" id="cb100-3" data-line-number="3">        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;error&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb100-4" data-line-number="4">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:15.361755762Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb100-5" data-line-number="5">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;ba56b4f1-8f0b-4fc5-9f6e-97f75f0764ac&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb100-4" data-line-number="4">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:37.405828975Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb100-5" data-line-number="5">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;74b55798-a395-4ceb-aa4b-a8d94aac231f&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb100-6" data-line-number="6">        <span class="dt">&quot;text&quot;</span><span class="fu">:</span> <span class="st">&quot;no field &#39;flow&#39; on context&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb100-7" data-line-number="7">        <span class="dt">&quot;fatal&quot;</span><span class="fu">:</span> <span class="kw">false</span></a>
 <a class="sourceLine" id="cb100-8" data-line-number="8">    <span class="fu">}</span><span class="ot">,</span></a>
 <a class="sourceLine" id="cb100-9" data-line-number="9">    <span class="fu">{</span></a>
 <a class="sourceLine" id="cb100-10" data-line-number="10">        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;error&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb100-11" data-line-number="11">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:15.361761598Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb100-12" data-line-number="12">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;ba56b4f1-8f0b-4fc5-9f6e-97f75f0764ac&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb100-11" data-line-number="11">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:37.405834208Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb100-12" data-line-number="12">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;74b55798-a395-4ceb-aa4b-a8d94aac231f&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb100-13" data-line-number="13">        <span class="dt">&quot;text&quot;</span><span class="fu">:</span> <span class="st">&quot;unable to add URN &#39;tel:@flow.phone_number&#39;: The phone number supplied was empty.&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb100-14" data-line-number="14">        <span class="dt">&quot;fatal&quot;</span><span class="fu">:</span> <span class="kw">false</span></a>
 <a class="sourceLine" id="cb100-15" data-line-number="15">    <span class="fu">}</span></a>
@@ -1177,13 +1177,13 @@ Event
 </h3>
 <div class="sourceCode" id="cb104"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb104-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb104-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;webhook_called&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb104-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.077782143Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb104-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;f557d0d8-1e59-4137-bd80-317be752f567&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb104-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.133054744Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb104-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;9242d680-5029-4e7a-b835-6f1c10b02704&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb104-5" data-line-number="5">    <span class="dt">&quot;url&quot;</span><span class="fu">:</span> <span class="st">&quot;https://api.ipify.org?format=json&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb104-6" data-line-number="6">    <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;success&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb104-7" data-line-number="7">    <span class="dt">&quot;status_code&quot;</span><span class="fu">:</span> <span class="dv">200</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb104-8" data-line-number="8">    <span class="dt">&quot;request&quot;</span><span class="fu">:</span> <span class="st">&quot;GET /?format=json HTTP/1.1</span><span class="ch">\r\n</span><span class="st">Host: api.ipify.org</span><span class="ch">\r\n</span><span class="st">User-Agent: Go-http-client/1.1</span><span class="ch">\r\n</span><span class="st">Authorization: Token AAFFZZHH</span><span class="ch">\r\n</span><span class="st">Accept-Encoding: gzip</span><span class="ch">\r\n\r\n</span><span class="st">&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb104-9" data-line-number="9">    <span class="dt">&quot;response&quot;</span><span class="fu">:</span> <span class="st">&quot;HTTP/1.1 200 OK</span><span class="ch">\r\n</span><span class="st">Content-Length: 23</span><span class="ch">\r\n</span><span class="st">Connection: keep-alive</span><span class="ch">\r\n</span><span class="st">Content-Type: application/json</span><span class="ch">\r\n</span><span class="st">Date: Wed, 21 Mar 2018 16:11:16 GMT</span><span class="ch">\r\n</span><span class="st">Server: Cowboy</span><span class="ch">\r\n</span><span class="st">Vary: Origin</span><span class="ch">\r\n</span><span class="st">Via: 1.1 vegur</span><span class="ch">\r\n\r\n</span><span class="st">{</span><span class="ch">\&quot;</span><span class="st">ip</span><span class="ch">\&quot;</span><span class="st">:</span><span class="ch">\&quot;</span><span class="st">190.154.48.130</span><span class="ch">\&quot;</span><span class="st">}&quot;</span></a>
+<a class="sourceLine" id="cb104-9" data-line-number="9">    <span class="dt">&quot;response&quot;</span><span class="fu">:</span> <span class="st">&quot;HTTP/1.1 200 OK</span><span class="ch">\r\n</span><span class="st">Content-Length: 23</span><span class="ch">\r\n</span><span class="st">Connection: keep-alive</span><span class="ch">\r\n</span><span class="st">Content-Type: application/json</span><span class="ch">\r\n</span><span class="st">Date: Wed, 21 Mar 2018 20:47:38 GMT</span><span class="ch">\r\n</span><span class="st">Server: Cowboy</span><span class="ch">\r\n</span><span class="st">Vary: Origin</span><span class="ch">\r\n</span><span class="st">Via: 1.1 vegur</span><span class="ch">\r\n\r\n</span><span class="st">{</span><span class="ch">\&quot;</span><span class="st">ip</span><span class="ch">\&quot;</span><span class="st">:</span><span class="ch">\&quot;</span><span class="st">190.154.48.130</span><span class="ch">\&quot;</span><span class="st">}&quot;</span></a>
 <a class="sourceLine" id="cb104-10" data-line-number="10"><span class="fu">}</span></a></code></pre></div>
 </div>
 <p><a name="actions:remove_contact_groups"></a></p>
@@ -1210,8 +1210,8 @@ Event
 </h3>
 <div class="sourceCode" id="cb106"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb106-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb106-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;contact_groups_removed&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb106-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.07875061Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb106-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;157c152c-56f5-4fef-9486-b48e1facabf1&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb106-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.134048187Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb106-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;d825584d-e4ca-4585-a748-0a6f734cc3fb&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb106-5" data-line-number="5">    <span class="dt">&quot;groups&quot;</span><span class="fu">:</span> <span class="ot">[</span></a>
 <a class="sourceLine" id="cb106-6" data-line-number="6">        <span class="fu">{</span></a>
 <a class="sourceLine" id="cb106-7" data-line-number="7">            <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;b7cf0d83-f1c9-411c-96fd-c511a4cfa86d&quot;</span><span class="fu">,</span></a>
@@ -1244,8 +1244,8 @@ Event
 </h3>
 <div class="sourceCode" id="cb108"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb108-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb108-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;broadcast_created&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb108-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.079508264Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb108-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;f29cadcb-1bba-4e02-8333-5107470b4364&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb108-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.13483456Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb108-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;5f3f384a-5196-4a0c-ad81-c1c61dc80f45&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb108-5" data-line-number="5">    <span class="dt">&quot;translations&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
 <a class="sourceLine" id="cb108-6" data-line-number="6">        <span class="dt">&quot;&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
 <a class="sourceLine" id="cb108-7" data-line-number="7">            <span class="dt">&quot;text&quot;</span><span class="fu">:</span> <span class="st">&quot;Hi Ryan Lewis, are you ready to complete today&#39;s survey?&quot;</span></a>
@@ -1282,15 +1282,15 @@ Event
 <div class="sourceCode" id="cb110"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb110-1" data-line-number="1"><span class="ot">[</span></a>
 <a class="sourceLine" id="cb110-2" data-line-number="2">    <span class="fu">{</span></a>
 <a class="sourceLine" id="cb110-3" data-line-number="3">        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;error&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb110-4" data-line-number="4">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.080357973Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb110-5" data-line-number="5">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;03bfce89-062c-4d08-ba88-c410ffc223c4&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb110-4" data-line-number="4">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.13569856Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb110-5" data-line-number="5">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;a5089b11-47a3-4db9-bea6-b561468c0607&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb110-6" data-line-number="6">        <span class="dt">&quot;text&quot;</span><span class="fu">:</span> <span class="st">&quot;unknown URN scheme: email&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb110-7" data-line-number="7">        <span class="dt">&quot;fatal&quot;</span><span class="fu">:</span> <span class="kw">false</span></a>
 <a class="sourceLine" id="cb110-8" data-line-number="8">    <span class="fu">}</span><span class="ot">,</span></a>
 <a class="sourceLine" id="cb110-9" data-line-number="9">    <span class="fu">{</span></a>
 <a class="sourceLine" id="cb110-10" data-line-number="10">        <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;email_created&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb110-11" data-line-number="11">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.080365714Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb110-12" data-line-number="12">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;03bfce89-062c-4d08-ba88-c410ffc223c4&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb110-11" data-line-number="11">        <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.135705359Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb110-12" data-line-number="12">        <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;a5089b11-47a3-4db9-bea6-b561468c0607&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb110-13" data-line-number="13">        <span class="dt">&quot;addresses&quot;</span><span class="fu">:</span> <span class="ot">[</span></a>
 <a class="sourceLine" id="cb110-14" data-line-number="14">            <span class="st">&quot;@contact.urns.email&quot;</span></a>
 <a class="sourceLine" id="cb110-15" data-line-number="15">        <span class="ot">]</span><span class="fu">,</span></a>
@@ -1320,10 +1320,10 @@ Event
 </h3>
 <div class="sourceCode" id="cb112"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb112-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb112-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;msg_created&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb112-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.081052958Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb112-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;2d6e80fb-88c9-42df-aec8-3a7604236387&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb112-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.136306386Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb112-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;d36bc0f9-a5a3-4c89-959c-848d23025a85&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb112-5" data-line-number="5">    <span class="dt">&quot;msg&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
-<a class="sourceLine" id="cb112-6" data-line-number="6">        <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;5680d42a-6fd4-42e0-987d-bbefc347b40f&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb112-6" data-line-number="6">        <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;a15748a3-dc1b-4e6b-9a3c-3b1590a6828c&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb112-7" data-line-number="7">        <span class="dt">&quot;urn&quot;</span><span class="fu">:</span> <span class="st">&quot;tel:+12065551212&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb112-8" data-line-number="8">        <span class="dt">&quot;channel&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
 <a class="sourceLine" id="cb112-9" data-line-number="9">            <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;57f1078f-88aa-46f4-a59a-948a5739c03d&quot;</span><span class="fu">,</span></a>
@@ -1356,8 +1356,8 @@ Event
 </h3>
 <div class="sourceCode" id="cb114"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb114-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb114-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;contact_field_changed&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb114-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.081647044Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb114-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;8f0ef5e5-a951-4382-951c-762db5f5d4ed&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb114-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.136905236Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb114-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;ff618f48-4bf5-41a8-b0d4-a81a6dfd78fa&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb114-5" data-line-number="5">    <span class="dt">&quot;field&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
 <a class="sourceLine" id="cb114-6" data-line-number="6">        <span class="dt">&quot;key&quot;</span><span class="fu">:</span> <span class="st">&quot;gender&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb114-7" data-line-number="7">        <span class="dt">&quot;label&quot;</span><span class="fu">:</span> <span class="st">&quot;Gender&quot;</span></a>
@@ -1375,7 +1375,7 @@ Action
 <div class="sourceCode" id="cb115"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb115-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb115-2" data-line-number="2">  <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;set_contact_property&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb115-3" data-line-number="3">  <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;8eebd020-1af5-431c-b943-aa670fc74da9&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb115-4" data-line-number="4">  <span class="dt">&quot;field_name&quot;</span><span class="fu">:</span> <span class="st">&quot;language&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb115-4" data-line-number="4">  <span class="dt">&quot;property&quot;</span><span class="fu">:</span> <span class="st">&quot;language&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb115-5" data-line-number="5">  <span class="dt">&quot;value&quot;</span><span class="fu">:</span> <span class="st">&quot;eng&quot;</span></a>
 <a class="sourceLine" id="cb115-6" data-line-number="6"><span class="fu">}</span></a></code></pre></div>
 </div>
@@ -1385,8 +1385,8 @@ Event
 </h3>
 <div class="sourceCode" id="cb116"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb116-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb116-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;contact_property_changed&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb116-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.082192665Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb116-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;05979e53-171e-47ac-83b2-3fe8e6e7587b&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb116-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.137648818Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb116-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;26f9d949-e299-46e7-b712-8cdb1d8a7a4e&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb116-5" data-line-number="5">    <span class="dt">&quot;property&quot;</span><span class="fu">:</span> <span class="st">&quot;language&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb116-6" data-line-number="6">    <span class="dt">&quot;value&quot;</span><span class="fu">:</span> <span class="st">&quot;eng&quot;</span></a>
 <a class="sourceLine" id="cb116-7" data-line-number="7"><span class="fu">}</span></a></code></pre></div>
@@ -1413,8 +1413,8 @@ Event
 </h3>
 <div class="sourceCode" id="cb118"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb118-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb118-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;run_result_changed&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb118-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.082740727Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb118-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;b8bc02d1-d6d2-444c-9a60-c3c17d3161a9&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb118-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.138613728Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb118-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;28d50c29-a520-4f2d-bf9b-a9578c762653&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb118-5" data-line-number="5">    <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Gender&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb118-6" data-line-number="6">    <span class="dt">&quot;value&quot;</span><span class="fu">:</span> <span class="st">&quot;m&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb118-7" data-line-number="7">    <span class="dt">&quot;category&quot;</span><span class="fu">:</span> <span class="st">&quot;Male&quot;</span><span class="fu">,</span></a>
@@ -1444,13 +1444,13 @@ Event
 </h3>
 <div class="sourceCode" id="cb120"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb120-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb120-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;flow_triggered&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb120-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.083294873Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb120-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;0ebb2e4c-d3a4-49ea-b0f0-bc6bc35517e3&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb120-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.139231138Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb120-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;b472a83a-324d-485a-9118-3dec55949117&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb120-5" data-line-number="5">    <span class="dt">&quot;flow&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
 <a class="sourceLine" id="cb120-6" data-line-number="6">        <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;b7cf0d83-f1c9-411c-96fd-c511a4cfa86d&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb120-7" data-line-number="7">        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Collect Language&quot;</span></a>
 <a class="sourceLine" id="cb120-8" data-line-number="8">    <span class="fu">},</span></a>
-<a class="sourceLine" id="cb120-9" data-line-number="9">    <span class="dt">&quot;parent_run_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;1d220af0-69d2-4e57-99cd-a5e771a3c021&quot;</span></a>
+<a class="sourceLine" id="cb120-9" data-line-number="9">    <span class="dt">&quot;parent_run_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;5ef2e18e-5b79-42b1-9f88-5617612c8a04&quot;</span></a>
 <a class="sourceLine" id="cb120-10" data-line-number="10"><span class="fu">}</span></a></code></pre></div>
 </div>
 <p><a name="actions:start_session"></a></p>
@@ -1481,8 +1481,8 @@ Event
 </h3>
 <div class="sourceCode" id="cb122"><pre class="sourceCode json"><code class="sourceCode json"><a class="sourceLine" id="cb122-1" data-line-number="1"><span class="fu">{</span></a>
 <a class="sourceLine" id="cb122-2" data-line-number="2">    <span class="dt">&quot;type&quot;</span><span class="fu">:</span> <span class="st">&quot;session_triggered&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb122-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T16:11:16.08401035Z&quot;</span><span class="fu">,</span></a>
-<a class="sourceLine" id="cb122-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;a90855cb-ef64-4d61-b9da-e39b3d63d1f4&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb122-3" data-line-number="3">    <span class="dt">&quot;created_on&quot;</span><span class="fu">:</span> <span class="st">&quot;2018-03-21T20:47:38.13993173Z&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb122-4" data-line-number="4">    <span class="dt">&quot;step_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;f72aaa14-518f-4894-9b39-9c03463df981&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb122-5" data-line-number="5">    <span class="dt">&quot;flow&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
 <a class="sourceLine" id="cb122-6" data-line-number="6">        <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;b7cf0d83-f1c9-411c-96fd-c511a4cfa86d&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb122-7" data-line-number="7">        <span class="dt">&quot;name&quot;</span><span class="fu">:</span> <span class="st">&quot;Registration&quot;</span></a>
@@ -1494,7 +1494,7 @@ Event
 <a class="sourceLine" id="cb122-13" data-line-number="13">        <span class="fu">}</span></a>
 <a class="sourceLine" id="cb122-14" data-line-number="14">    <span class="ot">]</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb122-15" data-line-number="15">    <span class="dt">&quot;run&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
-<a class="sourceLine" id="cb122-16" data-line-number="16">        <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;520dc7fd-1433-461f-9349-ac1b23d7e201&quot;</span><span class="fu">,</span></a>
+<a class="sourceLine" id="cb122-16" data-line-number="16">        <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;b4014a6b-835a-4a13-8e93-65e0bdad91c9&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb122-17" data-line-number="17">        <span class="dt">&quot;flow_uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;50c3706e-fedb-42c0-8eab-dda3335714b7&quot;</span><span class="fu">,</span></a>
 <a class="sourceLine" id="cb122-18" data-line-number="18">        <span class="dt">&quot;contact&quot;</span><span class="fu">:</span> <span class="fu">{</span></a>
 <a class="sourceLine" id="cb122-19" data-line-number="19">            <span class="dt">&quot;uuid&quot;</span><span class="fu">:</span> <span class="st">&quot;5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f&quot;</span><span class="fu">,</span></a>

--- a/excellent/functions.go
+++ b/excellent/functions.go
@@ -804,11 +804,11 @@ func Title(env utils.Environment, args ...interface{}) interface{} {
 	return strings.Title(arg)
 }
 
-// Word returns the word at the passed in `offset` for the passed in `string`, 1 indexed
+// Word returns the word at the passed in `offset` for the passed in `string`
 //
-//   @(word("foo bar", 1)) -> "foo"
-//   @(word("foo.bar", 1)) -> "foo"
-//   @(word("one two.three", 3)) -> "three"
+//   @(word("foo bar", 0)) -> "foo"
+//   @(word("foo.bar", 0)) -> "foo"
+//   @(word("one two.three", 2)) -> "three"
 //
 // @function word(string, offset)
 func Word(env utils.Environment, args ...interface{}) interface{} {
@@ -827,11 +827,11 @@ func Word(env utils.Environment, args ...interface{}) interface{} {
 	}
 
 	words := utils.TokenizeString(val)
-	if word-1 >= len(words) {
+	if word >= len(words) {
 		return fmt.Errorf("Word offset %d is greater than number of words %d", word, len(words))
 	}
 
-	return words[word-1]
+	return words[word]
 }
 
 // RemoveFirstWord removes the 1st word of `string`

--- a/excellent/functions_test.go
+++ b/excellent/functions_test.go
@@ -117,12 +117,12 @@ var funcTests = []struct {
 	{"title", []interface{}{struct{}{}}, nil, true},
 	{"title", []interface{}{}, nil, true},
 
-	{"word", []interface{}{"hello World", 2}, "World", false},
-	{"word", []interface{}{"", 1}, "", true},
-	{"word", []interface{}{"😁 hello World", 1}, "😁", false},
-	{"word", []interface{}{" hello World", 3}, nil, true},
+	{"word", []interface{}{"hello World", 1}, "World", false},
+	{"word", []interface{}{"", 0}, "", true},
+	{"word", []interface{}{"😁 hello World", 0}, "😁", false},
+	{"word", []interface{}{" hello World", 2}, nil, true},
 	{"word", []interface{}{"hello World", struct{}{}}, nil, true},
-	{"word", []interface{}{struct{}{}, 3}, nil, true},
+	{"word", []interface{}{struct{}{}, 2}, nil, true},
 	{"word", []interface{}{struct{}{}}, nil, true},
 	{"word", []interface{}{}, nil, true},
 

--- a/flows/actions/set_contact_property.go
+++ b/flows/actions/set_contact_property.go
@@ -20,7 +20,7 @@ const TypeSetContactProperty string = "set_contact_property"
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
 //     "type": "set_contact_property",
-//     "field_name": "language",
+//     "property": "language",
 //     "value": "eng"
 //   }
 // ```
@@ -28,8 +28,8 @@ const TypeSetContactProperty string = "set_contact_property"
 // @action set_contact_property
 type SetContactPropertyAction struct {
 	BaseAction
-	FieldName string `json:"field_name"    validate:"required,eq=name|eq=language"`
-	Value     string `json:"value"`
+	Property string `json:"property" validate:"required,eq=name|eq=language"`
+	Value    string `json:"value"`
 }
 
 // Type returns the type of this action
@@ -38,7 +38,7 @@ func (a *SetContactPropertyAction) Type() string { return TypeSetContactProperty
 // Validate validates our action is valid and has all the assets it needs
 func (a *SetContactPropertyAction) Validate(assets flows.SessionAssets) error {
 	// check language is valid if specified
-	if a.FieldName == "language" && a.Value != "" {
+	if a.Property == "language" && a.Value != "" {
 		if _, err := utils.ParseLanguage(a.Value); err != nil {
 			return err
 		}
@@ -64,6 +64,6 @@ func (a *SetContactPropertyAction) Execute(run flows.FlowRun, step flows.Step, l
 		return nil
 	}
 
-	log.Add(events.NewContactPropertyChangedEvent(a.FieldName, value))
+	log.Add(events.NewContactPropertyChangedEvent(a.Property, value))
 	return nil
 }

--- a/legacy/definition.go
+++ b/legacy/definition.go
@@ -397,7 +397,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 
 	case "lang":
 		return &actions.SetContactPropertyAction{
-			FieldName:  "language",
+			Property:   "language",
 			Value:      string(a.Language),
 			BaseAction: actions.NewBaseAction(a.UUID),
 		}, nil
@@ -542,7 +542,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 			}
 
 			return &actions.SetContactPropertyAction{
-				FieldName:  "name",
+				Property:   "name",
 				Value:      migratedValue,
 				BaseAction: actions.NewBaseAction(a.UUID),
 			}, nil

--- a/legacy/expressions.go
+++ b/legacy/expressions.go
@@ -174,6 +174,7 @@ var functionTemplates = map[string]functionTemplate{
 	"first_word": {name: "split", params: "(%s, \" \")[0]"},
 	"datevalue":  {name: "date"},
 	"edate":      {name: "date_add", params: "(%s, \"m\", %s)"},
+	"word":       {name: "word", params: "(%s, %s - 1)"},
 	"word_slice": {name: "word_slice", params: "(%s, %s)", three: "(%s, %s, %s)", four: "(%s, %s, %s, %v)"},
 	"field":      {name: "field", params: "(%s, %s - 1, %s)"},
 	"datedif":    {name: "date_diff"},

--- a/legacy/expressions_test.go
+++ b/legacy/expressions_test.go
@@ -91,6 +91,8 @@ func TestMigrateTemplate(t *testing.T) {
 		{old: "@(FIRST_WORD(WORD_SLICE(contact.blerg, 2, 4)))", new: "@(split(word_slice(contact.fields.blerg, 2, 4), \" \")[0])"},
 		{old: "@(\"this\" & contact.that)", new: "@(\"this\" & contact.fields.that)"},
 		{old: "@(FIRST_WORD(flow.blerg))", new: "@(split(run.results.blerg, \" \")[0])"},
+		{old: "@(WORD(flow.blerg, flow.index))", new: "@(word(run.results.blerg, run.results.index - 1))"},
+		{old: "@(WORD(flow.blerg, 1))", new: "@(word(run.results.blerg, 1 - 1))"},
 		{old: "@(WORD_SLICE(flow.blerg, 2))", new: "@(word_slice(run.results.blerg, 2))"},
 		{old: "@(ABS(-5))", new: "@(abs(-5))"},
 		{old: "@(AVERAGE(1, 2, 3, 4, 5))", new: "@(mean(1, 2, 3, 4, 5))"},

--- a/legacy/testdata/migrations/actions.json
+++ b/legacy/testdata/migrations/actions.json
@@ -119,7 +119,7 @@
         "expected_action": {
             "type": "set_contact_property",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
-            "field_name": "language",
+            "property": "language",
             "value": "fra"
         },
         "expected_localization": {}
@@ -190,7 +190,7 @@
         "expected_action": {
             "type": "set_contact_property",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
-            "field_name": "name",
+            "property": "name",
             "value": "Bob @run.input"
         },
         "expected_localization": {}
@@ -206,7 +206,7 @@
         "expected_action": {
             "type": "set_contact_property",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
-            "field_name": "name",
+            "property": "name",
             "value": "@run.input @(word_slice(contact.name, 2, -1))"
         },
         "expected_localization": {}


### PR DESCRIPTION
1. Rename `field_name` to `property` on `set_contact_property` action (matches `contact_property_changed` event)
2. Fix `word(..)` function being 1-indexed unlike everything else in Excellent2

Fixes #195 

cc @ycleptkellan @ericnewcomer 