### PR TITLE
Resolving refactor part 1

### DIFF
--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -26,10 +26,6 @@ func (r *testResolvable) Resolve(key string) interface{} {
 	}
 }
 
-func (r *testResolvable) Default() interface{} {
-	return r
-}
-
 func (r *testResolvable) String() string {
 	return "hello"
 }

--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -26,9 +26,12 @@ func (r *testResolvable) Resolve(key string) interface{} {
 	}
 }
 
-func (r *testResolvable) String() string {
+func (r *testResolvable) Atomize() interface{} {
 	return "hello"
 }
+
+var _ utils.VariableAtomizer = (*testResolvable)(nil)
+var _ utils.VariableResolver = (*testResolvable)(nil)
 
 func TestEvaluateTemplateAsString(t *testing.T) {
 

--- a/excellent/tests.go
+++ b/excellent/tests.go
@@ -2,6 +2,7 @@ package excellent
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -87,14 +88,14 @@ func (t XTestResult) Resolve(key string) interface{} {
 }
 
 // String satisfies the utils.VariableResolver interface, we always default to whether we matched
-func (t XTestResult) String() string {
+func (t XTestResult) Atomize() interface{} {
 	return strconv.FormatBool(t.matched)
 }
 
 // XFalseResult can be used as a singleton for false result values
 var XFalseResult = XTestResult{}
 
-// Enforce Variable Resolver interface
+var _ utils.VariableAtomizer = XTestResult{}
 var _ utils.VariableResolver = XTestResult{}
 
 //------------------------------------------------------------------------------------------
@@ -123,7 +124,7 @@ func IsStringEQ(env utils.Environment, args ...interface{}) interface{} {
 	string1, err1 := utils.ToString(env, args[0])
 	string2, err2 := utils.ToString(env, args[1])
 	if err1 != nil || err2 != nil {
-		return fmt.Errorf("IS_STRING_EQ must be called with strings as both arguments")
+		return fmt.Errorf("IS_STRING_EQ must be called with strings as both arguments, but got '%s' and '%s'", reflect.TypeOf(args[0]), reflect.TypeOf(args[1]))
 	}
 
 	if string1 == string2 {
@@ -395,9 +396,12 @@ func (m patternMatch) Resolve(key string) interface{} {
 	return fmt.Errorf("no such key '%s' on pattern match", key)
 }
 
-func (m patternMatch) String() string {
+func (m patternMatch) Atomize() interface{} {
 	return m[0]
 }
+
+var _ utils.VariableAtomizer = patternMatch{}
+var _ utils.VariableResolver = patternMatch{}
 
 // HasPattern tests whether `string` matches the regex `pattern`
 //

--- a/excellent/tests.go
+++ b/excellent/tests.go
@@ -86,11 +86,6 @@ func (t XTestResult) Resolve(key string) interface{} {
 	return fmt.Errorf("no such key '%s' on test result", key)
 }
 
-// Default returns the value of this result when it is the result of an expression
-func (t XTestResult) Default() interface{} {
-	return t.matched
-}
-
 // String satisfies the utils.VariableResolver interface, we always default to whether we matched
 func (t XTestResult) String() string {
 	return strconv.FormatBool(t.matched)
@@ -398,11 +393,6 @@ func (m patternMatch) Resolve(key string) interface{} {
 	}
 
 	return fmt.Errorf("no such key '%s' on pattern match", key)
-}
-
-// Default returns the value of this match when it is the result of an expression
-func (m patternMatch) Default() interface{} {
-	return m[0]
 }
 
 func (m patternMatch) String() string {

--- a/flows/attachments.go
+++ b/flows/attachments.go
@@ -40,8 +40,6 @@ func (a Attachment) Resolve(key string) interface{} {
 	return fmt.Errorf("No field '%s' on attachment", key)
 }
 
-// Default returns the value of this attachment when it is the result of an expression
-func (a Attachment) Default() interface{} { return a }
-func (a Attachment) String() string       { return a.URL() }
+func (a Attachment) String() string { return a.URL() }
 
 var _ utils.VariableResolver = (Attachment)("")

--- a/flows/attachments.go
+++ b/flows/attachments.go
@@ -40,6 +40,7 @@ func (a Attachment) Resolve(key string) interface{} {
 	return fmt.Errorf("No field '%s' on attachment", key)
 }
 
-func (a Attachment) String() string { return a.URL() }
+func (a Attachment) Atomize() interface{} { return a.URL() }
 
+var _ utils.VariableAtomizer = (Attachment)("")
 var _ utils.VariableResolver = (Attachment)("")

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -90,11 +90,6 @@ func (c *channel) Resolve(key string) interface{} {
 	return fmt.Errorf("No field '%s' on channel", key)
 }
 
-// Default returns the value of this channel when it is the result of an expression
-func (c *channel) Default() interface{} {
-	return c
-}
-
 // String returns the default string value for a channel, which is its name
 func (c *channel) String() string {
 	return c.name

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -80,7 +80,7 @@ func (c *channel) HasRole(role ChannelRole) bool {
 func (c *channel) Resolve(key string) interface{} {
 	switch key {
 	case "uuid":
-		return c.uuid
+		return string(c.uuid)
 	case "name":
 		return c.name
 	case "address":
@@ -91,10 +91,11 @@ func (c *channel) Resolve(key string) interface{} {
 }
 
 // String returns the default string value for a channel, which is its name
-func (c *channel) String() string {
+func (c *channel) Atomize() interface{} {
 	return c.name
 }
 
+var _ utils.VariableAtomizer = (*channel)(nil)
 var _ utils.VariableResolver = (*channel)(nil)
 
 // ChannelSet defines the unordered set of all channels for a session

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -140,11 +140,6 @@ func (c *Contact) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on contact", key)
 }
 
-// Default returns the value of this contact when it is the result of an expression
-func (c *Contact) Default() interface{} {
-	return c
-}
-
 // String returns our string value in the context
 func (c *Contact) String() string {
 	return c.name

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -111,7 +111,7 @@ func (c *Contact) Reference() *ContactReference { return NewContactReference(c.u
 func (c *Contact) Resolve(key string) interface{} {
 	switch key {
 	case "uuid":
-		return c.uuid
+		return string(c.uuid)
 	case "name":
 		return c.name
 	case "first_name":
@@ -123,7 +123,10 @@ func (c *Contact) Resolve(key string) interface{} {
 	case "language":
 		return string(c.language)
 	case "timezone":
-		return c.timezone
+		if c.timezone != nil {
+			return c.timezone.String()
+		}
+		return nil
 	case "urns":
 		return c.urns
 	case "groups":
@@ -141,10 +144,11 @@ func (c *Contact) Resolve(key string) interface{} {
 }
 
 // String returns our string value in the context
-func (c *Contact) String() string {
+func (c *Contact) Atomize() interface{} {
 	return c.name
 }
 
+var _ utils.VariableAtomizer = (*Contact)(nil)
 var _ utils.VariableResolver = (*Contact)(nil)
 
 // SetField updates the given contact field value for this contact

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -88,7 +88,7 @@ func (f *flow) Validate(assets flows.SessionAssets) error {
 func (f *flow) Resolve(key string) interface{} {
 	switch key {
 	case "uuid":
-		return f.UUID()
+		return string(f.UUID())
 	case "name":
 		return f.Name()
 	}
@@ -97,9 +97,12 @@ func (f *flow) Resolve(key string) interface{} {
 }
 
 // String returns the default string value for this flow, which is just our name
-func (f *flow) String() string {
+func (f *flow) Atomize() interface{} {
 	return f.name
 }
+
+var _ utils.VariableAtomizer = (*flow)(nil)
+var _ utils.VariableResolver = (*flow)(nil)
 
 func (f *flow) Reference() *flows.FlowReference {
 	return flows.NewFlowReference(f.uuid, f.name)
@@ -117,8 +120,6 @@ func (f *flow) buildNodeMap() error {
 	}
 	return nil
 }
-
-var _ utils.VariableResolver = (*flow)(nil)
 
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -96,11 +96,6 @@ func (f *flow) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on flow", key)
 }
 
-// Default returns the value of this flow when it is the result of an expression
-func (f *flow) Default() interface{} {
-	return f
-}
-
 // String returns the default string value for this flow, which is just our name
 func (f *flow) String() string {
 	return f.name

--- a/flows/fields.go
+++ b/flows/fields.go
@@ -94,10 +94,9 @@ func (v *FieldValue) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on field value", key)
 }
 
-// String returns the string representation of this field value
-func (v *FieldValue) String() string {
-	str, _ := utils.ToString(nil, v.TypedValue())
-	return str
+// Atomize returns the value of this as an XAtom type
+func (v *FieldValue) Atomize() interface{} {
+	return v.TypedValue()
 }
 
 // FieldValues is the set of all field values for a contact
@@ -148,7 +147,7 @@ func (f FieldValues) String() string {
 	fields := make([]string, 0, len(f))
 	for k, v := range f {
 		// TODO serilalize field value according to type
-		fields = append(fields, fmt.Sprintf("%s: %s", k, v.String()))
+		fields = append(fields, fmt.Sprintf("%s: %s", k, v.TypedValue()))
 	}
 	return strings.Join(fields, ", ")
 }

--- a/flows/fields.go
+++ b/flows/fields.go
@@ -94,11 +94,6 @@ func (v *FieldValue) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on field value", key)
 }
 
-// Default returns the value of this field value when it is the result of an expression
-func (v *FieldValue) Default() interface{} {
-	return v.TypedValue()
-}
-
 // String returns the string representation of this field value
 func (v *FieldValue) String() string {
 	str, _ := utils.ToString(nil, v.TypedValue())
@@ -146,11 +141,6 @@ func (f FieldValues) Resolve(key string) interface{} {
 		return fmt.Errorf("no such contact field '%s'", key)
 	}
 	return val
-}
-
-// Default returns the value of this set of field values when it is the result of an expression
-func (f FieldValues) Default() interface{} {
-	return f
 }
 
 // String returns the string representation of these Fields, which is our JSON representation

--- a/flows/fields.go
+++ b/flows/fields.go
@@ -143,7 +143,7 @@ func (f FieldValues) Resolve(key string) interface{} {
 }
 
 // String returns the string representation of these Fields, which is our JSON representation
-func (f FieldValues) String() string {
+func (f FieldValues) Atomize() interface{} {
 	fields := make([]string, 0, len(f))
 	for k, v := range f {
 		// TODO serilalize field value according to type
@@ -152,6 +152,7 @@ func (f FieldValues) String() string {
 	return strings.Join(fields, ", ")
 }
 
+var _ utils.VariableAtomizer = (FieldValues)(nil)
 var _ utils.VariableResolver = (FieldValues)(nil)
 
 // FieldSet defines the unordered set of all fields for a session

--- a/flows/group.go
+++ b/flows/group.go
@@ -66,7 +66,7 @@ func (g *Group) Reference() *GroupReference { return NewGroupReference(g.uuid, g
 func (g *Group) Resolve(key string) interface{} {
 	switch key {
 	case "uuid":
-		return g.uuid
+		return string(g.uuid)
 	case "name":
 		return g.name
 	}
@@ -75,8 +75,9 @@ func (g *Group) Resolve(key string) interface{} {
 }
 
 // String satisfies the stringer interface returning the name of the group
-func (g *Group) String() string { return g.name }
+func (g *Group) Atomize() interface{} { return g.name }
 
+var _ utils.VariableAtomizer = (*Group)(nil)
 var _ utils.VariableResolver = (*Group)(nil)
 
 // GroupList defines a contact's list of groups
@@ -154,7 +155,7 @@ func (l *GroupList) Resolve(key string) interface{} {
 }
 
 // String stringifies the group list, joining our names with a comma
-func (l GroupList) String() string {
+func (l GroupList) Atomize() interface{} {
 	names := make([]string, len(l.groups))
 	for g := range l.groups {
 		names[g] = l.groups[g].name
@@ -162,6 +163,7 @@ func (l GroupList) String() string {
 	return strings.Join(names, ", ")
 }
 
+var _ utils.VariableAtomizer = (*GroupList)(nil)
 var _ utils.VariableResolver = (*GroupList)(nil)
 
 // GroupSet defines the unordered set of all groups for a session

--- a/flows/group.go
+++ b/flows/group.go
@@ -74,9 +74,6 @@ func (g *Group) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on group", key)
 }
 
-// Default returns the value of this group when it is the result of an expression
-func (g *Group) Default() interface{} { return g }
-
 // String satisfies the stringer interface returning the name of the group
 func (g *Group) String() string { return g.name }
 
@@ -154,11 +151,6 @@ func (l *GroupList) Resolve(key string) interface{} {
 		return l.groups[i]
 	}
 	return nil
-}
-
-// Default returns the value of this group list when it is the result of an expression
-func (l GroupList) Default() interface{} {
-	return l
 }
 
 // String stringifies the group list, joining our names with a comma

--- a/flows/inputs/base.go
+++ b/flows/inputs/base.go
@@ -21,7 +21,7 @@ func (i *baseInput) CreatedOn() time.Time   { return i.createdOn }
 func (i *baseInput) Resolve(key string) interface{} {
 	switch key {
 	case "uuid":
-		return i.uuid
+		return string(i.uuid)
 	case "created_on":
 		return i.createdOn
 	case "channel":

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -47,11 +47,6 @@ func (i *MsgInput) Resolve(key string) interface{} {
 	return i.baseInput.Resolve(key)
 }
 
-// Default returns the value of this input when it is the result of an expression
-func (i *MsgInput) Default() interface{} {
-	return i
-}
-
 // String returns our default value if evaluated in a context, our text in our case
 func (i *MsgInput) String() string {
 	var parts []string

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -48,7 +48,7 @@ func (i *MsgInput) Resolve(key string) interface{} {
 }
 
 // String returns our default value if evaluated in a context, our text in our case
-func (i *MsgInput) String() string {
+func (i *MsgInput) Atomize() interface{} {
 	var parts []string
 	if i.text != "" {
 		parts = append(parts, i.text)
@@ -59,6 +59,8 @@ func (i *MsgInput) String() string {
 	return strings.Join(parts, "\n")
 }
 
+var _ utils.VariableAtomizer = (*MsgInput)(nil)
+var _ utils.VariableResolver = (*MsgInput)(nil)
 var _ flows.Input = (*MsgInput)(nil)
 
 //------------------------------------------------------------------------------------------

--- a/flows/results.go
+++ b/flows/results.go
@@ -42,10 +42,11 @@ func (r *Result) Resolve(key string) interface{} {
 }
 
 // String returns the string representation of a result, which is our value
-func (r *Result) String() string {
+func (r *Result) Atomize() interface{} {
 	return r.Value
 }
 
+var _ utils.VariableAtomizer = (*Result)(nil)
 var _ utils.VariableResolver = (*Result)(nil)
 
 // Results is our wrapper around a map of snakified result names to result objects
@@ -90,7 +91,7 @@ func (r Results) Resolve(key string) interface{} {
 }
 
 // String returns the string representation of our Results, which is a key/value pairing of our fields
-func (r Results) String() string {
+func (r Results) Atomize() interface{} {
 	results := make([]string, 0, len(r))
 	for _, v := range r {
 		results = append(results, fmt.Sprintf("%s: %s", v.Name, v.Value))
@@ -98,4 +99,5 @@ func (r Results) String() string {
 	return strings.Join(results, ", ")
 }
 
+var _ utils.VariableAtomizer = (*Results)(nil)
 var _ utils.VariableResolver = (*Results)(nil)

--- a/flows/results.go
+++ b/flows/results.go
@@ -41,11 +41,6 @@ func (r *Result) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on result", key)
 }
 
-// Default returns the value of this result when it is the result of an expression
-func (r *Result) Default() interface{} {
-	return r.Value
-}
-
 // String returns the string representation of a result, which is our value
 func (r *Result) String() string {
 	return r.Value
@@ -92,11 +87,6 @@ func (r Results) Resolve(key string) interface{} {
 	}
 
 	return result
-}
-
-// Default returns the value of this result set when it is the result of an expression
-func (r Results) Default() interface{} {
-	return r
 }
 
 // String returns the string representation of our Results, which is a key/value pairing of our fields

--- a/flows/runs/context.go
+++ b/flows/runs/context.go
@@ -37,10 +37,6 @@ func (c *runContext) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on context", key)
 }
 
-func (c *runContext) String() string {
-	return c.run.UUID().String()
-}
-
 // wraps parent/child runs and provides a reduced set of keys in the context
 type relatedRunContext struct {
 	run flows.RunSummary
@@ -58,13 +54,13 @@ func newRelatedRunContext(run flows.RunSummary) *relatedRunContext {
 func (c *relatedRunContext) Resolve(key string) interface{} {
 	switch key {
 	case "uuid":
-		return c.run.UUID()
+		return string(c.run.UUID())
 	case "contact":
 		return c.run.Contact()
 	case "flow":
 		return c.run.Flow()
 	case "status":
-		return c.run.Status()
+		return string(c.run.Status())
 	case "results":
 		return c.run.Results()
 	}

--- a/flows/runs/context.go
+++ b/flows/runs/context.go
@@ -37,11 +37,6 @@ func (c *runContext) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on context", key)
 }
 
-// Default returns the value of this context when it is the result of an expression
-func (c *runContext) Default() interface{} {
-	return c
-}
-
 func (c *runContext) String() string {
 	return c.run.UUID().String()
 }
@@ -75,10 +70,6 @@ func (c *relatedRunContext) Resolve(key string) interface{} {
 	}
 
 	return fmt.Errorf("no field '%s' on related run", key)
-}
-
-func (c *relatedRunContext) Default() interface{} {
-	return c
 }
 
 func (c *relatedRunContext) String() string {

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -315,7 +315,7 @@ func (r *flowRun) GetTranslatedTextArray(uuid utils.UUID, key string, native []s
 func (r *flowRun) Resolve(key string) interface{} {
 	switch key {
 	case "uuid":
-		return r.UUID()
+		return string(r.UUID())
 	case "contact":
 		return r.Contact()
 	case "flow":
@@ -325,7 +325,7 @@ func (r *flowRun) Resolve(key string) interface{} {
 	case "webhook":
 		return r.Webhook()
 	case "status":
-		return r.Status()
+		return string(r.Status())
 	case "results":
 		return r.Results()
 	case "created_on":
@@ -338,7 +338,7 @@ func (r *flowRun) Resolve(key string) interface{} {
 }
 
 // String returns the default string value for this run, which is just our UUID
-func (r *flowRun) String() string {
+func (r *flowRun) Atomize() interface{} {
 	return string(r.uuid)
 }
 
@@ -346,6 +346,7 @@ func (r *flowRun) Snapshot() flows.RunSummary {
 	return flows.NewRunSummaryFromRun(r)
 }
 
+var _ utils.VariableAtomizer = (*flowRun)(nil)
 var _ utils.VariableResolver = (*flowRun)(nil)
 var _ flows.FlowRun = (*flowRun)(nil)
 var _ flows.RunSummary = (*flowRun)(nil)

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -337,11 +337,6 @@ func (r *flowRun) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on run", key)
 }
 
-// Default returns the value of this run when it is the result of an expression
-func (r *flowRun) Default() interface{} {
-	return r
-}
-
 // String returns the default string value for this run, which is just our UUID
 func (r *flowRun) String() string {
 	return string(r.uuid)

--- a/flows/triggers/base.go
+++ b/flows/triggers/base.go
@@ -32,11 +32,6 @@ func (t *baseTrigger) Resolve(key string) interface{} {
 	return fmt.Errorf("No such field '%s' on trigger", key)
 }
 
-// Default returns the value of this trigger when it is the result of an expression
-func (t *baseTrigger) Default() interface{} {
-	return t
-}
-
 func (t *baseTrigger) String() string {
 	return string(t.flow.UUID())
 }

--- a/flows/triggers/base.go
+++ b/flows/triggers/base.go
@@ -32,6 +32,9 @@ func (t *baseTrigger) Resolve(key string) interface{} {
 	return fmt.Errorf("No such field '%s' on trigger", key)
 }
 
-func (t *baseTrigger) String() string {
+func (t *baseTrigger) Atomize() interface{} {
 	return string(t.flow.UUID())
 }
+
+var _ utils.VariableAtomizer = (*baseTrigger)(nil)
+var _ utils.VariableResolver = (*baseTrigger)(nil)

--- a/flows/urns.go
+++ b/flows/urns.go
@@ -60,9 +60,6 @@ func (u *ContactURN) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on URN", key)
 }
 
-// Default returns the value of this URN when it is the result of an expression
-func (u *ContactURN) Default() interface{} { return u }
-
 func (u *ContactURN) String() string { return string(u.URN) }
 
 // URNList is the list of a contact's URNs
@@ -152,11 +149,6 @@ func (l URNList) Resolve(key string) interface{} {
 	}
 
 	return l.WithScheme(scheme)
-}
-
-// Default returns the value of this URN list when it is the result of an expression
-func (l URNList) Default() interface{} {
-	return l
 }
 
 func (l URNList) String() string {

--- a/flows/urns.go
+++ b/flows/urns.go
@@ -60,7 +60,10 @@ func (u *ContactURN) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on URN", key)
 }
 
-func (u *ContactURN) String() string { return string(u.URN) }
+func (u *ContactURN) Atomize() interface{} { return string(u.URN) }
+
+var _ utils.VariableAtomizer = (*ContactURN)(nil)
+var _ utils.VariableResolver = (*ContactURN)(nil)
 
 // URNList is the list of a contact's URNs
 type URNList []*ContactURN
@@ -151,12 +154,12 @@ func (l URNList) Resolve(key string) interface{} {
 	return l.WithScheme(scheme)
 }
 
-func (l URNList) String() string {
+func (l URNList) Atomize() interface{} {
 	if len(l) > 0 {
 		return l[0].String()
 	}
 	return ""
 }
 
-var _ utils.VariableResolver = &ContactURN{}
+var _ utils.VariableAtomizer = (URNList)(nil)
 var _ utils.VariableResolver = (URNList)(nil)

--- a/legacy/expressions.go
+++ b/legacy/expressions.go
@@ -115,11 +115,6 @@ func (v *varMapper) Resolve(key string) interface{} {
 	return strings.Join(newPath, ".")
 }
 
-// Default returns the value of this mapper when it is the result of an expression
-func (v *varMapper) Default() interface{} {
-	return v.base
-}
-
 func (v *varMapper) String() string {
 	sub, exists := v.substitutions["__default__"]
 	if exists {
@@ -144,11 +139,6 @@ func (m *extraMapper) Resolve(key string) interface{} {
 	}
 	newPath = append(newPath, key)
 	return &extraMapper{extraAs: m.extraAs, path: strings.Join(newPath, ".")}
-}
-
-// Default returns the value of this extra mapper when it is the result of an expression
-func (m *extraMapper) Default() interface{} {
-	return m
 }
 
 func (m *extraMapper) String() string {

--- a/legacy/expressions.go
+++ b/legacy/expressions.go
@@ -115,6 +115,10 @@ func (v *varMapper) Resolve(key string) interface{} {
 	return strings.Join(newPath, ".")
 }
 
+func (v *varMapper) Atomize() interface{} {
+	return v.String()
+}
+
 func (v *varMapper) String() string {
 	sub, exists := v.substitutions["__default__"]
 	if exists {
@@ -122,6 +126,9 @@ func (v *varMapper) String() string {
 	}
 	return v.base
 }
+
+var _ utils.VariableAtomizer = (*varMapper)(nil)
+var _ utils.VariableResolver = (*varMapper)(nil)
 
 // Migration of @extra requires its own mapper because it can map differently depending on the containing flow
 type extraMapper struct {
@@ -141,7 +148,7 @@ func (m *extraMapper) Resolve(key string) interface{} {
 	return &extraMapper{extraAs: m.extraAs, path: strings.Join(newPath, ".")}
 }
 
-func (m *extraMapper) String() string {
+func (m *extraMapper) Atomize() interface{} {
 	switch m.extraAs {
 	case ExtraAsWebhookJSON:
 		return fmt.Sprintf("run.webhook.json.%s", m.path)
@@ -152,6 +159,9 @@ func (m *extraMapper) String() string {
 	}
 	return ""
 }
+
+var _ utils.VariableAtomizer = (*extraMapper)(nil)
+var _ utils.VariableResolver = (*extraMapper)(nil)
 
 type functionTemplate struct {
 	name   string

--- a/utils/conversions.go
+++ b/utils/conversions.go
@@ -235,15 +235,6 @@ func ToJSON(env Environment, val interface{}) (JSONFragment, error) {
 	case fmt.Stringer:
 		return ToFragment(json.Marshal(val.String()))
 
-	case VariableResolver:
-		// this checks that we aren't getting into an infinite loop
-		valDefault := val.Default()
-		valResolver, isResolver := valDefault.(VariableResolver)
-		if isResolver && reflect.DeepEqual(valResolver, val) {
-			return EmptyJSONFragment, fmt.Errorf("Loop found in ToJSON of '%s' with value '%+v'", reflect.TypeOf(val), val)
-		}
-		return ToJSON(env, valDefault)
-
 	case []string:
 		return ToFragment(json.Marshal(val))
 
@@ -318,15 +309,6 @@ func ToString(env Environment, val interface{}) (string, error) {
 
 	case fmt.Stringer:
 		return val.String(), nil
-
-	case VariableResolver:
-		// this checks that we aren't getting into an infinite loop
-		valDefault := val.Default()
-		valResolver, isResolver := valDefault.(VariableResolver)
-		if isResolver && reflect.DeepEqual(valResolver, val) {
-			return "", fmt.Errorf("Loop found in ToString of '%s' with value '%+v'", reflect.TypeOf(val), val)
-		}
-		return ToString(env, valDefault)
 
 	case Location:
 		return val.Name(), nil

--- a/utils/conversions.go
+++ b/utils/conversions.go
@@ -232,9 +232,6 @@ func ToJSON(env Environment, val interface{}) (JSONFragment, error) {
 	case JSONFragment:
 		return val, nil
 
-	case fmt.Stringer:
-		return ToFragment(json.Marshal(val.String()))
-
 	case VariableAtomizer:
 		return ToJSON(env, val.Atomize())
 
@@ -309,9 +306,6 @@ func ToString(env Environment, val interface{}) (string, error) {
 
 	case time.Time:
 		return DateToISO(val), nil
-
-	case fmt.Stringer:
-		return val.String(), nil
 
 	case VariableAtomizer:
 		return ToString(env, val.Atomize())
@@ -421,9 +415,6 @@ func ToDecimal(env Environment, val interface{}) (decimal.Decimal, error) {
 			return decimal.Zero, fmt.Errorf("Cannot convert '%s' to a decimal", val)
 		}
 		return parsed, nil
-
-	case fmt.Stringer:
-		return ToDecimal(env, val.String())
 
 	case VariableAtomizer:
 		return ToDecimal(env, val.Atomize())

--- a/utils/conversions.go
+++ b/utils/conversions.go
@@ -235,6 +235,9 @@ func ToJSON(env Environment, val interface{}) (JSONFragment, error) {
 	case fmt.Stringer:
 		return ToFragment(json.Marshal(val.String()))
 
+	case VariableAtomizer:
+		return ToJSON(env, val.Atomize())
+
 	case []string:
 		return ToFragment(json.Marshal(val))
 
@@ -310,6 +313,9 @@ func ToString(env Environment, val interface{}) (string, error) {
 	case fmt.Stringer:
 		return val.String(), nil
 
+	case VariableAtomizer:
+		return ToString(env, val.Atomize())
+
 	case Location:
 		return val.Name(), nil
 
@@ -362,7 +368,7 @@ func ToString(env Environment, val interface{}) (string, error) {
 	}
 
 	// welp, we give up, this isn't something we can convert, return an error
-	return "", fmt.Errorf("ToString unknown type '%s' with value '%+v'", reflect.TypeOf(val), val)
+	return "", fmt.Errorf("unable to convert value '%+v' of type '%s' to a string", val, reflect.TypeOf(val))
 }
 
 // ToInt tries to convert the passed in interface{} to an integer value, returning an error if that isn't possible
@@ -415,14 +421,15 @@ func ToDecimal(env Environment, val interface{}) (decimal.Decimal, error) {
 			return decimal.Zero, fmt.Errorf("Cannot convert '%s' to a decimal", val)
 		}
 		return parsed, nil
+
+	case fmt.Stringer:
+		return ToDecimal(env, val.String())
+
+	case VariableAtomizer:
+		return ToDecimal(env, val.Atomize())
 	}
 
-	asString, err := ToString(env, val)
-	if err != nil {
-		return decimal.Zero, err
-	}
-
-	return ToDecimal(env, asString)
+	return decimal.Zero, fmt.Errorf("unable to convert value '%+v' of type '%s' to a decimal", val, reflect.TypeOf(val))
 }
 
 // ToDate tries to convert the passed in interface to a time.Time returning an error if that isn't possible
@@ -450,14 +457,15 @@ func ToDate(env Environment, val interface{}) (time.Time, error) {
 
 	case string:
 		return DateFromString(env, val)
+
+	case fmt.Stringer:
+		return ToDate(env, val.String())
+
+	case VariableAtomizer:
+		return ToDate(env, val.Atomize())
 	}
 
-	asString, err := ToString(env, val)
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	return ToDate(env, asString)
+	return time.Time{}, fmt.Errorf("unable to convert value '%+v' of type '%s' to a date", val, reflect.TypeOf(val))
 }
 
 // ToBool tests whether the passed in item should be considered True
@@ -520,14 +528,12 @@ func ToBool(env Environment, test interface{}) (bool, error) {
 
 		// finally just string version
 		return asString != "" && strings.ToLower(asString) != "false", nil
+
+	case VariableAtomizer:
+		return ToBool(env, test.Atomize())
 	}
 
-	asString, err := ToString(env, test)
-	if err != nil {
-		return false, err
-	}
-
-	return ToBool(env, asString)
+	return false, fmt.Errorf("unable to convert value '%+v' of type '%s' to a bool", test, reflect.TypeOf(test))
 }
 
 // XType is an an enumeration of the possible types we can deal with

--- a/utils/conversions_test.go
+++ b/utils/conversions_test.go
@@ -15,8 +15,7 @@ type resolver struct {
 	defaultString string
 }
 
-func (r *resolver) Default() interface{} { return r.defaultString }
-func (r *resolver) String() string       { return r.defaultString }
+func (r *resolver) String() string { return r.defaultString }
 func (r *resolver) Resolve(key string) interface{} {
 	return fmt.Errorf("No such key")
 }

--- a/utils/conversions_test.go
+++ b/utils/conversions_test.go
@@ -15,7 +15,7 @@ type resolver struct {
 	defaultString string
 }
 
-func (r *resolver) String() string { return r.defaultString }
+func (r *resolver) Atomize() interface{} { return r.defaultString }
 func (r *resolver) Resolve(key string) interface{} {
 	return fmt.Errorf("No such key")
 }

--- a/utils/conversions_test.go
+++ b/utils/conversions_test.go
@@ -20,11 +20,6 @@ func (r *resolver) Resolve(key string) interface{} {
 	return fmt.Errorf("No such key")
 }
 
-// test stringer
-type stringer struct{}
-
-func (s *stringer) String() string { return "Stringer" }
-
 func TestToString(t *testing.T) {
 	strMap := make(map[string]string)
 	strMap["one"] = "1.0"
@@ -37,7 +32,6 @@ func TestToString(t *testing.T) {
 	date1 := time.Date(2017, 6, 23, 15, 30, 0, 0, time.UTC)
 	date2 := time.Date(2017, 7, 18, 15, 30, 0, 0, chi)
 
-	testStringer := &stringer{}
 	testResolver := &resolver{"Resolver"}
 
 	var tests = []struct {
@@ -55,7 +49,6 @@ func TestToString(t *testing.T) {
 		{float32(15.5), "15.5", false},
 		{float64(15.5), "15.5", false},
 		{decimal.NewFromFloat(15.5), "15.5", false},
-		{testStringer, "Stringer", false},
 		{testResolver, "Resolver", false},
 		{date1, "2017-06-23T15:30:00.000000Z", false},
 		{[]time.Time{date1, date2}, "2017-06-23T15:30:00.000000Z, 2017-07-18T15:30:00.000000-05:00", false},
@@ -190,7 +183,6 @@ func TestToJSON(t *testing.T) {
 	date1 := time.Date(2017, 6, 23, 15, 30, 0, 0, time.UTC)
 	date2 := time.Date(2017, 7, 18, 15, 30, 0, 0, chi)
 
-	testStringer := &stringer{}
 	testResolver := &resolver{"Resolver"}
 
 	var tests = []struct {
@@ -208,7 +200,6 @@ func TestToJSON(t *testing.T) {
 		{float32(15.5), "15.5", false},
 		{float64(15.5), "15.5", false},
 		{decimal.NewFromFloat(15.5), "15.5", false},
-		{testStringer, `"Stringer"`, false},
 		{testResolver, `"Resolver"`, false},
 		{date1, `"2017-06-23T15:30:00.000000Z"`, false},
 		{[]time.Time{date1, date2}, `["2017-06-23T15:30:00.000000Z","2017-07-18T15:30:00.000000-05:00"]`, false},
@@ -224,7 +215,7 @@ func TestToJSON(t *testing.T) {
 
 	for _, test := range tests {
 		fragment, err := utils.ToJSON(env, test.input)
-		result := fragment.String()
+		result := string(fragment)
 
 		if err != nil && !test.hasError {
 			t.Errorf("Unexpected error calling ToJSON on '%v': %s", test.input, err)

--- a/utils/http.go
+++ b/utils/http.go
@@ -100,7 +100,7 @@ func (r *RequestResponse) Resolve(key string) interface{} {
 	case "response":
 		return r.Response()
 	case "status":
-		return r.Status()
+		return string(r.Status())
 	case "status_code":
 		return r.StatusCode()
 	}
@@ -108,10 +108,11 @@ func (r *RequestResponse) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on webhook", key)
 }
 
-func (r *RequestResponse) String() string {
+func (r *RequestResponse) Atomize() interface{} {
 	return r.body
 }
 
+var _ VariableAtomizer = (*RequestResponse)(nil)
 var _ VariableResolver = (*RequestResponse)(nil)
 
 // newRRFromResponse creates a new RequestResponse based on the passed in http request and error (when we received no response)

--- a/utils/http.go
+++ b/utils/http.go
@@ -108,11 +108,6 @@ func (r *RequestResponse) Resolve(key string) interface{} {
 	return fmt.Errorf("no field '%s' on webhook", key)
 }
 
-// Default returns the value of this webhook when it is the result of an expression
-func (r *RequestResponse) Default() interface{} {
-	return r
-}
-
 func (r *RequestResponse) String() string {
 	return r.body
 }

--- a/utils/json.go
+++ b/utils/json.go
@@ -71,12 +71,13 @@ func (j JSONFragment) Resolve(key string) interface{} {
 	return JSONFragment(val)
 }
 
-var _ VariableResolver = EmptyJSONFragment
-
 // String returns the string representation of this JSON, which is just the JSON itself
-func (j JSONFragment) String() string {
+func (j JSONFragment) Atomize() interface{} {
 	return string(j)
 }
+
+var _ VariableAtomizer = EmptyJSONFragment
+var _ VariableResolver = EmptyJSONFragment
 
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding

--- a/utils/json.go
+++ b/utils/json.go
@@ -71,11 +71,6 @@ func (j JSONFragment) Resolve(key string) interface{} {
 	return JSONFragment(val)
 }
 
-// Default returns the value of this JSON fragment when it is the result of an expression
-func (j JSONFragment) Default() interface{} {
-	return j
-}
-
 var _ VariableResolver = EmptyJSONFragment
 
 // String returns the string representation of this JSON, which is just the JSON itself

--- a/utils/resolver.go
+++ b/utils/resolver.go
@@ -19,7 +19,6 @@ func Snakify(text string) string {
 // VariableResolver defines the interface used by Excellent objects that can be indexed into
 type VariableResolver interface {
 	Resolve(key string) interface{}
-	Default() interface{}
 	String() string
 }
 
@@ -150,8 +149,5 @@ func (r *mapResolver) Resolve(key string) interface{} {
 	}
 	return val
 }
-
-// Default returns the value of this map when it is the result of an expression
-func (r *mapResolver) Default() interface{} { return r }
 
 func (r *mapResolver) String() string { return fmt.Sprintf("%s", r.values) }

--- a/utils/resolver.go
+++ b/utils/resolver.go
@@ -16,12 +16,12 @@ func Snakify(text string) string {
 	return strings.Trim(strings.ToLower(snakedChars.ReplaceAllString(text, "_")), "_")
 }
 
-// VariableResolver defines the interface used by Excellent objects that can be indexed into
+// VariableResolver is the interface for objects in the context which can be keyed into, e.g. foo.bar
 type VariableResolver interface {
 	Resolve(key string) interface{}
 }
 
-// VariableAtomizer defines the interface used by Excellent objects that can be indexed into
+// VariableAtomizer is the interface for objects in the context which can reduce themselves to an XAtom primitive
 type VariableAtomizer interface {
 	Atomize() interface{}
 }

--- a/utils/resolver.go
+++ b/utils/resolver.go
@@ -19,7 +19,11 @@ func Snakify(text string) string {
 // VariableResolver defines the interface used by Excellent objects that can be indexed into
 type VariableResolver interface {
 	Resolve(key string) interface{}
-	String() string
+}
+
+// VariableAtomizer defines the interface used by Excellent objects that can be indexed into
+type VariableAtomizer interface {
+	Atomize() interface{}
 }
 
 // ResolveVariable will resolve the passed in string variable given in dot notation and return

--- a/utils/resolver.go
+++ b/utils/resolver.go
@@ -154,4 +154,7 @@ func (r *mapResolver) Resolve(key string) interface{} {
 	return val
 }
 
-func (r *mapResolver) String() string { return fmt.Sprintf("%s", r.values) }
+func (r *mapResolver) Atomize() interface{} { return fmt.Sprintf("%s", r.values) }
+
+var _ VariableAtomizer = (*mapResolver)(nil)
+var _ VariableResolver = (*mapResolver)(nil)


### PR DESCRIPTION
Playing around with variable resolving. The idea would be:

 * All variables in excellent should be one of:
    - A primitive of an `XAtom` type
    - A complex object that implements `VariableAtomizer`, i.e. can reduce itself to an `XAtom`
    - Lists of either of the above (these would cease to be `XAtom` types themselves)
* Make sure the excellent visitor can only produce such types, and we can greatly simply our conversion functions to not worry about other golang types.
* Replace `Default()` and `String()` with `Atomize()` which does the reduction to a primitive (usually a `string`). For example datetime field value returns itself as a `time.Time` - it doesn't need to know how to stringify itself - the conversion routines in utils have that logic in one place.

In this PR I've left `String()` around on most objects and it takes priority over `Atomize()` if it is defined.
