### PR TITLE
XValues should be JSONable via json.Marshal

### DIFF
--- a/cmd/flowrunner/testdata/flows/dynamic_groups_test.json
+++ b/cmd/flowrunner/testdata/flows/dynamic_groups_test.json
@@ -81,7 +81,7 @@
                 "contact": {
                     "fields": {
                         "age": {
-                            "decimal": "17",
+                            "decimal": 17,
                             "text": "17"
                         },
                         "first_name": {
@@ -156,7 +156,7 @@
                                         "name": "Android Channel",
                                         "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
                                     },
-                                    "text": "Current groups: Males, Old Men",
+                                    "text": "Current groups: [\"Males\",\"Old Men\"]",
                                     "urn": "tel:+12065551212",
                                     "uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094"
                                 },
@@ -176,7 +176,7 @@
                                         "name": "Android Channel",
                                         "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
                                     },
-                                    "text": "Current groups: Males, Old Men",
+                                    "text": "Current groups: [\"Males\",\"Old Men\"]",
                                     "urn": "tel:+12065551212",
                                     "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
                                 },
@@ -200,7 +200,7 @@
                                         "name": "Android Channel",
                                         "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
                                     },
-                                    "text": "Current groups: Males, Youth, MTN Callers",
+                                    "text": "Current groups: [\"Males\",\"Youth\",\"MTN Callers\"]",
                                     "urn": "tel:+12065551212",
                                     "uuid": "5802813d-6c58-4292-8228-9728778b6c98"
                                 },

--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -26,8 +26,8 @@ func NewTestXObject(foo string, bar int) *testXObject {
 	return &testXObject{foo: foo, bar: bar}
 }
 
-// ToJSON converts this type to JSON
-func (v *testXObject) ToJSON() types.XString {
+// ToXJSON converts this type to JSON
+func (v *testXObject) ToXJSON() types.XString {
 	e := struct {
 		Foo string `json:"foo"`
 		Bar int    `json:"bar"`

--- a/excellent/types/array.go
+++ b/excellent/types/array.go
@@ -18,6 +18,9 @@ type xarray struct {
 
 // NewXArray returns a new array with the given items
 func NewXArray(values ...XValue) XArray {
+	if values == nil {
+		values = []XValue{}
+	}
 	return &xarray{values: values}
 }
 
@@ -47,6 +50,11 @@ func (a *xarray) ToJSON() XString {
 	return MustMarshalToXString(marshaled)
 }
 
+// MarshalJSON converts this type to internal JSON
+func (a *xarray) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.values)
+}
+
 // Index is called when this object is indexed into in an expression
 func (a *xarray) Index(index int) XValue {
 	return a.values[index]
@@ -63,3 +71,4 @@ func (a *xarray) Append(value XValue) {
 }
 
 var _ XArray = (*xarray)(nil)
+var _ json.Marshaler = (*xarray)(nil)

--- a/excellent/types/array.go
+++ b/excellent/types/array.go
@@ -27,25 +27,25 @@ func NewXArray(values ...XValue) XArray {
 // Reduce returns the primitive version of this type (i.e. itself)
 func (a *xarray) Reduce() XPrimitive { return a }
 
-// ToString converts this type to a string
-func (a *xarray) ToString() XString {
+// ToXString converts this type to a string
+func (a *xarray) ToXString() XString {
 	strs := make([]XString, len(a.values))
 	for i := range a.values {
-		strs[i] = a.values[i].Reduce().ToString()
+		strs[i] = a.values[i].Reduce().ToXString()
 	}
 	return MustMarshalToXString(strs)
 }
 
-// ToBool converts this type to a bool
-func (a *xarray) ToBool() XBool {
+// ToXBool converts this type to a bool
+func (a *xarray) ToXBool() XBool {
 	return len(a.values) > 0
 }
 
-// ToJSON converts this type to JSON
-func (a *xarray) ToJSON() XString {
+// ToXJSON converts this type to JSON
+func (a *xarray) ToXJSON() XString {
 	marshaled := make([]json.RawMessage, len(a.values))
 	for i := range a.values {
-		marshaled[i] = json.RawMessage(a.values[i].ToJSON())
+		marshaled[i] = json.RawMessage(a.values[i].ToXJSON())
 	}
 	return MustMarshalToXString(marshaled)
 }

--- a/excellent/types/base.go
+++ b/excellent/types/base.go
@@ -10,7 +10,7 @@ import (
 
 // XValue is the base interface of all Excellent types
 type XValue interface {
-	ToJSON() XString
+	ToXJSON() XString
 	Reduce() XPrimitive
 }
 
@@ -18,8 +18,8 @@ type XValue interface {
 type XPrimitive interface {
 	XValue
 
-	ToString() XString
-	ToBool() XBool
+	ToXString() XString
+	ToXBool() XBool
 }
 
 // XResolvable is the interface for types which can be keyed into, e.g. foo.bar

--- a/excellent/types/bool.go
+++ b/excellent/types/bool.go
@@ -15,14 +15,14 @@ func NewXBool(value bool) XBool {
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x XBool) Reduce() XPrimitive { return x }
 
-// ToString converts this type to a string
-func (x XBool) ToString() XString { return NewXString(strconv.FormatBool(x.Native())) }
+// ToXString converts this type to a string
+func (x XBool) ToXString() XString { return NewXString(strconv.FormatBool(x.Native())) }
 
-// ToBool converts this type to a bool
-func (x XBool) ToBool() XBool { return x }
+// ToXBool converts this type to a bool
+func (x XBool) ToXBool() XBool { return x }
 
-// ToJSON converts this type to JSON
-func (x XBool) ToJSON() XString { return MustMarshalToXString(x.Native()) }
+// ToXJSON converts this type to JSON
+func (x XBool) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 
 // Native returns the native value of this type
 func (x XBool) Native() bool { return bool(x) }

--- a/excellent/types/conversions.go
+++ b/excellent/types/conversions.go
@@ -21,7 +21,7 @@ func ToXJSON(x XValue) (XString, XError) {
 		return XStringEmpty, x.(XError)
 	}
 
-	return x.ToJSON(), nil
+	return x.ToXJSON(), nil
 }
 
 // ToXString converts the given value to a string
@@ -33,7 +33,7 @@ func ToXString(x XValue) (XString, XError) {
 		return XStringEmpty, x.(XError)
 	}
 
-	return x.Reduce().ToString(), nil
+	return x.Reduce().ToXString(), nil
 }
 
 // ToXBool converts the given value to a boolean
@@ -47,7 +47,7 @@ func ToXBool(x XValue) (XBool, XError) {
 
 	primitive, isPrimitive := x.(XPrimitive)
 	if isPrimitive {
-		return primitive.ToBool(), nil
+		return primitive.ToXBool(), nil
 	}
 
 	lengthable, isLengthable := x.(XLengthable)
@@ -55,7 +55,7 @@ func ToXBool(x XValue) (XBool, XError) {
 		return lengthable.Length() > 0, nil
 	}
 
-	return x.Reduce().ToBool(), nil
+	return x.Reduce().ToXBool(), nil
 }
 
 // ToXNumber converts the given value to a number or returns an error if that isn't possible
@@ -114,7 +114,7 @@ func ToInteger(x XValue) (int, XError) {
 	intPart := number.Native().IntPart()
 
 	if intPart < math.MinInt32 && intPart > math.MaxInt32 {
-		return 0, NewXErrorf("number value %s is out of range for an integer", string(number.ToString()))
+		return 0, NewXErrorf("number value %s is out of range for an integer", string(number.ToXString()))
 	}
 
 	return int(intPart), nil

--- a/excellent/types/conversions_test.go
+++ b/excellent/types/conversions_test.go
@@ -22,8 +22,8 @@ func NewTestXObject(foo string, bar int) *testXObject {
 	return &testXObject{foo: foo, bar: bar}
 }
 
-// ToJSON converts this type to JSON
-func (v *testXObject) ToJSON() types.XString {
+// ToXJSON converts this type to JSON
+func (v *testXObject) ToXJSON() types.XString {
 	e := struct {
 		Foo string `json:"foo"`
 		Bar int    `json:"bar"`

--- a/excellent/types/date.go
+++ b/excellent/types/date.go
@@ -17,14 +17,14 @@ func NewXDate(value time.Time) XDate {
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x XDate) Reduce() XPrimitive { return x }
 
-// ToString converts this type to a string
-func (x XDate) ToString() XString { return XString(utils.DateToISO(x.Native())) }
+// ToXString converts this type to a string
+func (x XDate) ToXString() XString { return XString(utils.DateToISO(x.Native())) }
 
-// ToBool converts this type to a bool
-func (x XDate) ToBool() XBool { return XBool(!x.Native().IsZero()) }
+// ToXBool converts this type to a bool
+func (x XDate) ToXBool() XBool { return XBool(!x.Native().IsZero()) }
 
-// ToJSON converts this type to JSON
-func (x XDate) ToJSON() XString { return MustMarshalToXString(utils.DateToISO(x.Native())) }
+// ToXJSON converts this type to JSON
+func (x XDate) ToXJSON() XString { return MustMarshalToXString(utils.DateToISO(x.Native())) }
 
 // Native returns the native value of this type
 func (x XDate) Native() time.Time { return time.Time(x) }

--- a/excellent/types/error.go
+++ b/excellent/types/error.go
@@ -32,14 +32,14 @@ func NewXResolveError(resolvable XResolvable, key string) XError {
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x xerror) Reduce() XPrimitive { return x }
 
-// ToString converts this type to a string
-func (x xerror) ToString() XString { return XString(x.Native().Error()) }
+// ToXString converts this type to a string
+func (x xerror) ToXString() XString { return XString(x.Native().Error()) }
 
-// ToBool converts this type to a bool
-func (x xerror) ToBool() XBool { return XBool(false) }
+// ToXBool converts this type to a bool
+func (x xerror) ToXBool() XBool { return XBool(false) }
 
-// ToJSON converts this type to JSON
-func (x xerror) ToJSON() XString { return MustMarshalToXString(x.Native().Error()) }
+// ToXJSON converts this type to JSON
+func (x xerror) ToXJSON() XString { return MustMarshalToXString(x.Native().Error()) }
 
 // MarshalJSON converts this type to internal JSON
 func (x xerror) MarshalJSON() ([]byte, error) {

--- a/excellent/types/error.go
+++ b/excellent/types/error.go
@@ -41,6 +41,11 @@ func (x xerror) ToBool() XBool { return XBool(false) }
 // ToJSON converts this type to JSON
 func (x xerror) ToJSON() XString { return MustMarshalToXString(x.Native().Error()) }
 
+// MarshalJSON converts this type to internal JSON
+func (x xerror) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
 // Native returns the native value of this type
 func (x xerror) Native() error { return x.err }
 

--- a/excellent/types/json.go
+++ b/excellent/types/json.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/buger/jsonparser"
@@ -13,6 +14,10 @@ type XJSON []byte
 func (x XJSON) ToJSON() XString { return NewXString(string(x)) }
 
 func (x XJSON) Reduce() XPrimitive { return x.ToJSON() }
+
+func (x XJSON) MarshalJSON() ([]byte, error) {
+	return []byte(x), nil
+}
 
 type XJSONObject struct {
 	XJSON
@@ -43,6 +48,7 @@ func (x XJSONObject) Resolve(key string) XValue {
 var _ XValue = XJSONObject{}
 var _ XLengthable = XJSONObject{}
 var _ XResolvable = XJSONObject{}
+var _ json.Marshaler = XJSONObject{}
 
 type XJSONArray struct {
 	XJSON
@@ -70,6 +76,7 @@ func (x XJSONArray) Index(index int) XValue {
 
 var _ XValue = XJSONArray{}
 var _ XIndexable = XJSONArray{}
+var _ json.Marshaler = XJSONArray{}
 
 func JSONToXValue(data []byte) XValue {
 	val, valType, _, err := jsonparser.Get(data)

--- a/excellent/types/json.go
+++ b/excellent/types/json.go
@@ -11,9 +11,9 @@ import (
 // XJSON is the base type for XJSONObject and XJSONArray
 type XJSON []byte
 
-func (x XJSON) ToJSON() XString { return NewXString(string(x)) }
+func (x XJSON) ToXJSON() XString { return NewXString(string(x)) }
 
-func (x XJSON) Reduce() XPrimitive { return x.ToJSON() }
+func (x XJSON) Reduce() XPrimitive { return x.ToXJSON() }
 
 func (x XJSON) MarshalJSON() ([]byte, error) {
 	return []byte(x), nil

--- a/excellent/types/map.go
+++ b/excellent/types/map.go
@@ -35,25 +35,25 @@ func NewXEmptyMap() XMap {
 // Reduce returns the primitive version of this type (i.e. itself)
 func (m *xmap) Reduce() XPrimitive { return m }
 
-// ToString converts this type to a string
-func (m *xmap) ToString() XString {
+// ToXString converts this type to a string
+func (m *xmap) ToXString() XString {
 	strs := make(map[string]XString, len(m.values))
 	for k, v := range m.values {
-		strs[k] = v.Reduce().ToString()
+		strs[k] = v.Reduce().ToXString()
 	}
 	return MustMarshalToXString(strs)
 }
 
-// ToBool converts this type to a bool
-func (m *xmap) ToBool() XBool {
+// ToXBool converts this type to a bool
+func (m *xmap) ToXBool() XBool {
 	return len(m.values) > 0
 }
 
-// ToJSON converts this type to JSON
-func (m *xmap) ToJSON() XString {
+// ToXJSON converts this type to JSON
+func (m *xmap) ToXJSON() XString {
 	marshaled := make(map[string]json.RawMessage, len(m.values))
 	for k, v := range m.values {
-		marshaled[k] = json.RawMessage(v.ToJSON())
+		marshaled[k] = json.RawMessage(v.ToXJSON())
 	}
 	return MustMarshalToXString(marshaled)
 }

--- a/excellent/types/map.go
+++ b/excellent/types/map.go
@@ -58,6 +58,11 @@ func (m *xmap) ToJSON() XString {
 	return MustMarshalToXString(marshaled)
 }
 
+// MarshalJSON converts this type to internal JSON
+func (m *xmap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.values)
+}
+
 // Length is called when the length of this object is requested in an expression
 func (m *xmap) Length() int {
 	return len(m.values)
@@ -86,3 +91,4 @@ func (m *xmap) Keys() []string {
 }
 
 var _ XMap = (*xmap)(nil)
+var _ json.Marshaler = (*xmap)(nil)

--- a/excellent/types/number.go
+++ b/excellent/types/number.go
@@ -34,14 +34,14 @@ func RequireXNumberFromString(value string) XNumber {
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x XNumber) Reduce() XPrimitive { return x }
 
-// ToString converts this type to a string
-func (x XNumber) ToString() XString { return XString(x.Native().String()) }
+// ToXString converts this type to a string
+func (x XNumber) ToXString() XString { return XString(x.Native().String()) }
 
-// ToBool converts this type to a bool
-func (x XNumber) ToBool() XBool { return XBool(!x.Native().Equals(decimal.Zero)) }
+// ToXBool converts this type to a bool
+func (x XNumber) ToXBool() XBool { return XBool(!x.Native().Equals(decimal.Zero)) }
 
-// ToJSON converts this type to JSON
-func (x XNumber) ToJSON() XString { return MustMarshalToXString(x.Native()) }
+// ToXJSON converts this type to JSON
+func (x XNumber) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 
 // Native returns the native value of this type
 func (x XNumber) Native() decimal.Decimal { return decimal.Decimal(x) }

--- a/excellent/types/string.go
+++ b/excellent/types/string.go
@@ -16,14 +16,14 @@ func NewXString(value string) XString {
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x XString) Reduce() XPrimitive { return x }
 
-// ToString converts this type to a string
-func (x XString) ToString() XString { return x }
+// ToXString converts this type to a string
+func (x XString) ToXString() XString { return x }
 
-// ToBool converts this type to a bool
-func (x XString) ToBool() XBool { return string(x) != "" && strings.ToLower(string(x)) != "false" }
+// ToXBool converts this type to a bool
+func (x XString) ToXBool() XBool { return string(x) != "" && strings.ToLower(string(x)) != "false" }
 
-// ToJSON converts this type to JSON
-func (x XString) ToJSON() XString { return MustMarshalToXString(x.Native()) }
+// ToXJSON converts this type to JSON
+func (x XString) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 
 // Native returns the native value of this type
 func (x XString) Native() string { return string(x) }

--- a/flows/attachments.go
+++ b/flows/attachments.go
@@ -42,7 +42,7 @@ func (a Attachment) Resolve(key string) types.XValue {
 // Reduce is called when this object needs to be reduced to a primitive
 func (a Attachment) Reduce() types.XPrimitive { return types.NewXString(a.URL()) }
 
-func (a Attachment) ToJSON() types.XString { return types.NewXString("TODO") }
+func (a Attachment) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (Attachment)("")
 var _ types.XResolvable = (Attachment)("")
@@ -69,7 +69,7 @@ func (a AttachmentList) Reduce() types.XPrimitive {
 	return array
 }
 
-func (a AttachmentList) ToJSON() types.XString { return types.NewXString("TODO") }
+func (a AttachmentList) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (AttachmentList)(nil)
 var _ types.XIndexable = (AttachmentList)(nil)

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -95,7 +95,7 @@ func (c *channel) Reduce() types.XPrimitive {
 	return types.NewXString(c.name)
 }
 
-func (c *channel) ToJSON() types.XString { return types.NewXString("TODO") }
+func (c *channel) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*channel)(nil)
 var _ types.XResolvable = (*channel)(nil)

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -146,7 +146,7 @@ func (c *Contact) Reduce() types.XPrimitive {
 	return types.NewXString(c.name)
 }
 
-func (c *Contact) ToJSON() types.XString { return types.NewXString("TODO") }
+func (c *Contact) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*Contact)(nil)
 var _ types.XResolvable = (*Contact)(nil)

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -102,7 +102,7 @@ func (f *flow) Reduce() types.XPrimitive {
 	return types.NewXString(f.name)
 }
 
-func (f *flow) ToJSON() types.XString { return types.NewXString("TODO") }
+func (f *flow) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*flow)(nil)
 var _ types.XResolvable = (*flow)(nil)

--- a/flows/fields.go
+++ b/flows/fields.go
@@ -95,7 +95,7 @@ func (v *FieldValue) Reduce() types.XPrimitive {
 	return v.TypedValue().Reduce()
 }
 
-func (v *FieldValue) ToJSON() types.XString { return types.NewXString("TODO") }
+func (v *FieldValue) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*FieldValue)(nil)
 var _ types.XResolvable = (*FieldValue)(nil)
@@ -157,7 +157,7 @@ func (f FieldValues) Reduce() types.XPrimitive {
 	return values
 }
 
-func (f FieldValues) ToJSON() types.XString { return types.NewXString("TODO") }
+func (f FieldValues) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (FieldValues)(nil)
 var _ types.XLengthable = (FieldValues)(nil)

--- a/flows/group.go
+++ b/flows/group.go
@@ -77,7 +77,7 @@ func (g *Group) Resolve(key string) types.XValue {
 // Reduce is called when this object needs to be reduced to a primitive
 func (g *Group) Reduce() types.XPrimitive { return types.NewXString(g.name) }
 
-func (g *Group) ToJSON() types.XString { return types.NewXString("TODO") }
+func (g *Group) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*Group)(nil)
 var _ types.XResolvable = (*Group)(nil)
@@ -158,7 +158,7 @@ func (l GroupList) Reduce() types.XPrimitive {
 	return array
 }
 
-func (l GroupList) ToJSON() types.XString { return types.NewXString("TODO") }
+func (l GroupList) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*GroupList)(nil)
 var _ types.XIndexable = (*GroupList)(nil)

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -60,7 +60,7 @@ func (i *MsgInput) Reduce() types.XPrimitive {
 	return types.NewXString(strings.Join(parts, "\n"))
 }
 
-func (i *MsgInput) ToJSON() types.XString { return types.NewXString("TODO") }
+func (i *MsgInput) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*MsgInput)(nil)
 var _ types.XResolvable = (*MsgInput)(nil)

--- a/flows/locations.go
+++ b/flows/locations.go
@@ -50,7 +50,7 @@ func (b *Location) Children() []*Location { return b.children }
 // Reduce is called when this object needs to be reduced to a primitive
 func (b *Location) Reduce() types.XPrimitive { return types.NewXString(b.name) }
 
-func (b *Location) ToJSON() types.XString { return types.NewXString("TODO") }
+func (b *Location) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*Location)(nil)
 

--- a/flows/results.go
+++ b/flows/results.go
@@ -45,7 +45,7 @@ func (r *Result) Reduce() types.XPrimitive {
 	return types.NewXString(r.Value)
 }
 
-func (r *Result) ToJSON() types.XString { return types.MustMarshalToXString(r.Value) }
+func (r *Result) ToXJSON() types.XString { return types.MustMarshalToXString(r.Value) }
 
 var _ types.XValue = (*Result)(nil)
 var _ types.XResolvable = (*Result)(nil)
@@ -105,7 +105,7 @@ func (r Results) Reduce() types.XPrimitive {
 	return results
 }
 
-func (r Results) ToJSON() types.XString { return types.NewXString("TODO") }
+func (r Results) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (Results)(nil)
 var _ types.XLengthable = (Results)(nil)

--- a/flows/routers/tests/result.go
+++ b/flows/routers/tests/result.go
@@ -32,7 +32,7 @@ func (t XTestResult) Reduce() types.XPrimitive {
 	return types.NewXBool(t.matched)
 }
 
-func (t XTestResult) ToJSON() types.XString { return types.NewXString("TODO") }
+func (t XTestResult) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 // XFalseResult can be used as a singleton for false result values
 var XFalseResult = XTestResult{}

--- a/flows/routers/tests/tests.go
+++ b/flows/routers/tests/tests.go
@@ -340,7 +340,7 @@ func (m *patternMatch) Reduce() types.XPrimitive {
 	return m.groups.Index(0).(types.XString)
 }
 
-func (m *patternMatch) ToJSON() types.XString { return types.NewXString("TODO") }
+func (m *patternMatch) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*patternMatch)(nil)
 var _ types.XResolvable = (*patternMatch)(nil)

--- a/flows/routers/tests/tests_test.go
+++ b/flows/routers/tests/tests_test.go
@@ -38,7 +38,7 @@ func (r *testResolvable) Reduce() types.XPrimitive {
 	return types.NewXString("hello")
 }
 
-func (r *testResolvable) ToJSON() types.XString { return types.NewXString("TODO") }
+func (r *testResolvable) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var testTests = []struct {
 	name     string

--- a/flows/runs/context.go
+++ b/flows/runs/context.go
@@ -39,7 +39,7 @@ func (c *runContext) Reduce() types.XPrimitive {
 	return types.NewXString(c.run.UUID().String())
 }
 
-func (c *runContext) ToJSON() types.XString { return types.NewXString("TODO") }
+func (c *runContext) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*runContext)(nil)
 var _ types.XResolvable = (*runContext)(nil)
@@ -79,7 +79,7 @@ func (c *relatedRunContext) Reduce() types.XPrimitive {
 	return types.NewXString(c.run.UUID().String())
 }
 
-func (c *relatedRunContext) ToJSON() types.XString { return types.NewXString("TODO") }
+func (c *relatedRunContext) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*relatedRunContext)(nil)
 var _ types.XResolvable = (*relatedRunContext)(nil)

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -284,7 +284,7 @@ func (r *flowRun) Reduce() types.XPrimitive {
 	return types.NewXString(string(r.uuid))
 }
 
-func (r *flowRun) ToJSON() types.XString { return types.NewXString("TODO") }
+func (r *flowRun) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 func (r *flowRun) Snapshot() flows.RunSummary {
 	return flows.NewRunSummaryFromRun(r)

--- a/flows/triggers/base.go
+++ b/flows/triggers/base.go
@@ -37,7 +37,7 @@ func (t *baseTrigger) Reduce() types.XPrimitive {
 	return types.NewXString(string(t.flow.UUID()))
 }
 
-func (t *baseTrigger) ToJSON() types.XString { return types.NewXString("TODO") }
+func (t *baseTrigger) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*baseTrigger)(nil)
 var _ types.XResolvable = (*baseTrigger)(nil)

--- a/flows/urns.go
+++ b/flows/urns.go
@@ -63,7 +63,7 @@ func (u *ContactURN) Resolve(key string) types.XValue {
 // Reduce is called when this object needs to be reduced to a primitive
 func (u *ContactURN) Reduce() types.XPrimitive { return types.NewXString(string(u.URN)) }
 
-func (u *ContactURN) ToJSON() types.XString { return types.NewXString("TODO") }
+func (u *ContactURN) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*ContactURN)(nil)
 var _ types.XResolvable = (*ContactURN)(nil)
@@ -156,7 +156,7 @@ func (l URNList) Reduce() types.XPrimitive {
 	return array
 }
 
-func (l URNList) ToJSON() types.XString { return types.NewXString("TODO") }
+func (l URNList) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 // Index is called when this object is indexed into in an expression
 func (l URNList) Index(index int) types.XValue {

--- a/flows/webhook.go
+++ b/flows/webhook.go
@@ -108,7 +108,7 @@ func (w *WebhookCall) Reduce() types.XPrimitive {
 	return types.NewXString(w.body)
 }
 
-func (w *WebhookCall) ToJSON() types.XString { return types.NewXString("TODO") }
+func (w *WebhookCall) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 var _ types.XValue = (*WebhookCall)(nil)
 var _ types.XResolvable = (*WebhookCall)(nil)

--- a/legacy/expressions.go
+++ b/legacy/expressions.go
@@ -123,7 +123,7 @@ func (v *varMapper) Reduce() types.XPrimitive {
 }
 
 // Reduce is called when this object needs to be reduced to a primitive
-func (v *varMapper) ToJSON() types.XString { return types.NewXString("TODO") }
+func (v *varMapper) ToXJSON() types.XString { return types.NewXString("TODO") }
 
 func (v *varMapper) String() string {
 	sub, exists := v.substitutions["__default__"]


### PR DESCRIPTION
An `XValue` can have two different JSON representations:

 1. our internal representation, created via the usual json.Marshal methods
 2. the public representation returned from `@(to_json(...))`