### PR TITLE
Make XTypes Stringify (%s) same as their XString

### DIFF
--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -2,7 +2,6 @@ package excellent
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -262,7 +261,7 @@ func TestEvaluateTemplate(t *testing.T) {
 	}
 
 	for _, test := range evaluateTests {
-		eval, err := EvaluateTemplate(env, vars, test.template, vars.Keys())
+		result, err := EvaluateTemplate(env, vars, test.template, vars.Keys())
 
 		if test.hasError {
 			assert.Error(t, err, "expected error evaluating template '%s'", test.template)
@@ -271,20 +270,12 @@ func TestEvaluateTemplate(t *testing.T) {
 			assert.NoError(t, err, "unexpected error evaluating template '%s'", test.template)
 		}
 
-		// first try reflect comparison
-		equal := reflect.DeepEqual(eval, test.expected)
-
-		// back down to our equality
-		if !equal {
-			cmp, err := types.Compare(eval, test.expected)
-			if err != nil {
-				t.Errorf("Actual '%#v' does not match expected '%#v' evaluating template: '%s'", eval, test.expected, test.template)
-			}
-			equal = cmp == 0
+		cmp, err := types.Compare(result, test.expected)
+		if err != nil {
+			assert.Fail(t, err.Error(), "error while comparing expected: %T{%s} with result: %T{%s}: err", test.expected, test.expected, result, result, err)
 		}
-
-		if !equal {
-			t.Errorf("Actual '%#v' does not match expected '%#v' evaluating template: '%s'", eval, test.expected, test.template)
+		if cmp != 0 {
+			assert.Fail(t, "", "unexpected value, expected %T{%s}, got %T{%s} for function %s(%#v)", test.expected, test.expected, result, result, test.template)
 		}
 	}
 }

--- a/excellent/functions/functions.go
+++ b/excellent/functions/functions.go
@@ -260,7 +260,7 @@ func And(env utils.Environment, args ...types.XValue) types.XValue {
 		if err != nil {
 			return err
 		}
-		if !asBool {
+		if !asBool.Native() {
 			return types.XBoolFalse
 		}
 	}
@@ -283,7 +283,7 @@ func Or(env utils.Environment, args ...types.XValue) types.XValue {
 		if err != nil {
 			return err
 		}
-		if asBool {
+		if asBool.Native() {
 			return types.XBoolTrue
 		}
 	}
@@ -304,7 +304,7 @@ func If(env utils.Environment, test types.XValue, arg1 types.XValue, arg2 types.
 		return err
 	}
 
-	if asBool {
+	if asBool.Native() {
 		return arg1
 	}
 	return arg2
@@ -544,7 +544,7 @@ func FormatNum(env utils.Environment, args ...types.XValue) types.XValue {
 
 	// build our format string
 	formatStr := bytes.Buffer{}
-	if commas {
+	if commas.Native() {
 		formatStr.WriteString("#,###.")
 	} else {
 		formatStr.WriteString("####.")
@@ -578,7 +578,7 @@ func ReadCode(env utils.Environment, val types.XString) types.XValue {
 	// remove any leading +
 	val = types.NewXString(strings.TrimLeft(val.Native(), "+"))
 
-	length := len(val)
+	length := val.Length()
 
 	// groups of three
 	if length%3 == 0 {
@@ -604,7 +604,7 @@ func ReadCode(env utils.Environment, val types.XString) types.XValue {
 	}
 
 	// default, just do one at a time
-	for i, c := range val {
+	for i, c := range val.Native() {
 		if i > 0 {
 			output.WriteString(" , ")
 		}
@@ -1461,7 +1461,7 @@ func FormatURN(env utils.Environment, args ...types.XValue) types.XValue {
 		return xerr
 	}
 
-	urn := urns.URN(urnString)
+	urn := urns.URN(urnString.Native())
 	err := urn.Validate()
 	if err != nil {
 		return types.NewXErrorf("%s is not a valid URN: %s", urnString, err)

--- a/excellent/functions/functions_test.go
+++ b/excellent/functions/functions_test.go
@@ -338,10 +338,10 @@ func TestFunctions(t *testing.T) {
 
 		cmp, err := types.Compare(result, test.expected)
 		if err != nil {
-			assert.Fail(t, err.Error(), "error while comparing expected: '%s' with result: '%s': %v for function %s(%#v)", test.expected, result, err, test.name, test.args)
+			assert.Fail(t, err.Error(), "error while comparing expected: %T{%s} with result: %T{%s}: err", test.expected, test.expected, result, result, err)
 		}
 		if cmp != 0 {
-			assert.Fail(t, "", "unexpected value, expected '%v', got '%v' for function %s(%#v)", test.expected, result, test.name, test.args)
+			assert.Fail(t, "", "unexpected value, expected %T{%s}, got %T{%s} for function %s(%#v)", test.expected, test.expected, result, result, test.name, test.args)
 		}
 	}
 }

--- a/excellent/types/array.go
+++ b/excellent/types/array.go
@@ -13,6 +13,8 @@ type XArray interface {
 }
 
 type xarray struct {
+	baseXPrimitive
+
 	values []XValue
 }
 
@@ -38,7 +40,7 @@ func (a *xarray) ToXString() XString {
 
 // ToXBool converts this type to a bool
 func (a *xarray) ToXBool() XBool {
-	return len(a.values) > 0
+	return NewXBool(len(a.values) > 0)
 }
 
 // ToXJSON is called when this type is passed to @(to_json(...))
@@ -47,7 +49,7 @@ func (a *xarray) ToXJSON() XString {
 	for i, v := range a.values {
 		asJSON, err := ToXJSON(v)
 		if err == nil {
-			marshaled[i] = json.RawMessage(asJSON)
+			marshaled[i] = json.RawMessage(asJSON.Native())
 		}
 	}
 	return MustMarshalToXString(marshaled)

--- a/excellent/types/base.go
+++ b/excellent/types/base.go
@@ -62,14 +62,14 @@ func Compare(x1 XValue, x2 XValue) (int, error) {
 	if utils.IsNil(x1) && utils.IsNil(x2) {
 		return 0, nil
 	} else if utils.IsNil(x1) || utils.IsNil(x2) {
-		return 0, fmt.Errorf("can't compare non-nil and nil values: %s and %s", x1, x2)
+		return 0, fmt.Errorf("can't compare non-nil and nil values: %T{%s} and %T{%s}", x1, x1, x2, x2)
 	}
 
 	x1 = x1.Reduce()
 	x2 = x2.Reduce()
 
 	if reflect.TypeOf(x1) != reflect.TypeOf(x2) {
-		return 0, fmt.Errorf("can't compare different types of %#v and %#v", x1, x2)
+		return 0, fmt.Errorf("can't compare different types of %T and %T", x1, x2)
 	}
 
 	// common types, do real comparisons

--- a/excellent/types/base.go
+++ b/excellent/types/base.go
@@ -40,6 +40,14 @@ type XIndexable interface {
 	Index(index int) XValue
 }
 
+type baseXPrimitive struct {
+	XPrimitive
+}
+
+func (x *baseXPrimitive) String() string {
+	return x.ToXString().Native()
+}
+
 // ResolveKeys is a utility function that resolves multiple keys on an XResolvable and returns the results as a map
 func ResolveKeys(resolvable XResolvable, keys ...string) XMap {
 	values := make(map[string]XValue, len(keys))
@@ -54,7 +62,7 @@ func Compare(x1 XValue, x2 XValue) (int, error) {
 	if utils.IsNil(x1) && utils.IsNil(x2) {
 		return 0, nil
 	} else if utils.IsNil(x1) || utils.IsNil(x2) {
-		return 0, fmt.Errorf("can't compare non-nil and nil values: %v and %v", x1, x2)
+		return 0, fmt.Errorf("can't compare non-nil and nil values: %s and %s", x1, x2)
 	}
 
 	x1 = x1.Reduce()
@@ -79,5 +87,5 @@ func Compare(x1 XValue, x2 XValue) (int, error) {
 	}
 
 	// TODO: find better fallback
-	return strings.Compare(fmt.Sprintf("%v", x1), fmt.Sprintf("%v", x2)), nil
+	return strings.Compare(x1.ToXJSON().Native(), x2.ToXJSON().Native()), nil
 }

--- a/excellent/types/bool.go
+++ b/excellent/types/bool.go
@@ -1,15 +1,20 @@
 package types
 
 import (
+	"encoding/json"
 	"strconv"
 )
 
 // XBool is a boolean true or false
-type XBool bool
+type XBool struct {
+	baseXPrimitive
+
+	native bool
+}
 
 // NewXBool creates a new XBool
 func NewXBool(value bool) XBool {
-	return XBool(value)
+	return XBool{native: value}
 }
 
 // Reduce returns the primitive version of this type (i.e. itself)
@@ -25,7 +30,7 @@ func (x XBool) ToXBool() XBool { return x }
 func (x XBool) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 
 // Native returns the native value of this type
-func (x XBool) Native() bool { return bool(x) }
+func (x XBool) Native() bool { return x.native }
 
 // Compare compares this bool to another
 func (x XBool) Compare(other XBool) int {
@@ -37,6 +42,16 @@ func (x XBool) Compare(other XBool) int {
 	default:
 		return 0
 	}
+}
+
+// MarshalJSON is called when a struct containing this type is marshaled
+func (x XBool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(x.Native())
+}
+
+// UnmarshalJSON is called when a struct containing this type is unmarshaled
+func (x *XBool) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &x.native)
 }
 
 // XBoolFalse is the false boolean value

--- a/excellent/types/conversions.go
+++ b/excellent/types/conversions.go
@@ -52,7 +52,7 @@ func ToXBool(x XValue) (XBool, XError) {
 
 	lengthable, isLengthable := x.(XLengthable)
 	if isLengthable {
-		return lengthable.Length() > 0, nil
+		return NewXBool(lengthable.Length() > 0), nil
 	}
 
 	return x.Reduce().ToXBool(), nil
@@ -101,7 +101,7 @@ func ToXDate(env utils.Environment, x XValue) (XDate, XError) {
 		}
 	}
 
-	return XDateZero, NewXErrorf("unable to convert value '%v' of type '%s' to a date", x, reflect.TypeOf(x))
+	return XDateZero, NewXErrorf("unable to convert value '%s' of type '%s' to a date", x, reflect.TypeOf(x))
 }
 
 // ToInteger tries to convert the passed in value to an integer or returns an error if that isn't possible
@@ -114,7 +114,7 @@ func ToInteger(x XValue) (int, XError) {
 	intPart := number.Native().IntPart()
 
 	if intPart < math.MinInt32 && intPart > math.MaxInt32 {
-		return 0, NewXErrorf("number value %s is out of range for an integer", string(number.ToXString()))
+		return 0, NewXErrorf("number value %s is out of range for an integer", number.ToXString().Native())
 	}
 
 	return int(intPart), nil
@@ -124,9 +124,9 @@ func ToInteger(x XValue) (int, XError) {
 func MustMarshalToXString(x interface{}) XString {
 	j, err := json.Marshal(x)
 	if err != nil {
-		panic(fmt.Sprintf("unable to marshal %v to JSON", x))
+		panic(fmt.Sprintf("unable to marshal %s to JSON", x))
 	}
-	return XString(j)
+	return NewXString(string(j))
 }
 
 func parseDecimalFuzzy(val string) (decimal.Decimal, error) {

--- a/excellent/types/conversions_test.go
+++ b/excellent/types/conversions_test.go
@@ -207,10 +207,10 @@ func TestXValueRequiredConversions(t *testing.T) {
 		asString, _ := types.ToXString(test.value)
 		asBool, _ := types.ToXBool(test.value)
 
-		assert.Equal(t, test.asInternalJSON, string(asInternalJSON), "json.Marshal failed for %s", test.value)
-		assert.Equal(t, types.NewXString(test.asJSON), asJSON, "ToXJSON failed for %s", test.value)
-		assert.Equal(t, types.NewXString(test.asString), asString, "ToXString failed for %s", test.value)
-		assert.Equal(t, types.NewXBool(test.asBool), asBool, "ToXBool failed for %s", test.value)
+		assert.Equal(t, test.asInternalJSON, string(asInternalJSON), "json.Marshal failed for %T{%s}", test.value, test.value)
+		assert.Equal(t, types.NewXString(test.asJSON), asJSON, "ToXJSON failed for %T{%s}", test.value, test.value)
+		assert.Equal(t, types.NewXString(test.asString), asString, "ToXString failed for %T{%s}", test.value, test.value)
+		assert.Equal(t, types.NewXBool(test.asBool), asBool, "ToXBool failed for %T{%s}", test.value, test.value)
 	}
 }
 
@@ -233,10 +233,10 @@ func TestToXNumber(t *testing.T) {
 		result, err := types.ToXNumber(test.value)
 
 		if test.hasError {
-			assert.Error(t, err, "expected error for input '%s'", test.value)
+			assert.Error(t, err, "expected error for input %T{%s}", test.value, test.value)
 		} else {
-			assert.NoError(t, err, "unexpected error for input '%s'", test.value)
-			assert.Equal(t, test.asNumber.Native(), result.Native(), "result mismatch for input '%+v'", test.value)
+			assert.NoError(t, err, "unexpected error for input %T{%s}", test.value, test.value)
+			assert.Equal(t, test.asNumber.Native(), result.Native(), "result mismatch for input %T{%s}", test.value, test.value)
 		}
 	}
 }
@@ -262,10 +262,10 @@ func TestToXDate(t *testing.T) {
 		result, err := types.ToXDate(env, test.value)
 
 		if test.hasError {
-			assert.Error(t, err, "expected error for input '%s'", test.value)
+			assert.Error(t, err, "expected error for input %T{%s}", test.value, test.value)
 		} else {
-			assert.NoError(t, err, "unexpected error for input '%s'", test.value)
-			assert.Equal(t, test.asNumber.Native(), result.Native(), "result mismatch for input '%+v'", test.value)
+			assert.NoError(t, err, "unexpected error for input %T{%s}", test.value, test.value)
+			assert.Equal(t, test.asNumber.Native(), result.Native(), "result mismatch for input %T{%s}", test.value, test.value)
 		}
 	}
 }

--- a/excellent/types/date.go
+++ b/excellent/types/date.go
@@ -7,27 +7,31 @@ import (
 )
 
 // XDate is a date
-type XDate time.Time
+type XDate struct {
+	baseXPrimitive
+
+	native time.Time
+}
 
 // NewXDate creates a new date
 func NewXDate(value time.Time) XDate {
-	return XDate(value)
+	return XDate{native: value}
 }
 
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x XDate) Reduce() XPrimitive { return x }
 
 // ToXString converts this type to a string
-func (x XDate) ToXString() XString { return XString(utils.DateToISO(x.Native())) }
+func (x XDate) ToXString() XString { return NewXString(utils.DateToISO(x.Native())) }
 
 // ToXBool converts this type to a bool
-func (x XDate) ToXBool() XBool { return XBool(!x.Native().IsZero()) }
+func (x XDate) ToXBool() XBool { return NewXBool(!x.Native().IsZero()) }
 
 // ToXJSON is called when this type is passed to @(to_json(...))
 func (x XDate) ToXJSON() XString { return MustMarshalToXString(utils.DateToISO(x.Native())) }
 
 // Native returns the native value of this type
-func (x XDate) Native() time.Time { return time.Time(x) }
+func (x XDate) Native() time.Time { return x.native }
 
 // Compare compares this date to another
 func (x XDate) Compare(other XDate) int {
@@ -43,13 +47,12 @@ func (x XDate) Compare(other XDate) int {
 
 // MarshalJSON is called when a struct containing this type is marshaled
 func (x XDate) MarshalJSON() ([]byte, error) {
-	nativePtr := (time.Time)(x)
-	return nativePtr.MarshalJSON()
+	return x.Native().MarshalJSON()
 }
 
 // UnmarshalJSON is called when a struct containing this type is unmarshaled
 func (x *XDate) UnmarshalJSON(data []byte) error {
-	nativePtr := (*time.Time)(x)
+	nativePtr := &x.native
 	return nativePtr.UnmarshalJSON(data)
 }
 

--- a/excellent/types/error.go
+++ b/excellent/types/error.go
@@ -11,12 +11,14 @@ type XError interface {
 }
 
 type xerror struct {
-	err error
+	baseXPrimitive
+
+	native error
 }
 
 // NewXError creates a new XError
 func NewXError(err error) XError {
-	return xerror{err: err}
+	return xerror{native: err}
 }
 
 // NewXErrorf creates a new XError
@@ -33,10 +35,10 @@ func NewXResolveError(resolvable XResolvable, key string) XError {
 func (x xerror) Reduce() XPrimitive { return x }
 
 // ToXString converts this type to a string
-func (x xerror) ToXString() XString { return XString(x.Native().Error()) }
+func (x xerror) ToXString() XString { return NewXString(x.Native().Error()) }
 
 // ToXBool converts this type to a bool
-func (x xerror) ToXBool() XBool { return XBool(false) }
+func (x xerror) ToXBool() XBool { return XBoolFalse }
 
 // ToXJSON is called when this type is passed to @(to_json(...))
 func (x xerror) ToXJSON() XString { return MustMarshalToXString(x.Native().Error()) }
@@ -47,10 +49,9 @@ func (x xerror) MarshalJSON() ([]byte, error) {
 }
 
 // Native returns the native value of this type
-func (x xerror) Native() error { return x.err }
+func (x xerror) Native() error { return x.native }
 
-func (x xerror) Error() string  { return x.err.Error() }
-func (x xerror) String() string { return x.Native().Error() }
+func (x xerror) Error() string { return x.Native().Error() }
 
 // NilXError is the nil error value
 var NilXError = NewXError(nil)

--- a/excellent/types/json.go
+++ b/excellent/types/json.go
@@ -15,6 +15,11 @@ func (x XJSON) ToXJSON() XString { return NewXString(string(x)) }
 
 func (x XJSON) Reduce() XPrimitive { return x.ToXJSON() }
 
+// String converts this type to native string
+func (x XJSON) String() string {
+	return string(x)
+}
+
 func (x XJSON) MarshalJSON() ([]byte, error) {
 	return []byte(x), nil
 }

--- a/excellent/types/map.go
+++ b/excellent/types/map.go
@@ -15,6 +15,8 @@ type XMap interface {
 }
 
 type xmap struct {
+	baseXPrimitive
+
 	values map[string]XValue
 }
 
@@ -46,7 +48,7 @@ func (m *xmap) ToXString() XString {
 
 // ToXBool converts this type to a bool
 func (m *xmap) ToXBool() XBool {
-	return len(m.values) > 0
+	return NewXBool(len(m.values) > 0)
 }
 
 // ToXJSON is called when this type is passed to @(to_json(...))
@@ -55,7 +57,7 @@ func (m *xmap) ToXJSON() XString {
 	for k, v := range m.values {
 		asJSON, err := ToXJSON(v)
 		if err == nil {
-			marshaled[k] = json.RawMessage(asJSON)
+			marshaled[k] = json.RawMessage(asJSON.Native())
 		}
 	}
 	return MustMarshalToXString(marshaled)

--- a/excellent/types/number.go
+++ b/excellent/types/number.go
@@ -9,42 +9,46 @@ func init() {
 }
 
 // XNumber is any whole or fractional number
-type XNumber decimal.Decimal
+type XNumber struct {
+	baseXPrimitive
+
+	native decimal.Decimal
+}
 
 // NewXNumber creates a new XNumber
 func NewXNumber(value decimal.Decimal) XNumber {
-	return XNumber(value)
+	return XNumber{native: value}
 }
 
 // NewXNumberFromInt creates a new XNumber from the given int
 func NewXNumberFromInt(value int) XNumber {
-	return XNumber(decimal.New(int64(value), 0))
+	return NewXNumber(decimal.New(int64(value), 0))
 }
 
 // NewXNumberFromInt64 creates a new XNumber from the given int
 func NewXNumberFromInt64(value int64) XNumber {
-	return XNumber(decimal.New(value, 0))
+	return NewXNumber(decimal.New(value, 0))
 }
 
 // RequireXNumberFromString creates a new XNumber from the given string
 func RequireXNumberFromString(value string) XNumber {
-	return XNumber(decimal.RequireFromString(value))
+	return NewXNumber(decimal.RequireFromString(value))
 }
 
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x XNumber) Reduce() XPrimitive { return x }
 
 // ToXString converts this type to a string
-func (x XNumber) ToXString() XString { return XString(x.Native().String()) }
+func (x XNumber) ToXString() XString { return NewXString(x.Native().String()) }
 
 // ToXBool converts this type to a bool
-func (x XNumber) ToXBool() XBool { return XBool(!x.Native().Equals(decimal.Zero)) }
+func (x XNumber) ToXBool() XBool { return NewXBool(!x.Native().Equals(decimal.Zero)) }
 
 // ToXJSON is called when this type is passed to @(to_json(...))
 func (x XNumber) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 
 // Native returns the native value of this type
-func (x XNumber) Native() decimal.Decimal { return decimal.Decimal(x) }
+func (x XNumber) Native() decimal.Decimal { return x.native }
 
 // Compare compares this number to another
 func (x XNumber) Compare(other XNumber) int {
@@ -53,16 +57,15 @@ func (x XNumber) Compare(other XNumber) int {
 
 // MarshalJSON is called when a struct containing this type is marshaled
 func (x XNumber) MarshalJSON() ([]byte, error) {
-	nativePtr := (decimal.Decimal)(x)
-	return nativePtr.MarshalJSON()
+	return x.Native().MarshalJSON()
 }
 
 // UnmarshalJSON is called when a struct containing this type is unmarshaled
 func (x *XNumber) UnmarshalJSON(data []byte) error {
-	nativePtr := (*decimal.Decimal)(x)
+	nativePtr := &x.native
 	return nativePtr.UnmarshalJSON(data)
 }
 
 // XNumberZero is the zero number value
-var XNumberZero = XNumber(decimal.Zero)
+var XNumberZero = NewXNumber(decimal.Zero)
 var _ XPrimitive = XNumberZero

--- a/excellent/types/number.go
+++ b/excellent/types/number.go
@@ -42,13 +42,18 @@ func (x XNumber) Reduce() XPrimitive { return x }
 func (x XNumber) ToXString() XString { return NewXString(x.Native().String()) }
 
 // ToXBool converts this type to a bool
-func (x XNumber) ToXBool() XBool { return NewXBool(!x.Native().Equals(decimal.Zero)) }
+func (x XNumber) ToXBool() XBool { return NewXBool(!x.Equals(XNumberZero)) }
 
 // ToXJSON is called when this type is passed to @(to_json(...))
 func (x XNumber) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 
 // Native returns the native value of this type
 func (x XNumber) Native() decimal.Decimal { return x.native }
+
+// Equals determines equality for this type
+func (x XNumber) Equals(other XNumber) bool {
+	return x.Native().Equals(other.Native())
+}
 
 // Compare compares this number to another
 func (x XNumber) Compare(other XNumber) int {

--- a/excellent/types/string.go
+++ b/excellent/types/string.go
@@ -40,6 +40,11 @@ func (x XString) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 // Native returns the native value of this type
 func (x XString) Native() string { return x.native }
 
+// Equals determines equality for this type
+func (x XString) Equals(other XString) bool {
+	return x.Native() == other.Native()
+}
+
 // Compare compares this string to another
 func (x XString) Compare(other XString) int {
 	return strings.Compare(x.Native(), other.Native())

--- a/excellent/types/string.go
+++ b/excellent/types/string.go
@@ -1,32 +1,44 @@
 package types
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
 
 // XString is a string of characters
-type XString string
+type XString struct {
+	baseXPrimitive
+
+	native string
+}
 
 // NewXString creates a new XString
 func NewXString(value string) XString {
-	return XString(value)
+	return XString{native: value}
 }
 
 // Reduce returns the primitive version of this type (i.e. itself)
 func (x XString) Reduce() XPrimitive { return x }
 
+// String converts this type to native string
+func (x XString) String() string {
+	return x.Native()
+}
+
 // ToXString converts this type to a string
 func (x XString) ToXString() XString { return x }
 
 // ToXBool converts this type to a bool
-func (x XString) ToXBool() XBool { return string(x) != "" && strings.ToLower(string(x)) != "false" }
+func (x XString) ToXBool() XBool {
+	return NewXBool(!x.Empty() && strings.ToLower(x.Native()) != "false")
+}
 
 // ToXJSON is called when this type is passed to @(to_json(...))
 func (x XString) ToXJSON() XString { return MustMarshalToXString(x.Native()) }
 
 // Native returns the native value of this type
-func (x XString) Native() string { return string(x) }
+func (x XString) Native() string { return x.native }
 
 // Compare compares this string to another
 func (x XString) Compare(other XString) int {
@@ -35,6 +47,19 @@ func (x XString) Compare(other XString) int {
 
 // Length returns the length of this string
 func (x XString) Length() int { return utf8.RuneCountInString(x.Native()) }
+
+// Empty returns whether this is an empty string
+func (x XString) Empty() bool { return x.Native() == "" }
+
+// MarshalJSON is called when a struct containing this type is marshaled
+func (x XString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(x.Native())
+}
+
+// UnmarshalJSON is called when a struct containing this type is unmarshaled
+func (x *XString) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &x.native)
+}
 
 // XStringEmpty is the empty string value
 var XStringEmpty = NewXString("")

--- a/excellent/visitor.go
+++ b/excellent/visitor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/nyaruka/goflow/utils"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	"github.com/shopspring/decimal"
 )
 
 type Visitor struct {
@@ -256,7 +255,7 @@ func (v *Visitor) VisitMultiplicationOrDivision(ctx *gen.MultiplicationOrDivisio
 	}
 
 	// division!
-	if num2.Native().Equals(decimal.Zero) {
+	if num2.Equals(types.XNumberZero) {
 		return types.NewXErrorf("division by zero")
 	}
 

--- a/flows/fields.go
+++ b/flows/fields.go
@@ -56,7 +56,7 @@ type FieldValue struct {
 }
 
 func (v *FieldValue) IsEmpty() bool {
-	return !(v.text != "" || v.datetime != nil || v.decimal != nil || v.state != nil || v.district != nil || v.ward != nil)
+	return !(!v.text.Empty() || v.datetime != nil || v.decimal != nil || v.state != nil || v.district != nil || v.ward != nil)
 }
 
 func (v *FieldValue) TypedValue() types.XValue {

--- a/flows/routers/tests/tests.go
+++ b/flows/routers/tests/tests.go
@@ -175,7 +175,7 @@ func HasGroup(env utils.Environment, arg1 types.XValue, arg2 types.XValue) types
 	}
 
 	// iterate through the groups looking for one with the same UUID as passed in
-	group := contact.Groups().FindByUUID(flows.GroupUUID(groupUUID))
+	group := contact.Groups().FindByUUID(flows.GroupUUID(groupUUID.Native()))
 	if group != nil {
 		return XTestResult{true, group}
 	}
@@ -254,7 +254,7 @@ func HasText(env utils.Environment, str types.XString) types.XValue {
 	str = types.NewXString(strings.TrimSpace(str.Native()))
 
 	// if there is anything left then we have text
-	if len(str) > 0 {
+	if str.Length() > 0 {
 		return XTestResult{true, str}
 	}
 
@@ -620,7 +620,7 @@ func HasDistrict(env utils.Environment, args ...types.XValue) types.XValue {
 	}
 
 	// try without a parent state - it's ok as long as we get a single match
-	if stateText == "" {
+	if stateText.Empty() {
 		districts, err := runEnv.FindLocationsFuzzy(text.Native(), flows.LocationLevel(2), nil)
 		if err != nil {
 			return types.NewXError(err)
@@ -688,7 +688,7 @@ func HasWard(env utils.Environment, args ...types.XValue) types.XValue {
 	}
 
 	// try without a parent district - it's ok as long as we get a single match
-	if districtText == "" {
+	if districtText.Empty() {
 		wards, err := runEnv.FindLocationsFuzzy(text.Native(), flows.LocationLevel(3), nil)
 		if err != nil {
 			return types.NewXError(err)

--- a/flows/routers/tests/tests.go
+++ b/flows/routers/tests/tests.go
@@ -84,7 +84,7 @@ var XTESTS = map[string]functions.XFunction{
 //
 // @test is_string_eq(string, string)
 func IsStringEQ(env utils.Environment, str1 types.XString, str2 types.XString) types.XValue {
-	if str1.Native() == str2.Native() {
+	if str1.Equals(str2) {
 		return XTestResult{true, str1}
 	}
 


### PR DESCRIPTION
So that test output is like `types.XDate{2017-12-01T00:00:00.000000Z}` instead of `types.XDate{wall:0x0, ext:63647683200, loc:(*time.Location)(nil)}`

This PR introduces a base struct to X primitives so they need to become structs instead of type aliases. That means you have to be explicit about calling `.Native()` to get the underlying native value, but I think I prefer that over it sometimes working without that.