### PR TITLE
Support channels with UUIDs which aren't UUID4

### DIFF
--- a/flows/channel.go
+++ b/flows/channel.go
@@ -175,7 +175,7 @@ func (s *ChannelSet) FindByUUID(uuid ChannelUUID) Channel {
 //------------------------------------------------------------------------------------------
 
 type channelEnvelope struct {
-	UUID    ChannelUUID   `json:"uuid" validate:"required,uuid4"`
+	UUID    ChannelUUID   `json:"uuid" validate:"required,uuid"`
 	Name    string        `json:"name"`
 	Address string        `json:"address"`
 	Schemes []string      `json:"schemes" validate:"min=1"`

--- a/flows/channel_test.go
+++ b/flows/channel_test.go
@@ -33,3 +33,12 @@ func TestChannelSetGetForURN(t *testing.T) {
 	// explicit channel with URN
 	assert.Equal(t, set.GetForURN(flows.NewContactURN(urns.URN("tel:+250962222222"), nexmo)), nexmo)
 }
+
+func TestChannelUnmarsal(t *testing.T) {
+	// check that UUIDs aren't required to be valid UUID4s
+	channel, err := flows.ReadChannel([]byte(`{"uuid": "ffffffff-9b24-92e1-ffff-ffffb207cdb4", "name": "Old Channel", "schemes": ["tel"], "roles": ["send"]}`))
+	assert.NoError(t, err)
+	assert.Equal(t, flows.ChannelUUID("ffffffff-9b24-92e1-ffff-ffffb207cdb4"), channel.UUID())
+	assert.Equal(t, "Old Channel", channel.Name())
+	assert.Equal(t, []flows.ChannelRole{flows.ChannelRoleSend}, channel.Roles())
+}


### PR DESCRIPTION
https://sentry.io/nyaruka/textit/issues/542055954/

Some old relayer channels have janky UUIDs 