### PR TITLE
Expression migrating fixes

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -514,12 +514,11 @@ Returns the rune for the passed in codepoint, `num`, which may be unicode, this 
 
 ## clean(text)
 
-Strips any leading or trailing whitespace from `text`
+Strips any non-printable characters from `text`
 
 
 ```objectivec
-@(clean("\nfoo\t")) → foo
-@(clean(" bar")) → bar
+@(clean("😃 Hello \nwo\tr\rld")) → 😃 Hello world
 @(clean(123)) → 123
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -516,10 +516,9 @@
 <a class="sourceLine" id="cb22-3" data-line-number="3">@(<span class="dt">char</span>(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:clean"></a></p>
 <h2 id="cleantext">clean(text)</h2>
-<p>Strips any leading or trailing whitespace from <code>text</code></p>
-<div class="sourceCode" id="cb23"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb23-1" data-line-number="1">@(clean(<span class="st">&quot;</span><span class="sc">\n</span><span class="st">foo</span><span class="sc">\t</span><span class="st">&quot;</span>)) → foo</a>
-<a class="sourceLine" id="cb23-2" data-line-number="2">@(clean(<span class="st">&quot; bar&quot;</span>)) → bar</a>
-<a class="sourceLine" id="cb23-3" data-line-number="3">@(clean(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
+<p>Strips any non-printable characters from <code>text</code></p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb23-1" data-line-number="1">@(clean(<span class="st">&quot;😃 Hello </span><span class="sc">\n</span><span class="st">wo</span><span class="sc">\t</span><span class="st">r</span><span class="sc">\r</span><span class="st">ld&quot;</span>)) → 😃 Hello world</a>
+<a class="sourceLine" id="cb23-2" data-line-number="2">@(clean(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
 <p><a name="function:code"></a></p>
 <h2 id="codetext">code(text)</h2>
 <p>Returns the numeric code for the first character in <code>text</code>, it is the inverse of char</p>

--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -92,6 +92,7 @@ func TestEvaluateTemplateAsString(t *testing.T) {
 		{"1 + 2", "1 + 2", false},
 		{"@(1 + 2)", "3", false},
 		{"@@string1", "@string1", false},
+		{"@@@string1", "@foo", false},
 
 		{"@string1@string2", "foobar", false},
 		{"@(string1 & string2)", "foobar", false},

--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -91,6 +91,9 @@ func TestEvaluateTemplateAsString(t *testing.T) {
 
 		{"1 + 2", "1 + 2", false},
 		{"@(1 + 2)", "3", false},
+
+		{"@", "@", false},
+		{"@@", "@", false},
 		{"@@string1", "@string1", false},
 		{"@@@string1", "@foo", false},
 

--- a/excellent/functions/functions.go
+++ b/excellent/functions/functions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -16,6 +17,8 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/shopspring/decimal"
 )
+
+var nonPrintableRegex = regexp.MustCompile(`[\p{Cc}\p{C}]`)
 
 // XFunction defines the interface that Excellent functions must implement
 type XFunction func(env utils.Environment, args ...types.XValue) types.XValue
@@ -508,15 +511,14 @@ func Field(env utils.Environment, args ...types.XValue) types.XValue {
 	return types.NewXText(strings.TrimSpace(fields[field]))
 }
 
-// Clean strips any leading or trailing whitespace from `text`
+// Clean strips any non-printable characters from `text`
 //
-//   @(clean("\nfoo\t")) -> foo
-//   @(clean(" bar")) -> bar
+//   @(clean("😃 Hello \nwo\tr\rld")) -> 😃 Hello world
 //   @(clean(123)) -> 123
 //
 // @function clean(text)
 func Clean(env utils.Environment, text types.XText) types.XValue {
-	return types.NewXText(strings.TrimSpace(text.Native()))
+	return types.NewXText(nonPrintableRegex.ReplaceAllString(text.Native(), ""))
 }
 
 // Left returns the `count` most left characters of the passed in `text`

--- a/excellent/functions/functions_test.go
+++ b/excellent/functions/functions_test.go
@@ -69,7 +69,7 @@ var funcTests = []struct {
 	{"code", []types.XValue{}, ERROR},
 
 	{"clean", []types.XValue{xs("hello")}, xs("hello")},
-	{"clean", []types.XValue{xs("  hello  world\n\t")}, xs("hello  world")},
+	{"clean", []types.XValue{xs("😃 Hello \nwo\tr\rld")}, xs("😃 Hello world")},
 	{"clean", []types.XValue{xs("")}, xs("")},
 	{"clean", []types.XValue{}, ERROR},
 

--- a/legacy/expressions/migrate.go
+++ b/legacy/expressions/migrate.go
@@ -40,7 +40,7 @@ func migrateLegacyTemplateAsString(resolver Resolvable, template string) (string
 		case excellent.BODY:
 			buf.WriteString(token)
 		case excellent.IDENTIFIER:
-			value := resolveValue(nil, resolver, token)
+			value := resolveLookup(nil, resolver, token)
 			if value == nil {
 				errors.Add(fmt.Sprintf("@%s", token), "unable to migrate variable")
 				buf.WriteString("@")
@@ -142,13 +142,7 @@ func migrateExpression(env utils.Environment, resolver interface{}, expression s
 	return value, nil
 }
 
-// ResolveValue will resolve the passed in string variable given in dot notation and return
-// the value as defined by the Resolvable passed in.
-//
-// Example syntaxes:
-//      foo.bar.0  - 0th element of bar slice within foo, could also be "0" key in bar map within foo
-//      foo.bar[0] - same as above
-func resolveValue(env utils.Environment, variable interface{}, key string) interface{} {
+func resolveLookup(env utils.Environment, variable interface{}, key string) interface{} {
 	// self referencing
 	if key == "" {
 		return variable
@@ -208,7 +202,6 @@ func popNextVariable(input string) (string, string) {
 
 	key := strings.Trim(input[keyStart:keyEnd], "\"")
 	rest := input[restStart:]
-
 	return key, rest
 }
 

--- a/legacy/expressions/migrate.go
+++ b/legacy/expressions/migrate.go
@@ -42,7 +42,7 @@ func migrateLegacyTemplateAsString(resolver types.XValue, template string) (stri
 		case excellent.IDENTIFIER:
 			value := excellent.ResolveValue(nil, resolver, token)
 			if value == nil {
-				errors.Add(fmt.Sprintf("@%s", token), "unable to map")
+				errors.Add(fmt.Sprintf("@%s", token), "unable to migrate variable")
 				buf.WriteString("@")
 				buf.WriteString(token)
 			} else {
@@ -115,7 +115,6 @@ func migrateExpression(env utils.Environment, resolver types.XValue, expression 
 	p.AddErrorListener(errListener)
 
 	// speed up parsing
-	p.SetErrorHandler(antlr.NewBailErrorStrategy())
 	p.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)
 	// TODO: add second stage - https://github.com/antlr/antlr4/issues/192
 

--- a/legacy/expressions/migrate.go
+++ b/legacy/expressions/migrate.go
@@ -33,6 +33,7 @@ func MigrateTemplate(template string, extraAs ExtraVarsMapping) (string, error) 
 func migrateLegacyTemplateAsString(resolver types.XValue, template string) (string, error) {
 	var buf bytes.Buffer
 	scanner := excellent.NewXScanner(strings.NewReader(template), ContextTopLevels)
+	scanner.SetUnescapeBody(false)
 	errors := excellent.NewTemplateErrors()
 
 	for tokenType, token := scanner.Scan(); tokenType != excellent.EOF; tokenType, token = scanner.Scan() {

--- a/legacy/expressions/migrate_test.go
+++ b/legacy/expressions/migrate_test.go
@@ -207,6 +207,9 @@ func TestMigrateTemplate(t *testing.T) {
 		// non-expressions
 		{old: `bob@nyaruka.com`, new: `bob@nyaruka.com`},
 		{old: `@twitter_handle`, new: `@twitter_handle`},
+
+		{old: `@`, new: `@`},
+		{old: `Hi @@@flow.favorite_color @@flow.favorite_color @flow.favorite_color @nyaruka @ @`, new: `Hi @@@run.results.favorite_color @@flow.favorite_color @run.results.favorite_color @nyaruka @ @`},
 	}
 
 	for i := range tests {

--- a/legacy/expressions/testdata/legacy_tests.json
+++ b/legacy/expressions/testdata/legacy_tests.json
@@ -1267,5 +1267,44 @@
         "url_encode": false,
         "output": "@(\")",
         "errors": []
+    },
+    {
+        "template": "@('x')",
+        "context": {
+            "variables": {},
+            "timezone": "UTC",
+            "date_style": "day_first"
+        },
+        "url_encode": false,
+        "output": "@('x')",
+        "errors": [
+            "Expression error at: '"
+        ]
+    },
+    {
+        "template": "@(0 / )",
+        "context": {
+            "variables": {},
+            "timezone": "UTC",
+            "date_style": "day_first"
+        },
+        "url_encode": false,
+        "output": "@(0 / )",
+        "errors": [
+            "Expression error at: )"
+        ]
+    },
+    {
+        "template": "@(1.1.0)",
+        "context": {
+            "variables": {},
+            "timezone": "UTC",
+            "date_style": "day_first"
+        },
+        "url_encode": false,
+        "output": "@(1.1.0)",
+        "errors": [
+            "Expression is invalid"
+        ]
     }
 ]

--- a/legacy/expressions/testdata/legacy_tests.json
+++ b/legacy/expressions/testdata/legacy_tests.json
@@ -1306,5 +1306,18 @@
         "errors": [
             "Expression is invalid"
         ]
+    },
+    {
+        "template": "@(FOO())",
+        "context": {
+            "variables": {},
+            "timezone": "UTC",
+            "date_style": "day_first"
+        },
+        "url_encode": false,
+        "output": "@(FOO())",
+        "errors": [
+            "Undefined function: FOO"
+        ]
     }
 ]

--- a/legacy/expressions/testdata/legacy_tests.json
+++ b/legacy/expressions/testdata/legacy_tests.json
@@ -1256,5 +1256,16 @@
         "errors": [
             "Division by zero"
         ]
+    },
+    {
+        "template": "@(\")",
+        "context": {
+            "variables": {},
+            "timezone": "UTC",
+            "date_style": "day_first"
+        },
+        "url_encode": false,
+        "output": "@(\")",
+        "errors": []
     }
 ]

--- a/legacy/expressions/visitor.go
+++ b/legacy/expressions/visitor.go
@@ -49,7 +49,7 @@ func (v *legacyVisitor) VisitDotLookup(ctx *gen.DotLookupContext) interface{} {
 	if err != nil {
 		return err
 	}
-	return resolveValue(v.env, value, lookup)
+	return resolveLookup(v.env, value, lookup)
 }
 
 // VisitStringLiteral deals with string literals such as "asdf"
@@ -150,7 +150,7 @@ func (v *legacyVisitor) VisitFalse(ctx *gen.FalseContext) interface{} {
 // VisitContextReference deals with references to variables in the context such as "foo"
 func (v *legacyVisitor) VisitContextReference(ctx *gen.ContextReferenceContext) interface{} {
 	key := strings.ToLower(ctx.GetText())
-	val := resolveValue(v.env, v.resolver, key)
+	val := resolveLookup(v.env, v.resolver, key)
 	if val == nil {
 		return fmt.Errorf("Invalid key: '%s'", key)
 	}


### PR DESCRIPTION
 * Fix `@` at end of expression
 * Fix migrating `@@` escape sequences
 * Fix `clean()` to match old behaviour
 * Fix panics when migrating expressions with errors https://github.com/nyaruka/goflow/issues/273