### PR TITLE
Handle legacy flows with missing translations

### DIFF
--- a/legacy/definition_test.go
+++ b/legacy/definition_test.go
@@ -148,8 +148,6 @@ func TestFlowMigration(t *testing.T) {
 		migratedFlowJSON, _ := utils.JSONMarshalPretty(migratedFlow)
 		expectedFlowJSON, _ := utils.JSONMarshalPretty(test.Expected)
 
-		fmt.Println(string(migratedFlowJSON))
-
 		assert.Equal(t, string(expectedFlowJSON), string(migratedFlowJSON))
 	}
 }
@@ -172,8 +170,8 @@ func TestActionMigration(t *testing.T) {
 
 		migratedAction := migratedFlow.Nodes()[0].Actions()[0]
 		migratedActionEnvelope, _ := utils.EnvelopeFromTyped(migratedAction)
-		migratedActionJSON, _ := utils.JSONMarshalPretty(migratedActionEnvelope)
-		expectedActionJSON, _ := utils.JSONMarshalPretty(test.ExpectedAction)
+		migratedActionJSON, _ := utils.JSONMarshal(migratedActionEnvelope)
+		expectedActionJSON, _ := utils.JSONMarshal(test.ExpectedAction)
 
 		assert.Equal(t, string(expectedActionJSON), string(migratedActionJSON))
 
@@ -207,8 +205,8 @@ func TestTestMigration(t *testing.T) {
 			t.Errorf("Got no migrated case from legacy test:\n%s\n\n", string(test.LegacyTest))
 		} else {
 			migratedCase := migratedRouter.Cases[0]
-			migratedCaseJSON, _ := utils.JSONMarshalPretty(migratedCase)
-			expectedCaseJSON, _ := utils.JSONMarshalPretty(test.ExpectedCase)
+			migratedCaseJSON, _ := utils.JSONMarshal(migratedCase)
+			expectedCaseJSON, _ := utils.JSONMarshal(test.ExpectedCase)
 
 			assert.Equal(t, string(expectedCaseJSON), string(migratedCaseJSON))
 
@@ -249,8 +247,8 @@ func TestRuleSetMigration(t *testing.T) {
 				}
 			}
 
-			migratedNodeJSON, _ := utils.JSONMarshalPretty(migratedNode)
-			expectedNodeJSON, _ := utils.JSONMarshalPretty(test.ExpectedNode)
+			migratedNodeJSON, _ := utils.JSONMarshal(migratedNode)
+			expectedNodeJSON, _ := utils.JSONMarshal(test.ExpectedNode)
 
 			assert.Equal(t, string(expectedNodeJSON), string(migratedNodeJSON))
 
@@ -266,14 +264,29 @@ func readLegacyTestFlows(flowsJSON string) ([]*legacy.Flow, error) {
 }
 
 func checkFlowLocalization(t *testing.T, flow flows.Flow, expectedLocalizationRaw json.RawMessage) {
-	actualLocalizationJSON, _ := utils.JSONMarshalPretty(flow.Localization())
-	expectedLocalizationJSON, _ := utils.JSONMarshalPretty(expectedLocalizationRaw)
+	actualLocalizationJSON, _ := utils.JSONMarshal(flow.Localization())
+	expectedLocalizationJSON, _ := utils.JSONMarshal(expectedLocalizationRaw)
 
 	assert.Equal(t, string(expectedLocalizationJSON), string(actualLocalizationJSON))
 }
 
 func TestTranslations(t *testing.T) {
-	translations := []map[utils.Language]string{
+	// can unmarshall from a single string
+	translations := make(legacy.Translations)
+	json.Unmarshal([]byte(`"hello"`), &translations)
+	assert.Equal(t, legacy.Translations{"base": "hello"}, translations)
+
+	// or a map
+	translations = make(legacy.Translations)
+	json.Unmarshal([]byte(`{"eng": "hello", "fra": "bonjour"}`), &translations)
+	assert.Equal(t, legacy.Translations{"eng": "hello", "fra": "bonjour"}, translations)
+
+	// and back to JSON
+	data, err := json.Marshal(translations)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`{"eng":"hello","fra":"bonjour"}`), data)
+
+	translationSet := []legacy.Translations{
 		{"eng": "Yes", "fra": "Oui"},
 		{"eng": "No", "fra": "Non"},
 		{"eng": "Maybe"},
@@ -282,5 +295,5 @@ func TestTranslations(t *testing.T) {
 	assert.Equal(t, map[utils.Language][]string{
 		"eng": {"Yes", "No", "Maybe", "Never"},
 		"fra": {"Oui", "Non", "", "Jamas"},
-	}, legacy.TransformTranslations(translations))
+	}, legacy.TransformTranslations(translationSet))
 }

--- a/legacy/definition_test.go
+++ b/legacy/definition_test.go
@@ -269,31 +269,3 @@ func checkFlowLocalization(t *testing.T, flow flows.Flow, expectedLocalizationRa
 
 	assert.Equal(t, string(expectedLocalizationJSON), string(actualLocalizationJSON))
 }
-
-func TestTranslations(t *testing.T) {
-	// can unmarshall from a single string
-	translations := make(legacy.Translations)
-	json.Unmarshal([]byte(`"hello"`), &translations)
-	assert.Equal(t, legacy.Translations{"base": "hello"}, translations)
-
-	// or a map
-	translations = make(legacy.Translations)
-	json.Unmarshal([]byte(`{"eng": "hello", "fra": "bonjour"}`), &translations)
-	assert.Equal(t, legacy.Translations{"eng": "hello", "fra": "bonjour"}, translations)
-
-	// and back to JSON
-	data, err := json.Marshal(translations)
-	require.NoError(t, err)
-	assert.Equal(t, []byte(`{"eng":"hello","fra":"bonjour"}`), data)
-
-	translationSet := []legacy.Translations{
-		{"eng": "Yes", "fra": "Oui"},
-		{"eng": "No", "fra": "Non"},
-		{"eng": "Maybe"},
-		{"eng": "Never", "fra": "Jamas"},
-	}
-	assert.Equal(t, map[utils.Language][]string{
-		"eng": {"Yes", "No", "Maybe", "Never"},
-		"fra": {"Oui", "Non", "", "Jamas"},
-	}, legacy.TransformTranslations(translationSet))
-}

--- a/legacy/testdata/flows.json
+++ b/legacy/testdata/flows.json
@@ -26,7 +26,7 @@
                     "actions": [
                       {
                         "msg": {
-                          "base": "Hello",
+                          "eng": "Hello",
                           "fre": "Bonjour"
                         },
                         "media": {},
@@ -46,13 +46,6 @@
             "language": "eng",
             "expire_after_minutes": 0,
             "localization": {
-                "base": {
-                    "98388930-7a0f-4eb8-9a0a-09be2f006420": {
-                        "text": [
-                            "Hello"
-                        ]
-                    }
-                },
                 "fre": {
                     "98388930-7a0f-4eb8-9a0a-09be2f006420": {
                         "text": [
@@ -68,7 +61,7 @@
                         {
                             "type": "send_msg",
                             "uuid": "98388930-7a0f-4eb8-9a0a-09be2f006420",
-                            "text": "",
+                            "text": "Hello",
                             "attachments": []
                         }
                     ],

--- a/legacy/testdata/tests.json
+++ b/legacy/testdata/tests.json
@@ -59,6 +59,19 @@
     },
     {
         "legacy_test": {
+            "type": "contains_any",
+            "test": "oops not a dict"
+        },
+        "expected_case": {
+            "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+            "type": "has_any_word",
+            "arguments": ["oops not a dict"],
+            "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
+        },
+        "expected_localization": {}
+    },
+    {
+        "legacy_test": {
             "type": "contains_only_phrase",
             "test": {
                 "eng": "yes yeah",

--- a/legacy/utils.go
+++ b/legacy/utils.go
@@ -1,0 +1,55 @@
+package legacy
+
+import (
+	"encoding/json"
+
+	"github.com/nyaruka/goflow/utils"
+)
+
+// Translations is an inline translation map used for localization
+type Translations map[utils.Language]string
+
+// Base looks up the translation in the given base language, or "base"
+func (t Translations) Base(baseLanguage utils.Language) string {
+	val, exists := t[baseLanguage]
+	if exists {
+		return val
+	}
+	return t["base"]
+}
+
+// UnmarshalJSON unmarshals legacy translations from the given JSON
+func (t *Translations) UnmarshalJSON(data []byte) error {
+	// sometimes legacy flows have a single string instead of a map
+	if data[0] == '"' {
+		var asString string
+		if err := json.Unmarshal(data, &asString); err != nil {
+			return err
+		}
+		*t = Translations{"base": asString}
+		return nil
+	}
+
+	asMap := make(map[utils.Language]string)
+	if err := json.Unmarshal(data, &asMap); err != nil {
+		return err
+	}
+
+	*t = asMap
+	return nil
+}
+
+// DecimalString represents a decimal value which may be provided as a string or floating point value
+type DecimalString string
+
+// UnmarshalJSON unmarshals a decimal string from the given JSON
+func (s *DecimalString) UnmarshalJSON(data []byte) error {
+	if data[0] == '"' {
+		// data is a quoted string
+		*s = DecimalString(data[1 : len(data)-1])
+	} else {
+		// data is JSON float
+		*s = DecimalString(data)
+	}
+	return nil
+}

--- a/legacy/utils_test.go
+++ b/legacy/utils_test.go
@@ -1,0 +1,50 @@
+package legacy_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nyaruka/goflow/legacy"
+	"github.com/nyaruka/goflow/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslations(t *testing.T) {
+	// can unmarshall from a single string
+	translations := make(legacy.Translations)
+	json.Unmarshal([]byte(`"hello"`), &translations)
+	assert.Equal(t, legacy.Translations{"base": "hello"}, translations)
+
+	// or a map
+	translations = make(legacy.Translations)
+	json.Unmarshal([]byte(`{"eng": "hello", "fra": "bonjour"}`), &translations)
+	assert.Equal(t, legacy.Translations{"eng": "hello", "fra": "bonjour"}, translations)
+
+	// and back to JSON
+	data, err := json.Marshal(translations)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`{"eng":"hello","fra":"bonjour"}`), data)
+
+	translationSet := []legacy.Translations{
+		{"eng": "Yes", "fra": "Oui"},
+		{"eng": "No", "fra": "Non"},
+		{"eng": "Maybe"},
+		{"eng": "Never", "fra": "Jamas"},
+	}
+	assert.Equal(t, map[utils.Language][]string{
+		"eng": {"Yes", "No", "Maybe", "Never"},
+		"fra": {"Oui", "Non", "", "Jamas"},
+	}, legacy.TransformTranslations(translationSet))
+}
+
+func TestDecimalString(t *testing.T) {
+	// can unmarshall from a string
+	var decimal legacy.DecimalString
+	json.Unmarshal([]byte(`"123.45"`), &decimal)
+	assert.Equal(t, legacy.DecimalString("123.45"), decimal)
+
+	// or a floating point (JSON number type)
+	json.Unmarshal([]byte(`567.89`), &decimal)
+	assert.Equal(t, legacy.DecimalString("567.89"), decimal)
+}


### PR DESCRIPTION
Can unmarshal translatable items from a single string
