### PR TITLE
Router result and legacy URN expression migration fixes

### DIFF
--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -42,6 +42,7 @@ var flowTests = []struct {
 	{"triggered.json", "triggered_test.json"},
 	{"no_contact.json", "no_contact_test.json"},
 	{"redact_urns.json", "redact_urns_test.json"},
+	{"router_tests.json", "router_tests_test.json"},
 }
 
 var writeOutput bool

--- a/cmd/flowrunner/testdata/flows/router_tests.json
+++ b/cmd/flowrunner/testdata/flows/router_tests.json
@@ -1,0 +1,52 @@
+[
+    {
+        "type": "flow",
+        "url": "http://testserver/assets/flow/615b8a0f-588c-4d20-a05f-363b0b4ce6f4",
+        "content": {
+            "uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4",
+            "name": "Router Test",
+            "language": "eng",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
+                    "router": {
+                        "type": "switch",
+                        "result_name": "URN Check",
+                        "default_exit_uuid": "85038c16-0060-486c-97be-898c65587658",
+                        "operand": "@(format_urn(contact.urns.telegram.0))",
+                        "cases": [
+                            {
+                                "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+                                "type": "has_text",
+                                "exit_uuid": "9b30398f-c6e8-47e2-9c0c-99493f83cbef"
+                            }
+                        ]
+                    },
+                    "exits": [
+                        {
+                            "uuid": "9b30398f-c6e8-47e2-9c0c-99493f83cbef",
+                            "destination_node_uuid": "11a772f3-3ca2-4429-8b33-20fdcfc2b69e",
+                            "name": "Telegram"
+                        },
+                        {
+                            "uuid": "85038c16-0060-486c-97be-898c65587658",
+                            "destination_node_uuid": "11a772f3-3ca2-4429-8b33-20fdcfc2b69e",
+                            "name": "Other"
+                        }
+                    ]
+                },
+                {
+                    "uuid": "11a772f3-3ca2-4429-8b33-20fdcfc2b69e",
+                    "actions": [
+                        {
+                            "uuid": "d2a4052a-3fa9-4608-ab3e-5b9631440447",
+                            "type": "send_msg",
+                            "text": "URN Check: @run.results.urn_check"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/cmd/flowrunner/testdata/flows/router_tests.json
+++ b/cmd/flowrunner/testdata/flows/router_tests.json
@@ -14,7 +14,7 @@
                         "type": "switch",
                         "result_name": "URN Check",
                         "default_exit_uuid": "85038c16-0060-486c-97be-898c65587658",
-                        "operand": "@(format_urn(contact.urns.telegram.0))",
+                        "operand": "@(format_urn(contact.urns.telegram))",
                         "cases": [
                             {
                                 "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",

--- a/cmd/flowrunner/testdata/flows/router_tests_test.json
+++ b/cmd/flowrunner/testdata/flows/router_tests_test.json
@@ -6,13 +6,6 @@
         {
             "events": [
                 {
-                    "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "fatal": false,
-                    "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
-                    "text": "error calling FORMAT_URN: index 0 out of range for 0 items",
-                    "type": "error"
-                },
-                {
                     "category": "Other",
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
                     "input": "",
@@ -72,13 +65,6 @@
                     {
                         "created_on": "2000-01-01T00:00:00.000000000-00:00",
                         "events": [
-                            {
-                                "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                                "fatal": false,
-                                "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
-                                "text": "error calling FORMAT_URN: index 0 out of range for 0 items",
-                                "type": "error"
-                            },
                             {
                                 "category": "Other",
                                 "created_on": "2000-01-01T00:00:00.000000000-00:00",

--- a/cmd/flowrunner/testdata/flows/router_tests_test.json
+++ b/cmd/flowrunner/testdata/flows/router_tests_test.json
@@ -1,0 +1,221 @@
+{
+    "caller_events": [
+        []
+    ],
+    "outputs": [
+        {
+            "events": [
+                {
+                    "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                    "fatal": false,
+                    "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
+                    "text": "error calling FORMAT_URN: index 0 out of range for 0 items",
+                    "type": "error"
+                },
+                {
+                    "category": "Other",
+                    "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                    "input": "",
+                    "name": "URN Check",
+                    "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
+                    "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
+                    "type": "run_result_changed",
+                    "value": ""
+                },
+                {
+                    "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                    "msg": {
+                        "channel": {
+                            "name": "Android Channel",
+                            "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                        },
+                        "text": "URN Check: ",
+                        "urn": "tel:+12065551212",
+                        "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
+                    },
+                    "step_uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094",
+                    "type": "msg_created"
+                }
+            ],
+            "session": {
+                "contact": {
+                    "fields": {
+                        "first_name": {
+                            "text": "Ben"
+                        },
+                        "state": {
+                            "state": "Ecuador > Azuay",
+                            "text": "Ecuador > Azuay"
+                        }
+                    },
+                    "id": 1234567,
+                    "language": "eng",
+                    "name": "Ben Haggerty",
+                    "timezone": "America/Guayaquil",
+                    "urns": [
+                        "tel:+12065551212",
+                        "facebook:1122334455667788",
+                        "mailto:ben@macklemore"
+                    ],
+                    "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                },
+                "environment": {
+                    "date_format": "YYYY-MM-DD",
+                    "languages": [
+                        "eng"
+                    ],
+                    "redaction_policy": "none",
+                    "time_format": "hh:mm",
+                    "timezone": "America/Los_Angeles"
+                },
+                "runs": [
+                    {
+                        "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                        "events": [
+                            {
+                                "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "fatal": false,
+                                "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
+                                "text": "error calling FORMAT_URN: index 0 out of range for 0 items",
+                                "type": "error"
+                            },
+                            {
+                                "category": "Other",
+                                "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "input": "",
+                                "name": "URN Check",
+                                "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
+                                "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
+                                "type": "run_result_changed",
+                                "value": ""
+                            },
+                            {
+                                "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "msg": {
+                                    "channel": {
+                                        "name": "Android Channel",
+                                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                                    },
+                                    "text": "URN Check: ",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
+                                },
+                                "step_uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094",
+                                "type": "msg_created"
+                            }
+                        ],
+                        "exited_on": "2000-01-01T00:00:00.000000000-00:00",
+                        "expires_on": "2000-01-01T00:00:00.000000000-00:00",
+                        "flow": {
+                            "name": "Router Test",
+                            "uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4"
+                        },
+                        "path": [
+                            {
+                                "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "exit_uuid": "85038c16-0060-486c-97be-898c65587658",
+                                "left_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
+                                "uuid": "692926ea-09d6-4942-bd38-d266ec8d3716"
+                            },
+                            {
+                                "arrived_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "left_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "node_uuid": "11a772f3-3ca2-4429-8b33-20fdcfc2b69e",
+                                "uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094"
+                            }
+                        ],
+                        "results": {
+                            "urn_check": {
+                                "category": "Other",
+                                "created_on": "2000-01-01T00:00:00.000000000-00:00",
+                                "input": "",
+                                "name": "URN Check",
+                                "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
+                                "value": ""
+                            }
+                        },
+                        "status": "completed",
+                        "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5"
+                    }
+                ],
+                "status": "completed",
+                "trigger": {
+                    "contact": {
+                        "fields": {
+                            "first_name": {
+                                "text": "Ben"
+                            },
+                            "state": {
+                                "state": "Ecuador > Azuay",
+                                "text": "Ecuador > Azuay"
+                            }
+                        },
+                        "id": 1234567,
+                        "language": "eng",
+                        "name": "Ben Haggerty",
+                        "timezone": "America/Guayaquil",
+                        "urns": [
+                            "tel:+12065551212",
+                            "facebook:1122334455667788",
+                            "mailto:ben@macklemore"
+                        ],
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                    },
+                    "environment": {
+                        "date_format": "YYYY-MM-DD",
+                        "languages": [
+                            "eng"
+                        ],
+                        "redaction_policy": "none",
+                        "time_format": "hh:mm",
+                        "timezone": "America/Los_Angeles"
+                    },
+                    "flow": {
+                        "name": "Router Test",
+                        "uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4"
+                    },
+                    "triggered_on": "2000-01-01T00:00:00Z",
+                    "type": "manual"
+                }
+            }
+        }
+    ],
+    "trigger": {
+        "contact": {
+            "fields": {
+                "first_name": {
+                    "text": "Ben"
+                },
+                "state": {
+                    "state": "Ecuador > Azuay",
+                    "text": "Ecuador > Azuay"
+                }
+            },
+            "id": 1234567,
+            "language": "eng",
+            "name": "Ben Haggerty",
+            "timezone": "America/Guayaquil",
+            "urns": [
+                "tel:+12065551212",
+                "facebook:1122334455667788",
+                "mailto:ben@macklemore"
+            ],
+            "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+        },
+        "environment": {
+            "date_format": "YYYY-MM-DD",
+            "languages": [
+                "eng"
+            ],
+            "time_format": "hh:mm",
+            "timezone": "America/Los_Angeles"
+        },
+        "flow": {
+            "name": "Router Test",
+            "uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4"
+        },
+        "triggered_on": "2000-01-01T00:00:00.000000000-00:00",
+        "type": "manual"
+    }
+}

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -447,7 +447,7 @@ func (s *session) pickNodeExit(run flows.FlowRun, node flows.Node, step flows.St
 	}
 
 	// save our results if appropriate
-	if router != nil && router.ResultName() != "" && route.Match() != "" {
+	if router != nil && router.ResultName() != "" {
 		event := events.NewRunResultChangedEvent(router.ResultName(), route.Match(), exit.Name(), localizedExitName, node.UUID(), operand)
 		run.ApplyEvent(step, nil, event)
 	}

--- a/legacy/expressions/context.go
+++ b/legacy/expressions/context.go
@@ -186,8 +186,8 @@ func newMigrationBaseVars() map[string]interface{} {
 	for scheme := range urns.ValidSchemes {
 		contact.baseVars[scheme] = &varMapper{
 			substitutions: map[string]string{
-				"__default__": fmt.Sprintf("format_urn(contact.urns.%s.0)", scheme),
-				"display":     fmt.Sprintf("format_urn(contact.urns.%s.0)", scheme),
+				"__default__": fmt.Sprintf("format_urn(contact.urns.%s)", scheme),
+				"display":     fmt.Sprintf("format_urn(contact.urns.%s)", scheme),
 				"scheme":      fmt.Sprintf("contact.urns.%s.0.scheme", scheme),
 				"path":        fmt.Sprintf("contact.urns.%s.0.path", scheme),
 				"urn":         fmt.Sprintf("contact.urns.%s.0", scheme),

--- a/legacy/expressions/migrate_test.go
+++ b/legacy/expressions/migrate_test.go
@@ -44,14 +44,14 @@ func TestMigrateTemplate(t *testing.T) {
 		{old: `@contact.groups`, new: `@(join(contact.groups, ","))`},
 
 		// contact URN variables
-		{old: `@contact.tel`, new: `@(format_urn(contact.urns.tel.0))`},
-		{old: `@contact.tel.display`, new: `@(format_urn(contact.urns.tel.0))`},
+		{old: `@contact.tel`, new: `@(format_urn(contact.urns.tel))`},
+		{old: `@contact.tel.display`, new: `@(format_urn(contact.urns.tel))`},
 		{old: `@contact.tel.scheme`, new: `@contact.urns.tel.0.scheme`},
 		{old: `@contact.tel.path`, new: `@contact.urns.tel.0.path`},
 		{old: `@contact.tel.urn`, new: `@contact.urns.tel.0`},
 		{old: `@contact.tel_e164`, new: `@contact.urns.tel.0.path`},
-		{old: `@contact.twitterid`, new: `@(format_urn(contact.urns.twitterid.0))`},
-		{old: `@contact.mailto`, new: `@(format_urn(contact.urns.mailto.0))`},
+		{old: `@contact.twitterid`, new: `@(format_urn(contact.urns.twitterid))`},
+		{old: `@contact.mailto`, new: `@(format_urn(contact.urns.mailto))`},
 
 		// run variables
 		{old: `@flow.favorite_color`, new: `@run.results.favorite_color`},
@@ -96,7 +96,7 @@ func TestMigrateTemplate(t *testing.T) {
 		{old: `@extra.flow.role`, new: `@parent.results.role`},
 
 		// variables in parens
-		{old: `@(contact.tel)`, new: `@(format_urn(contact.urns.tel.0))`},
+		{old: `@(contact.tel)`, new: `@(format_urn(contact.urns.tel))`},
 		{old: `@(contact.gender)`, new: `@(contact.fields.gender)`},
 		{old: `@(flow.favorite_color)`, new: `@(run.results.favorite_color)`},
 

--- a/legacy/testdata/actions.json
+++ b/legacy/testdata/actions.json
@@ -65,7 +65,7 @@
             "type": "call_webhook",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "method": "GET",
-            "url": "http://example.com?contact=@(format_urn(contact.urns.tel.0))"
+            "url": "http://example.com?contact=@(format_urn(contact.urns.tel))"
         },
         "expected_localization": {}
     },
@@ -86,7 +86,7 @@
             "type": "call_webhook",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "method": "POST",
-            "url": "http://example.com?contact=@(format_urn(contact.urns.tel.0))",
+            "url": "http://example.com?contact=@(format_urn(contact.urns.tel))",
             "headers": {
                 "Content-Type": "application/json",
                 "User-Agent": "rapidpro"

--- a/legacy/testdata/rulesets.json
+++ b/legacy/testdata/rulesets.json
@@ -634,5 +634,73 @@
 		        }
 		    }
         }
+    },
+    {
+        "legacy_ruleset": {
+            "uuid": "9e4078de-2304-4751-b6e7-35532cc5ab8f",
+            "x": 708,
+            "y": 1611,
+            "label": "Response 14",
+            "rules": [
+                {
+                    "uuid": "9b30398f-c6e8-47e2-9c0c-99493f83cbef",
+                    "category": {
+                        "eng": "Telegram"
+                    },
+                    "destination": "5b977652-91e3-48be-8e86-7c8094b4aa8f",
+                    "destination_type": "A",
+                    "test": {
+                        "type": "not_empty"
+                    },
+                    "label": null
+                },
+                {
+                    "uuid": "85038c16-0060-486c-97be-898c65587658",
+                    "category": {
+                        "eng": "Other"
+                    },
+                    "destination": "833fc698-d590-42dc-93e1-39e701b7e8e4",
+                    "destination_type": "A",
+                    "test": {
+                        "type": "true"
+                    },
+                    "label": null
+                }
+            ],
+            "finished_key": null,
+            "ruleset_type": "contact_field",
+            "response_type": "",
+            "operand": "@contact.telegram",
+            "config": {}
+        },
+        "expected_node": {
+            "uuid": "9e4078de-2304-4751-b6e7-35532cc5ab8f",
+            "router": {
+                "type": "switch",
+                "result_name": "Response 14",
+                "default_exit_uuid": "85038c16-0060-486c-97be-898c65587658",
+                "operand": "@(format_urn(contact.urns.telegram.0))",
+                "cases": [
+                    {
+                        "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+                        "type": "has_text",
+                        "exit_uuid": "9b30398f-c6e8-47e2-9c0c-99493f83cbef"
+                    }
+                ]
+            },
+            "exits": [
+                {
+                    "uuid": "9b30398f-c6e8-47e2-9c0c-99493f83cbef",
+                    "destination_node_uuid": "5b977652-91e3-48be-8e86-7c8094b4aa8f",
+                    "name": "Telegram"
+                },
+                {
+                    "uuid": "85038c16-0060-486c-97be-898c65587658",
+                    "destination_node_uuid": "833fc698-d590-42dc-93e1-39e701b7e8e4",
+                    "name": "Other"
+                }
+            ]
+        },
+        "expected_localization": {}
     }
 ]

--- a/legacy/testdata/rulesets.json
+++ b/legacy/testdata/rulesets.json
@@ -679,7 +679,7 @@
                 "type": "switch",
                 "result_name": "Response 14",
                 "default_exit_uuid": "85038c16-0060-486c-97be-898c65587658",
-                "operand": "@(format_urn(contact.urns.telegram.0))",
+                "operand": "@(format_urn(contact.urns.telegram))",
                 "cases": [
                     {
                         "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",


### PR DESCRIPTION
 * Taking the default exit of a router should still save a result as long as the router has a name
 * Migrate `@contact.<scheme>` expressions to `@(format_urn(contact.urns.<scheme>))` instead of `@(format_urn(contact.urns.<scheme>.0))` as the former won't error if there's no such URN

Would fix trial failures like https://sentry.io/nyaruka/rapidpro/issues/542067797/?query=is:unresolved