### PR TITLE
🌐 Encode spaces as %20 in URL expressions

### DIFF
--- a/cmd/flowrunner/testdata/flows/all_actions.json
+++ b/cmd/flowrunner/testdata/flows/all_actions.json
@@ -172,7 +172,7 @@
                         {
                             "uuid": "f3581032-e122-45ee-8be7-4f3c955d97f8",
                             "type": "set_contact_name",
-                            "name": "Jeff"
+                            "name": "Jeff Jefferson"
                         },
                         {
                             "uuid": "e0ae5679-5145-4bdd-9737-3481932bf095",
@@ -192,7 +192,7 @@
                             "uuid": "06153fbd-3e2c-413a-b0df-ed15d631835a",
                             "type": "call_webhook",
                             "method": "GET",
-                            "url": "http://localhost/?cmd=success"
+                            "url": "http://localhost/?cmd=success&name=@contact.name"
                         }
                     ]
                 }

--- a/cmd/flowrunner/testdata/flows/all_actions_test.json
+++ b/cmd/flowrunner/testdata/flows/all_actions_test.json
@@ -307,7 +307,7 @@
                 },
                 {
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "name": "Jeff",
+                    "name": "Jeff Jefferson",
                     "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                     "type": "contact_name_changed"
                 },
@@ -329,13 +329,13 @@
                 },
                 {
                     "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                    "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                    "request": "GET /?cmd=success&name=Jeff%20Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }",
                     "status": "success",
                     "status_code": 200,
                     "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                     "type": "webhook_called",
-                    "url": "http://127.0.0.1:49999/?cmd=success"
+                    "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff%20Jefferson"
                 }
             ],
             "session": {
@@ -364,7 +364,7 @@
                     ],
                     "id": 1234567,
                     "language": "eng",
-                    "name": "Jeff",
+                    "name": "Jeff Jefferson",
                     "timezone": "America/Guayaquil",
                     "urns": [
                         "tel:+12065551212",
@@ -690,7 +690,7 @@
                             },
                             {
                                 "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                                "name": "Jeff",
+                                "name": "Jeff Jefferson",
                                 "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                                 "type": "contact_name_changed"
                             },
@@ -712,13 +712,13 @@
                             },
                             {
                                 "created_on": "2000-01-01T00:00:00.000000000-00:00",
-                                "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                                "request": "GET /?cmd=success&name=Jeff%20Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                                 "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }",
                                 "status": "success",
                                 "status_code": 200,
                                 "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                                 "type": "webhook_called",
-                                "url": "http://127.0.0.1:49999/?cmd=success"
+                                "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff%20Jefferson"
                             }
                         ],
                         "exited_on": "2000-01-01T00:00:00.000000000-00:00",
@@ -757,11 +757,11 @@
                         "status": "completed",
                         "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
                         "webhook": {
-                            "request": "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                            "request": "GET /?cmd=success&name=Jeff%20Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                             "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }",
                             "status": "success",
                             "status_code": 200,
-                            "url": "http://127.0.0.1:49999/?cmd=success"
+                            "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff%20Jefferson"
                         }
                     },
                     {

--- a/excellent/evaluator.go
+++ b/excellent/evaluator.go
@@ -3,7 +3,6 @@ package excellent
 import (
 	"bytes"
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -112,7 +111,7 @@ func EvaluateTemplateAsString(env utils.Environment, context types.XValue, templ
 			} else {
 				strValue, _ := types.ToXText(env, value)
 				if urlEncode {
-					strValue = types.NewXText(url.PathEscape(strValue.Native()))
+					strValue = types.NewXText(utils.URLEscape(strValue.Native()))
 				}
 
 				buf.WriteString(strValue.Native())
@@ -125,7 +124,7 @@ func EvaluateTemplateAsString(env utils.Environment, context types.XValue, templ
 			} else {
 				strValue, _ := types.ToXText(env, value)
 				if urlEncode {
-					strValue = types.NewXText(url.PathEscape(strValue.Native()))
+					strValue = types.NewXText(utils.URLEscape(strValue.Native()))
 				}
 
 				buf.WriteString(strValue.Native())

--- a/excellent/evaluator.go
+++ b/excellent/evaluator.go
@@ -112,7 +112,7 @@ func EvaluateTemplateAsString(env utils.Environment, context types.XValue, templ
 			} else {
 				strValue, _ := types.ToXText(env, value)
 				if urlEncode {
-					strValue = types.NewXText(url.QueryEscape(strValue.Native()))
+					strValue = types.NewXText(url.PathEscape(strValue.Native()))
 				}
 
 				buf.WriteString(strValue.Native())
@@ -125,7 +125,7 @@ func EvaluateTemplateAsString(env utils.Environment, context types.XValue, templ
 			} else {
 				strValue, _ := types.ToXText(env, value)
 				if urlEncode {
-					strValue = types.NewXText(url.QueryEscape(strValue.Native()))
+					strValue = types.NewXText(url.PathEscape(strValue.Native()))
 				}
 
 				buf.WriteString(strValue.Native())

--- a/utils/text.go
+++ b/utils/text.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -11,6 +12,11 @@ var snakedChars = regexp.MustCompile(`[^\p{L}\d_]+`)
 // characters with _ and replace any duplicate underscores
 func Snakify(text string) string {
 	return strings.Trim(strings.ToLower(snakedChars.ReplaceAllString(text, "_")), "_")
+}
+
+// URLEscape escapes spaces as %20 matching urllib.quote(s, safe="") in Python
+func URLEscape(s string) string {
+	return strings.Replace(url.QueryEscape(s), "+", "%20", -1)
 }
 
 // see: https://en.wikipedia.org/wiki/Emoji for emoji ranges

--- a/utils/text_test.go
+++ b/utils/text_test.go
@@ -22,11 +22,22 @@ func TestSnakify(t *testing.T) {
 	}
 
 	for _, test := range snakeTests {
-		value := utils.Snakify(test.input)
+		assert.Equal(t, test.expected, utils.Snakify(test.input), "unexpected result snakifying '%s'", test.input)
+	}
+}
 
-		if value != test.expected {
-			t.Errorf("Expected: '%s' Got: '%s' for input: '%s'", test.expected, value, test.input)
-		}
+func TestURLEscape(t *testing.T) {
+	var urlTests = []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"hello_world-there", "hello_world-there"},
+		{"foo: bar ? & some/thing", "foo%3A%20bar%20%3F%20%26%20some%2Fthing"},
+	}
+
+	for _, test := range urlTests {
+		assert.Equal(t, test.expected, utils.URLEscape(test.input), "unexpected result URL escaping '%s'", test.input)
 	}
 }
 


### PR DESCRIPTION
We've been using `url.QueryEncode` which uses `+` for spaces but the problem is that we don't know that the expression is going to be in the query part of the URL