### PR TITLE
LocationHierarchy assets should be managed like a set like other asset types

### DIFF
--- a/flows/assets/cache.go
+++ b/flows/assets/cache.go
@@ -17,13 +17,13 @@ import (
 type assetType string
 
 const (
-	assetTypeChannelSet        assetType = "channel_set"
-	assetTypeFieldSet          assetType = "field_set"
-	assetTypeFlow              assetType = "flow"
-	assetTypeGroupSet          assetType = "group_set"
-	assetTypeLabelSet          assetType = "label_set"
-	assetTypeLocationHierarchy assetType = "location_hierarchy"
-	assetTypeResthookSet       assetType = "resthook_set"
+	assetTypeChannelSet           assetType = "channel_set"
+	assetTypeFieldSet             assetType = "field_set"
+	assetTypeFlow                 assetType = "flow"
+	assetTypeGroupSet             assetType = "group_set"
+	assetTypeLabelSet             assetType = "label_set"
+	assetTypeLocationHierarchySet assetType = "location_hierarchy_set"
+	assetTypeResthookSet          assetType = "resthook_set"
 )
 
 // AssetCache fetches and caches assets for the engine
@@ -134,8 +134,8 @@ func (c *AssetCache) Include(data json.RawMessage) error {
 func readAsset(data json.RawMessage, itemType assetType) (interface{}, error) {
 	var assetReader func(data json.RawMessage) (interface{}, error)
 
-	if itemType == assetTypeLocationHierarchy {
-		assetReader = func(data json.RawMessage) (interface{}, error) { return utils.ReadLocationHierarchy(data) }
+	if itemType == assetTypeLocationHierarchySet {
+		assetReader = func(data json.RawMessage) (interface{}, error) { return flows.ReadLocationHierarchySet(data) }
 	} else if itemType == assetTypeChannelSet {
 		assetReader = func(data json.RawMessage) (interface{}, error) { return flows.ReadChannelSet(data) }
 	} else if itemType == assetTypeFieldSet {

--- a/flows/assets/server.go
+++ b/flows/assets/server.go
@@ -112,13 +112,13 @@ func NewMockAssetServer() *MockAssetServer {
 	return &MockAssetServer{
 		assetServer: assetServer{
 			typeURLs: map[assetType]string{
-				assetTypeChannelSet:        "http://testserver/assets/channel/",
-				assetTypeFieldSet:          "http://testserver/assets/field/",
-				assetTypeFlow:              "http://testserver/assets/flow/{uuid}/",
-				assetTypeGroupSet:          "http://testserver/assets/group/",
-				assetTypeLabelSet:          "http://testserver/assets/label/",
-				assetTypeLocationHierarchy: "http://testserver/assets/location_hierarchy/",
-				assetTypeResthookSet:       "http://testserver/assets/resthook/",
+				assetTypeChannelSet:           "http://testserver/assets/channel/",
+				assetTypeFieldSet:             "http://testserver/assets/field/",
+				assetTypeFlow:                 "http://testserver/assets/flow/{uuid}/",
+				assetTypeGroupSet:             "http://testserver/assets/group/",
+				assetTypeLabelSet:             "http://testserver/assets/label/",
+				assetTypeLocationHierarchySet: "http://testserver/assets/location_hierarchy/",
+				assetTypeResthookSet:          "http://testserver/assets/resthook/",
 			},
 		},
 		mockResponses:  map[string]json.RawMessage{},

--- a/flows/assets/session.go
+++ b/flows/assets/session.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/goflow/flows"
-	"github.com/nyaruka/goflow/utils"
 )
 
 // our implementation of SessionAssets - the high-level API for asset access from the engine
@@ -22,20 +21,20 @@ func NewSessionAssets(cache *AssetCache, server AssetServer) flows.SessionAssets
 
 // HasLocations returns whether locations are supported as an asset item type
 func (s *sessionAssets) HasLocations() bool {
-	return s.server.isTypeSupported(assetTypeLocationHierarchy)
+	return s.server.isTypeSupported(assetTypeLocationHierarchySet)
 }
 
 // GetLocationHierarchy gets the location hierarchy asset for the session
-func (s *sessionAssets) GetLocationHierarchy() (*utils.LocationHierarchy, error) {
-	asset, err := s.cache.GetAsset(s.server, assetTypeLocationHierarchy, "")
+func (s *sessionAssets) GetLocationHierarchySet() (*flows.LocationHierarchySet, error) {
+	asset, err := s.cache.GetAsset(s.server, assetTypeLocationHierarchySet, "")
 	if err != nil {
 		return nil, err
 	}
-	hierarchy, isType := asset.(*utils.LocationHierarchy)
+	set, isType := asset.(*flows.LocationHierarchySet)
 	if !isType {
 		return nil, fmt.Errorf("asset cache contains asset with wrong type")
 	}
-	return hierarchy, nil
+	return set, nil
 }
 
 // GetChannel gets a channel asset for the session

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -128,7 +128,7 @@ type SessionAssets interface {
 	GetLabelSet() (*LabelSet, error)
 
 	HasLocations() bool
-	GetLocationHierarchy() (*utils.LocationHierarchy, error)
+	GetLocationHierarchySet() (*LocationHierarchySet, error)
 
 	GetResthookSet() (*ResthookSet, error)
 }

--- a/flows/location.go
+++ b/flows/location.go
@@ -1,6 +1,7 @@
 package flows
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/nyaruka/goflow/excellent/types"
@@ -46,3 +47,39 @@ func (p LocationPath) ToXJSON(env utils.Environment) types.XText {
 }
 
 var _ types.XValue = LocationPath("")
+
+// LocationHierarchySet defines the unordered set of all location hierarchies for a session
+type LocationHierarchySet struct {
+	hierarchies []*utils.LocationHierarchy
+}
+
+// NewLocationHierarchySet creates a new location hierarchy set from the given list of hierarchies
+func NewLocationHierarchySet(hierarchies []*utils.LocationHierarchy) *LocationHierarchySet {
+	return &LocationHierarchySet{hierarchies: hierarchies}
+}
+
+// All returns all hierarchies in this location hierarchy set
+func (s *LocationHierarchySet) All() []*utils.LocationHierarchy {
+	return s.hierarchies
+}
+
+//------------------------------------------------------------------------------------------
+// JSON Encoding / Decoding
+//------------------------------------------------------------------------------------------
+
+// ReadLocationHierarchySet reads a location hierarchy set from the given JSON
+func ReadLocationHierarchySet(data json.RawMessage) (*LocationHierarchySet, error) {
+	items, err := utils.UnmarshalArray(data)
+	if err != nil {
+		return nil, err
+	}
+
+	hierarchies := make([]*utils.LocationHierarchy, len(items))
+	for d := range items {
+		if hierarchies[d], err = utils.ReadLocationHierarchy(items[d]); err != nil {
+			return nil, err
+		}
+	}
+
+	return NewLocationHierarchySet(hierarchies), nil
+}

--- a/flows/runs/environment.go
+++ b/flows/runs/environment.go
@@ -46,7 +46,14 @@ func (e *runEnvironment) Languages() utils.LanguageList {
 func (e *runEnvironment) Locations() (*utils.LocationHierarchy, error) {
 	sessionAssets := e.run.Session().Assets()
 	if sessionAssets.HasLocations() {
-		return sessionAssets.GetLocationHierarchy()
+		hierarchies, err := sessionAssets.GetLocationHierarchySet()
+		if err != nil {
+			return nil, err
+		}
+
+		// in the future we might support more than one hiearchy per session,
+		// but for now we only use the first one
+		return hierarchies.All()[0], nil
 	}
 
 	return nil, nil

--- a/test/session.go
+++ b/test/session.go
@@ -173,41 +173,43 @@ var sessionAssets = `[
         ]
     },
     {
-        "type": "location_hierarchy",
+        "type": "location_hierarchy_set",
         "url": "http://testserver/assets/location_hierarchy",
-        "content": {
-            "id": "2342",
-            "name": "Rwanda",
-            "aliases": ["Ruanda"],		
-            "children": [
-                {
-                    "id": "234521",
-                    "name": "Kigali City",
-                    "aliases": ["Kigali", "Kigari"],
-                    "children": [
-                        {
-                            "id": "57735322",
-                            "name": "Gasabo",
-                            "children": [
-                                {
-                                    "id": "575743222",
-                                    "name": "Gisozi"
-                                },
-                                {
-                                    "id": "457378732",
-                                    "name": "Ndera"
-                                }
-                            ]
-                        },
-                        {
-                            "id": "46547322",
-                            "name": "Nyarugenge",
-                            "children": []
-                        }
-                    ]
-                }
-            ]
-        }
+        "content": [
+            {
+                "id": "2342",
+                "name": "Rwanda",
+                "aliases": ["Ruanda"],		
+                "children": [
+                    {
+                        "id": "234521",
+                        "name": "Kigali City",
+                        "aliases": ["Kigali", "Kigari"],
+                        "children": [
+                            {
+                                "id": "57735322",
+                                "name": "Gasabo",
+                                "children": [
+                                    {
+                                        "id": "575743222",
+                                        "name": "Gisozi"
+                                    },
+                                    {
+                                        "id": "457378732",
+                                        "name": "Ndera"
+                                    }
+                                ]
+                            },
+                            {
+                                "id": "46547322",
+                                "name": "Nyarugenge",
+                                "children": []
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     },
     {
         "type": "resthook_set",


### PR DESCRIPTION
So that we're consistent with asset server URLs - `/foo/` returns a set and `/foo/xyz` returns an object