### PR TITLE
Migrate flows individually

### DIFF
--- a/cmd/flowserver/handlers.go
+++ b/cmd/flowserver/handlers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/excellent/types"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/assets"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/flows/events"
@@ -133,8 +132,8 @@ func (s *FlowServer) handleResume(w http.ResponseWriter, r *http.Request) (inter
 }
 
 type migrateRequest struct {
-	Flows     []json.RawMessage `json:"flows"`
-	IncludeUI *bool             `json:"include_ui"`
+	Flow      json.RawMessage `json:"flow"`
+	IncludeUI *bool           `json:"include_ui"`
 }
 
 func (s *FlowServer) handleMigrate(w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -152,26 +151,18 @@ func (s *FlowServer) handleMigrate(w http.ResponseWriter, r *http.Request) (inte
 		return nil, err
 	}
 
-	if migrate.Flows == nil {
-		return nil, fmt.Errorf("missing flows element")
+	if migrate.Flow == nil {
+		return nil, fmt.Errorf("missing flow element")
 	}
 
-	legacyFlows, err := legacy.ReadLegacyFlows(migrate.Flows)
+	legacyFlow, err := legacy.ReadLegacyFlow(migrate.Flow)
 	if err != nil {
 		return nil, err
 	}
 
 	includeUI := migrate.IncludeUI == nil || *migrate.IncludeUI
 
-	flows := make([]flows.Flow, len(legacyFlows))
-	for f := range legacyFlows {
-		flows[f], err = legacyFlows[f].Migrate(includeUI)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return flows, err
+	return legacyFlow.Migrate(includeUI)
 }
 
 type expressionResponse struct {

--- a/legacy/definition.go
+++ b/legacy/definition.go
@@ -985,20 +985,6 @@ func migateActionSet(lang utils.Language, a ActionSet, localization flows.Locali
 	return definition.NewNode(a.UUID, actions, nil, []flows.Exit{definition.NewExit(a.ExitUUID, a.Destination, "")}, nil), nil
 }
 
-// ReadLegacyFlows reads in legacy formatted flows
-func ReadLegacyFlows(data []json.RawMessage) ([]*Flow, error) {
-	var err error
-	flows := make([]*Flow, len(data))
-	for f := range data {
-		flows[f], err = ReadLegacyFlow(data[f])
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return flows, nil
-}
-
 // ReadLegacyFlow reads a single legacy formatted flow
 func ReadLegacyFlow(data json.RawMessage) (*Flow, error) {
 	flow := &Flow{}

--- a/legacy/definition_test.go
+++ b/legacy/definition_test.go
@@ -15,92 +15,86 @@ import (
 )
 
 var legacyActionHolderDef = `
-[
-	{
-		"base_language": "eng",
-		"entry": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65", 
-		"action_sets": [{
-			"uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
-			"y": 100, 
-            "x": 100, 
-			"destination": null, 
-			"exit_uuid": "cfcf5cef-49f9-41a6-886b-f466575a3045",
-			"actions": [%s]
-		}],
-		"metadata": {
-			"uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7",
-			"name": "TestFlow"
-		}
+{
+	"base_language": "eng",
+	"entry": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65", 
+	"action_sets": [{
+		"uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
+		"y": 100, 
+		"x": 100, 
+		"destination": null, 
+		"exit_uuid": "cfcf5cef-49f9-41a6-886b-f466575a3045",
+		"actions": [%s]
+	}],
+	"metadata": {
+		"uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7",
+		"name": "TestFlow"
 	}
-]
+}
 `
 
 var legacyTestHolderDef = `
-[
-	{
-		"base_language": "eng",
-		"entry": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
-		"rule_sets": [{
-			"uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
-			"rules": [{
-				"test": %s, 
-				"category": {"eng": "All Responses"}, 
-				"destination": null, 
-				"uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783", 
-				"destination_type": null
-			}],
-			"ruleset_type": "wait_message", 
-			"label": "Name", 
-			"operand": "@step.value", 
-			"finished_key": null, 
-			"response_type": "", 
-			"y": 0, 
-			"x": 100, 
-			"config": {}
+{
+	"base_language": "eng",
+	"entry": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
+	"rule_sets": [{
+		"uuid": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
+		"rules": [{
+			"test": %s, 
+			"category": {"eng": "All Responses"}, 
+			"destination": null, 
+			"uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783", 
+			"destination_type": null
 		}],
-		"metadata": {
-			"uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7",
-			"name": "TestFlow"
-		}
+		"ruleset_type": "wait_message", 
+		"label": "Name", 
+		"operand": "@step.value", 
+		"finished_key": null, 
+		"response_type": "", 
+		"y": 0, 
+		"x": 100, 
+		"config": {}
+	}],
+	"metadata": {
+		"uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7",
+		"name": "TestFlow"
 	}
-]
+}
 `
 
 var legacyRuleSetHolderDef = `
-[
-	{
-		"base_language": "eng",
-		"entry": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
-		"rule_sets": [%s],
-		"action_sets": [
-			{
-				"uuid": "5b977652-91e3-48be-8e86-7c8094b4aa8f",
-				"x": 0, "y": 200, 
-				"destination": null, 
-				"exit_uuid": "cfcf5cef-49f9-41a6-886b-f466575a3045",
-				"actions": []
-			},
-			{
-				"uuid": "833fc698-d590-42dc-93e1-39e701b7e8e4",
-				"x": 0, "y": 400, 
-				"destination": null, 
-				"exit_uuid": "da3e7eaf-c087-4e80-97b5-0b2e217fcc93",
-				"actions": []
-			},
-			{
-				"uuid": "42ff72d3-5f4d-4dbf-89c9-8a97864dabcd",
-				"x": 0, "y": 600, 
-				"destination": null, 
-				"exit_uuid": "6a8cb81b-1b59-4cfb-b00e-575ccbafd3ba",
-				"actions": []
-			}
-		],
-		"metadata": {
-			"uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7",
-			"name": "TestFlow"
+{
+	"base_language": "eng",
+	"entry": "10e483a8-5ffb-4c4f-917b-d43ce86c1d65",
+	"rule_sets": [%s],
+	"action_sets": [
+		{
+			"uuid": "5b977652-91e3-48be-8e86-7c8094b4aa8f",
+			"x": 0, "y": 200, 
+			"destination": null, 
+			"exit_uuid": "cfcf5cef-49f9-41a6-886b-f466575a3045",
+			"actions": []
+		},
+		{
+			"uuid": "833fc698-d590-42dc-93e1-39e701b7e8e4",
+			"x": 0, "y": 400, 
+			"destination": null, 
+			"exit_uuid": "da3e7eaf-c087-4e80-97b5-0b2e217fcc93",
+			"actions": []
+		},
+		{
+			"uuid": "42ff72d3-5f4d-4dbf-89c9-8a97864dabcd",
+			"x": 0, "y": 600, 
+			"destination": null, 
+			"exit_uuid": "6a8cb81b-1b59-4cfb-b00e-575ccbafd3ba",
+			"actions": []
 		}
+	],
+	"metadata": {
+		"uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7",
+		"name": "TestFlow"
 	}
-]
+}
 `
 
 type FlowMigrationTest struct {
@@ -161,11 +155,11 @@ func TestActionMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, test := range tests {
-		legacyFlowsJSON := fmt.Sprintf(legacyActionHolderDef, string(test.LegacyAction))
-		legacyFlows, err := readLegacyTestFlows(legacyFlowsJSON)
+		legacyFlowJSON := fmt.Sprintf(legacyActionHolderDef, string(test.LegacyAction))
+		legacyFlow, err := legacy.ReadLegacyFlow(json.RawMessage(legacyFlowJSON))
 		require.NoError(t, err)
 
-		migratedFlow, err := legacyFlows[0].Migrate(false)
+		migratedFlow, err := legacyFlow.Migrate(false)
 		require.NoError(t, err)
 
 		migratedAction := migratedFlow.Nodes()[0].Actions()[0]
@@ -192,11 +186,11 @@ func TestTestMigration(t *testing.T) {
 	for _, test := range tests {
 		utils.SetUUIDGenerator(utils.NewSeededUUID4Generator(123456))
 
-		legacyFlowsJSON := fmt.Sprintf(legacyTestHolderDef, string(test.LegacyTest))
-		legacyFlows, err := readLegacyTestFlows(legacyFlowsJSON)
+		legacyFlowJSON := fmt.Sprintf(legacyTestHolderDef, string(test.LegacyTest))
+		legacyFlow, err := legacy.ReadLegacyFlow(json.RawMessage(legacyFlowJSON))
 		require.NoError(t, err)
 
-		migratedFlow, err := legacyFlows[0].Migrate(false)
+		migratedFlow, err := legacyFlow.Migrate(false)
 		require.NoError(t, err)
 
 		migratedRouter := migratedFlow.Nodes()[0].Router().(*routers.SwitchRouter)
@@ -228,11 +222,11 @@ func TestRuleSetMigration(t *testing.T) {
 	for _, test := range tests {
 		utils.SetUUIDGenerator(utils.NewSeededUUID4Generator(123456))
 
-		legacyFlowsJSON := fmt.Sprintf(legacyRuleSetHolderDef, string(test.LegacyRuleSet))
-		legacyFlows, err := readLegacyTestFlows(legacyFlowsJSON)
+		legacyFlowJSON := fmt.Sprintf(legacyRuleSetHolderDef, string(test.LegacyRuleSet))
+		legacyFlow, err := legacy.ReadLegacyFlow(json.RawMessage(legacyFlowJSON))
 		require.NoError(t, err)
 
-		migratedFlow, err := legacyFlows[0].Migrate(false)
+		migratedFlow, err := legacyFlow.Migrate(false)
 		require.NoError(t, err)
 
 		// check we now have a new node in addition to the 3 actionsets used as destinations
@@ -259,12 +253,6 @@ func TestRuleSetMigration(t *testing.T) {
 			checkFlowLocalization(t, migratedFlow, test.ExpectedLocalization)
 		}
 	}
-}
-
-func readLegacyTestFlows(flowsJSON string) ([]*legacy.Flow, error) {
-	var legacyFlows []json.RawMessage
-	json.Unmarshal(json.RawMessage(flowsJSON), &legacyFlows)
-	return legacy.ReadLegacyFlows(legacyFlows)
 }
 
 func checkFlowLocalization(t *testing.T, flow flows.Flow, expectedLocalizationRaw json.RawMessage) {


### PR DESCRIPTION
Simplifies legacy flow migration by doing one flow at a time - this is how we always use it now from RapidPro