### PR TITLE
🍫 Wrap multiple asset responses in a results object

### DIFF
--- a/flows/assets/assets_test.go
+++ b/flows/assets/assets_test.go
@@ -12,10 +12,14 @@ import (
 
 func TestAssetCache(t *testing.T) {
 	server := NewMockAssetServer()
-	server.MockResponse("http://testserver/assets/label/", json.RawMessage(`[{
-		"uuid": "f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4",
-		"name": "Spam"
-	}]`))
+	server.MockResponse("http://testserver/assets/label/", json.RawMessage(`{
+		"results": [
+			{
+				"uuid": "f2a3e00c-e86a-4282-a9e8-bb2275e1b9a4",
+				"name": "Spam"
+			}
+		]
+	}`))
 	cache := NewAssetCache(100, 10)
 
 	asset, err := cache.GetAsset(server, assetType("pizza"), "")
@@ -37,10 +41,14 @@ func TestAssetCache(t *testing.T) {
 
 func TestAssetServer(t *testing.T) {
 	server := NewMockAssetServer()
-	server.MockResponse("http://testserver/assets/group/", json.RawMessage(`[{
-		"uuid": "da310302-2340-4cee-b5bb-5ee37a24a122",
-		"name": "Survey Audience"
-	}]`))
+	server.MockResponse("http://testserver/assets/group/", json.RawMessage(`{
+		"results": [
+			{
+				"uuid": "da310302-2340-4cee-b5bb-5ee37a24a122",
+				"name": "Survey Audience"
+			}
+		]
+	}`))
 	server.MockResponse("http://testserver/assets/flow/2aad21f6-30b7-42c5-bd7f-1b720c154817/", json.RawMessage(`{
 		"uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817",
 		"name": "Registration",
@@ -69,12 +77,14 @@ func TestAssetServer(t *testing.T) {
 
 func TestSessionAssets(t *testing.T) {
 	server := NewMockAssetServer()
-	server.mockResponses["http://testserver/assets/group/"] = json.RawMessage(`[
-		{
-			"uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817",
-			"name": "Survey Audience"
-		}
-	]`)
+	server.mockResponses["http://testserver/assets/group/"] = json.RawMessage(`{
+		"results": [
+			{
+				"uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817",
+				"name": "Survey Audience"
+			}
+		]
+	}`)
 	cache := NewAssetCache(100, 10)
 	sessionAssets := NewSessionAssets(cache, server)
 

--- a/flows/assets/server.go
+++ b/flows/assets/server.go
@@ -84,11 +84,11 @@ func (s *assetServer) fetchAsset(url string, itemType assetType) (interface{}, e
 	log.WithField("asset_type", string(itemType)).WithField("url", url).Debugf("asset requested")
 
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("asset request (%s) returned non-200 response (%d)", url, response.StatusCode)
+		return nil, fmt.Errorf("request returned non-200 response (%d)", response.StatusCode)
 	}
 
 	if response.Header.Get("Content-Type") != "application/json" {
-		return nil, fmt.Errorf("asset request (%s) returned non-JSON response", url)
+		return nil, fmt.Errorf("request returned non-JSON response")
 	}
 
 	buf, err := ioutil.ReadAll(response.Body)
@@ -96,7 +96,12 @@ func (s *assetServer) fetchAsset(url string, itemType assetType) (interface{}, e
 		return nil, err
 	}
 
-	return readAsset(buf, itemType)
+	cfg := typeConfigs[itemType]
+	if cfg == nil {
+		return nil, fmt.Errorf("unsupported asset type: %s", itemType)
+	}
+
+	return readAsset(buf, itemType, true)
 }
 
 type MockAssetServer struct {
@@ -140,7 +145,7 @@ func (s *MockAssetServer) fetchAsset(url string, itemType assetType) (interface{
 	if !found {
 		return nil, fmt.Errorf("mock asset server has no mocked response for URL: %s", url)
 	}
-	return readAsset(assetBuf, itemType)
+	return readAsset(assetBuf, itemType, true)
 }
 
 // MarshalJSON marshals this mock asset server into JSON


### PR DESCRIPTION
Equivalent RapidPro change: https://github.com/nyaruka/rapidpro/pull/2054