### PR TITLE
Better docs

### DIFF
--- a/cmd/docgen/docs.go
+++ b/cmd/docgen/docs.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -14,6 +15,8 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 )
+
+var tagLineRegex = regexp.MustCompile(`@\w+\s+(?P<value>\w+)(?P<extra>.+)?`)
 
 var docSets = []struct {
 	contextKey string
@@ -32,7 +35,8 @@ var docSets = []struct {
 type documentedItem struct {
 	typeName    string   // actual go type name
 	tagName     string   // tag used to make this as a documented item
-	tagValue    string   // value after @tag
+	tagValue    string   // identifier value after @tag
+	tagExtra    string   // additional text after tag value
 	examples    []string // any indented line
 	description []string // any other line
 }
@@ -40,12 +44,12 @@ type documentedItem struct {
 type renderFunc func(output *strings.Builder, item *documentedItem, session flows.Session) error
 
 // builds the documentation generation context from the given base directory
-func buildDocsContext(baseDir string) (map[string]string, error) {
+func buildDocsContext(baseDir string) (map[string]string, map[string]bool, error) {
 	fmt.Println("Generating docs...")
 
 	server, err := test.NewTestHTTPServer(49998)
 	if err != nil {
-		return nil, fmt.Errorf("error starting mock HTTP server: %s", err)
+		return nil, nil, fmt.Errorf("error starting mock HTTP server: %s", err)
 	}
 	defer server.Close()
 
@@ -59,26 +63,31 @@ func buildDocsContext(baseDir string) (map[string]string, error) {
 
 	session, err := test.CreateTestSession(server.URL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error creating example session: %s", err)
+		return nil, nil, fmt.Errorf("error creating example session: %s", err)
 	}
 
 	context := make(map[string]string, len(docSets))
+	linkTargets := make(map[string]bool)
 
 	for _, ds := range docSets {
-		if context[ds.contextKey], err = buildDocSet(baseDir, ds.searchDirs, ds.tag, ds.handler, session); err != nil {
-			return nil, err
+		var tagValues []string
+		if context[ds.contextKey], tagValues, err = buildDocSet(baseDir, ds.searchDirs, ds.tag, ds.handler, session); err != nil {
+			return nil, nil, err
+		}
+		for _, tagValue := range tagValues {
+			linkTargets[ds.tag+":"+tagValue] = true
 		}
 	}
 
-	return context, nil
+	return context, linkTargets, nil
 }
 
-func buildDocSet(baseDir string, searchDirs []string, tag string, renderer renderFunc, session flows.Session) (string, error) {
+func buildDocSet(baseDir string, searchDirs []string, tag string, renderer renderFunc, session flows.Session) (string, []string, error) {
 	items := make([]*documentedItem, 0)
 	for _, searchDir := range searchDirs {
 		fromDir, err := findDocumentedItems(baseDir, searchDir, tag)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 		items = append(items, fromDir...)
 	}
@@ -89,14 +98,17 @@ func buildDocSet(baseDir string, searchDirs []string, tag string, renderer rende
 	fmt.Printf(" > Found %d documented items with tag %s\n", len(items), tag)
 
 	buffer := &strings.Builder{}
+	tagValues := make([]string, len(items))
 
-	for _, item := range items {
+	for i, item := range items {
+		tagValues[i] = item.tagValue
+
 		if err := renderer(buffer, item, session); err != nil {
-			return "", fmt.Errorf("error rendering %s:%s: %s", item.tagName, item.tagValue, err)
+			return "", nil, fmt.Errorf("error rendering %s:%s: %s", item.tagName, item.tagValue, err)
 		}
 	}
 
-	return buffer.String(), nil
+	return buffer.String(), tagValues, nil
 }
 
 // finds all documented items in go files in the given directory
@@ -129,7 +141,7 @@ func findDocumentedItems(baseDir string, searchDir string, tag string) ([]*docum
 }
 
 func parseDocString(tag string, docString string, typeName string) *documentedItem {
-	var tagValue string
+	var tagValue, tagExtra string
 	examples := make([]string, 0)
 	description := make([]string, 0)
 
@@ -139,7 +151,9 @@ func parseDocString(tag string, docString string, typeName string) *documentedIt
 		trimmed := strings.TrimSpace(l)
 
 		if strings.HasPrefix(l, tag) {
-			tagValue = l[len(tag)+1:]
+			parts := tagLineRegex.FindStringSubmatch(l)
+			tagValue = parts[1]
+			tagExtra = parts[2]
 		} else if strings.HasPrefix(l, "  ") { // examples are indented by at least two spaces
 			examples = append(examples, trimmed)
 		} else {
@@ -147,7 +161,7 @@ func parseDocString(tag string, docString string, typeName string) *documentedIt
 		}
 	}
 
-	return &documentedItem{typeName: typeName, tagName: tag[1:], tagValue: tagValue, examples: examples, description: description}
+	return &documentedItem{typeName: typeName, tagName: tag[1:], tagValue: tagValue, tagExtra: tagExtra, examples: examples, description: description}
 }
 
 // Golang convention is to start all docstrings with the type name, but the actual type name can differ from how the type is

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
+	"strings"
 	"text/template"
 )
 
@@ -21,12 +23,13 @@ const (
 
 var resources = []string{"styles.css"}
 var templates = []struct {
-	title string
-	path  string
+	title         string
+	path          string
+	containsTypes []string
 }{
-	{"Flow Specification", "index.md"},
-	{"Flows", "flows.md"},
-	{"Sessions", "sessions.md"},
+	{"Flow Specification", "index.md", nil},
+	{"Flows", "flows.md", []string{"action", "function", "router", "wait"}},
+	{"Sessions", "sessions.md", []string{"event", "trigger"}},
 }
 
 func main() {
@@ -41,6 +44,12 @@ func GenerateDocs(baseDir string, outputDir string) error {
 	context, err := buildDocsContext(baseDir)
 	if err != nil {
 		return fmt.Errorf("error building docs context: %s", err)
+	}
+
+	// post-process context values to resolve links between templates
+	linkResolver := createLinkResolver()
+	for k, v := range context {
+		context[k] = resolveLinks(v, linkResolver)
 	}
 
 	// ensure our output directory exists
@@ -122,6 +131,36 @@ func renderHTML(src, dst, htmlTemplate string, variables map[string]string) erro
 
 	panDocArgs = append(panDocArgs, src)
 	return exec.Command("pandoc", panDocArgs...).Run()
+}
+
+func createLinkResolver() func(string, string) (string, error) {
+	typeTemplates := make(map[string]string)
+
+	for _, template := range templates {
+		for _, typeTag := range template.containsTypes {
+			typeTemplates[typeTag] = fmt.Sprintf("%s.html#%s:%%s", template.path[0:len(template.path)-3], typeTag)
+		}
+	}
+
+	return func(tag string, val string) (string, error) {
+		linkTpl := typeTemplates[tag]
+		if linkTpl == "" {
+			return "", fmt.Errorf("no link template for type %s", tag)
+		}
+		return fmt.Sprintf(linkTpl, val), nil
+	}
+}
+
+func resolveLinks(s string, urlResolver func(string, string) (string, error)) string {
+	r := regexp.MustCompile(`\[\w+:\w+\]`)
+	return r.ReplaceAllStringFunc(s, func(old string) string {
+		groups := strings.Split(old[1:len(old)-1], ":")
+		url, err := urlResolver(groups[0], groups[1])
+		if err != nil {
+			return err.Error()
+		}
+		return fmt.Sprintf("[%s](%s)", groups[1], url)
+	})
 }
 
 // copies a file from one path to another

--- a/cmd/docgen/renderers.go
+++ b/cmd/docgen/renderers.go
@@ -45,11 +45,8 @@ func renderFunctionDoc(output *strings.Builder, item *documentedItem, session fl
 		return fmt.Errorf("no examples found for function %s", item.tagValue)
 	}
 
-	// get name of function from signature to use as our anchor
-	name := item.tagValue[0:strings.Index(item.tagValue, "(")]
-
 	// check the function name is a registered function
-	_, exists := functions.XFUNCTIONS[name]
+	_, exists := functions.XFUNCTIONS[item.tagValue]
 	if !exists {
 		return fmt.Errorf("docstring function tag %s isn't a registered function", item.tagValue)
 	}
@@ -63,8 +60,8 @@ func renderFunctionDoc(output *strings.Builder, item *documentedItem, session fl
 
 	exampleBlock := strings.Replace(strings.Join(item.examples, "\n"), "->", "→", -1)
 
-	output.WriteString(fmt.Sprintf("<a name=\"%s:%s\"></a>\n\n", item.tagName, name))
-	output.WriteString(fmt.Sprintf("## %s\n\n", item.tagValue))
+	output.WriteString(fmt.Sprintf("<a name=\"%s:%s\"></a>\n\n", item.tagName, item.tagValue))
+	output.WriteString(fmt.Sprintf("## %s%s\n\n", item.tagValue, item.tagExtra))
 	output.WriteString(strings.Join(item.description, "\n"))
 	output.WriteString("\n")
 	output.WriteString("```objectivec\n")

--- a/cmd/docgen/templates/styles.css
+++ b/cmd/docgen/templates/styles.css
@@ -115,8 +115,7 @@ code .st {
     color: #888;
 }
 
-p code,
-li code {
+p code, li code {
     color: white;
     background-color: #444;
     border-radius: 3px;

--- a/docs/flows.html
+++ b/docs/flows.html
@@ -302,7 +302,7 @@
 <li><code>scheme</code> the scheme of the URN, e.g. “tel”, “twitter”</li>
 <li><code>path</code> the path of the URN, e.g. “+16303524567”</li>
 <li><code>display</code> the display portion of the URN, e.g. “+16303524567”</li>
-<li><code>channel</code> the preferred <a href="flows.html#context:channel">channel</a> of the URN</li>
+<li><code>channel</code> the preferred <a href="#context:channel">channel</a> of the URN</li>
 </ul>
 <p>To render a URN in a human friendly format, use the <a href="flows.html#function:format_urn">format_urn</a> function.</p>
 <p>Examples:</p>
@@ -1022,7 +1022,7 @@
 <div class="actions">
 <p><a name="action:add_contact_groups"></a></p>
 <h2 id="add_contact_groups">add_contact_groups</h2>
-<p>Can be used to add a contact to one or more groups. An <a href="sessions.html#event:contact_groups_added">contact_groups_added</a> event will be created for the groups which the contact has been added to.</p>
+<p>Can be used to add a contact to one or more groups. A <a href="sessions.html#event:contact_groups_added">contact_groups_added</a> event will be created for the groups which the contact has been added to.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1056,7 +1056,7 @@ Event
 </div>
 <p><a name="action:add_contact_urn"></a></p>
 <h2 id="add_contact_urn">add_contact_urn</h2>
-<p>Can be used to add a URN to the current contact. An <a href="sessions.html#event:contact_urn_added">contact_urn_added</a> event will be created when this action is encountered. If there is no contact then this action will be ignored.</p>
+<p>Can be used to add a URN to the current contact. A <a href="sessions.html#event:contact_urn_added">contact_urn_added</a> event will be created when this action is encountered. If there is no contact then this action will be ignored.</p>
 <div class="input_action">
 <h3>
 Action

--- a/docs/flows.html
+++ b/docs/flows.html
@@ -302,9 +302,9 @@
 <li><code>scheme</code> the scheme of the URN, e.g. “tel”, “twitter”</li>
 <li><code>path</code> the path of the URN, e.g. “+16303524567”</li>
 <li><code>display</code> the display portion of the URN, e.g. “+16303524567”</li>
-<li><code>channel</code> the preferred <a href="#context:channel">channel</a> of the URN</li>
+<li><code>channel</code> the preferred no link template for type context of the URN</li>
 </ul>
-<p>To render a URN in a human friendly format, use the <a href="#function:format_urn">format_urn</a> function.</p>
+<p>To render a URN in a human friendly format, use the <a href="flows.html#function:format_urn">format_urn</a> function.</p>
 <p>Examples:</p>
 <div class="sourceCode" id="cb16"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb16-1" data-line-number="1">@contact.urns<span class="fl">.0</span> → tel:+<span class="dv">12065551212</span></a>
 <a class="sourceLine" id="cb16-2" data-line-number="2">@contact.urns.<span class="fl">0.</span>scheme → tel</a>
@@ -1022,7 +1022,7 @@
 <div class="actions">
 <p><a name="action:add_contact_groups"></a></p>
 <h2 id="add_contact_groups">add_contact_groups</h2>
-<p>Can be used to add a contact to one or more groups. An <code>contact_groups_added</code> event will be created for the groups which the contact has been added to.</p>
+<p>Can be used to add a contact to one or more groups. An <a href="sessions.html#event:contact_groups_added">contact_groups_added</a> event will be created for the groups which the contact has been added to.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1056,7 +1056,7 @@ Event
 </div>
 <p><a name="action:add_contact_urn"></a></p>
 <h2 id="add_contact_urn">add_contact_urn</h2>
-<p>Can be used to add a URN to the current contact. An <code>contact_urn_added</code> event will be created when this action is encountered. If there is no contact then this action will be ignored.</p>
+<p>Can be used to add a URN to the current contact. An <a href="sessions.html#event:contact_urn_added">contact_urn_added</a> event will be created when this action is encountered. If there is no contact then this action will be ignored.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1081,7 +1081,7 @@ Event
 </div>
 <p><a name="action:add_input_labels"></a></p>
 <h2 id="add_input_labels">add_input_labels</h2>
-<p>Can be used to add labels to the last user input on a flow. An <code>input_labels_added</code> event will be created with the labels added when this action is encountered. If there is no user input at that point then this action will be ignored.</p>
+<p>Can be used to add labels to the last user input on a flow. An <a href="sessions.html#event:input_labels_added">input_labels_added</a> event will be created with the labels added when this action is encountered. If there is no user input at that point then this action will be ignored.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1117,7 +1117,7 @@ Event
 <p><a name="action:call_resthook"></a></p>
 <h2 id="call_resthook">call_resthook</h2>
 <p>Can be used to call a resthook.</p>
-<p>A <code>resthook_subscriber_called</code> event will be created based on the results of the HTTP call to each subscriber of the resthook.</p>
+<p>A <a href="sessions.html#event:resthook_called">resthook_called</a> event will be created based on the results of the HTTP call to each subscriber of the resthook.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1151,7 +1151,7 @@ Event
 <p><a name="action:call_webhook"></a></p>
 <h2 id="call_webhook">call_webhook</h2>
 <p>Can be used to call an external service. The body, header and url fields may be templates and will be evaluated at runtime.</p>
-<p>A <code>webhook_called</code> event will be created based on the results of the HTTP call.</p>
+<p>A <a href="sessions.html#event:webhook_called">webhook_called</a> event will be created based on the results of the HTTP call.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1183,7 +1183,7 @@ Event
 </div>
 <p><a name="action:remove_contact_groups"></a></p>
 <h2 id="remove_contact_groups">remove_contact_groups</h2>
-<p>Can be used to remove a contact from one or more groups. A <code>contact_groups_removed</code> event will be created for the groups which the contact is removed from. Groups can either be explicitly provided or <code>all_groups</code> can be set to true to remove the contact from all non-dynamic groups.</p>
+<p>Can be used to remove a contact from one or more groups. A <a href="sessions.html#event:contact_groups_removed">contact_groups_removed</a> event will be created for the groups which the contact is removed from. Groups can either be explicitly provided or <code>all_groups</code> can be set to true to remove the contact from all non-dynamic groups.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1219,7 +1219,7 @@ Event
 <p><a name="action:send_broadcast"></a></p>
 <h2 id="send_broadcast">send_broadcast</h2>
 <p>Can be used to send a message to one or more contacts. It accepts a list of URNs, a list of groups and a list of contacts.</p>
-<p>The URNs and text fields may be templates. A <code>send_broadcast</code> event will be created for each unique urn, contact and group with the evaluated text.</p>
+<p>The URNs and text fields may be templates. A <a href="sessions.html#event:broadcast_created">broadcast_created</a> event will be created for each unique urn, contact and group with the evaluated text.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1256,7 +1256,7 @@ Event
 <p><a name="action:send_email"></a></p>
 <h2 id="send_email">send_email</h2>
 <p>Can be used to send an email to one or more recipients. The subject, body and addresses can all contain expressions.</p>
-<p>An <code>email_created</code> event will be created for each email address.</p>
+<p>An <a href="sessions.html#event:email_created">email_created</a> event will be created for each email address.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1289,7 +1289,7 @@ Event
 <p><a name="action:send_msg"></a></p>
 <h2 id="send_msg">send_msg</h2>
 <p>Can be used to reply to the current contact in a flow. The text field may contain templates.</p>
-<p>A <code>broadcast_created</code> event will be created with the evaluated text.</p>
+<p>A <a href="sessions.html#event:msg_created">msg_created</a> event will be created with the evaluated text.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1323,7 +1323,7 @@ Event
 <p><a name="action:set_contact_channel"></a></p>
 <h2 id="set_contact_channel">set_contact_channel</h2>
 <p>Can be used to update the preferred channel of the current contact.</p>
-<p>A <code>contact_channel_changed</code> event will be created with the set channel.</p>
+<p>A <a href="sessions.html#event:contact_channel_changed">contact_channel_changed</a> event will be created with the set channel.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1353,7 +1353,7 @@ Event
 </div>
 <p><a name="action:set_contact_field"></a></p>
 <h2 id="set_contact_field">set_contact_field</h2>
-<p>Can be used to update a field value on the contact. The value is a localizable template and white space is trimmed from the final value. An empty string clears the value. A <code>contact_field_changed</code> event will be created with the corresponding value.</p>
+<p>Can be used to update a field value on the contact. The value is a localizable template and white space is trimmed from the final value. An empty string clears the value. A <a href="sessions.html#event:contact_field_changed">contact_field_changed</a> event will be created with the corresponding value.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1385,7 +1385,7 @@ Event
 </div>
 <p><a name="action:set_contact_language"></a></p>
 <h2 id="set_contact_language">set_contact_language</h2>
-<p>Can be used to update the name of the contact. The language is a localizable template and white space is trimmed from the final value. An empty string clears the language. A <code>contact_language_changed</code> event will be created with the corresponding value.</p>
+<p>Can be used to update the name of the contact. The language is a localizable template and white space is trimmed from the final value. An empty string clears the language. A <a href="sessions.html#event:contact_language_changed">contact_language_changed</a> event will be created with the corresponding value.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1409,7 +1409,7 @@ Event
 </div>
 <p><a name="action:set_contact_name"></a></p>
 <h2 id="set_contact_name">set_contact_name</h2>
-<p>Can be used to update the name of the contact. The name is a localizable template and white space is trimmed from the final value. An empty string clears the name. A <code>contact_name_changed</code> event will be created with the corresponding value.</p>
+<p>Can be used to update the name of the contact. The name is a localizable template and white space is trimmed from the final value. An empty string clears the name. A <a href="sessions.html#event:contact_name_changed">contact_name_changed</a> event will be created with the corresponding value.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1433,7 +1433,7 @@ Event
 </div>
 <p><a name="action:set_contact_timezone"></a></p>
 <h2 id="set_contact_timezone">set_contact_timezone</h2>
-<p>Can be used to update the timezone of the contact. The timezone is a localizable template and white space is trimmed from the final value. An empty string clears the timezone. A <code>contact_timezone_changed</code> event will be created with the corresponding value.</p>
+<p>Can be used to update the timezone of the contact. The timezone is a localizable template and white space is trimmed from the final value. An empty string clears the timezone. A <a href="sessions.html#event:contact_timezone_changed">contact_timezone_changed</a> event will be created with the corresponding value.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1458,7 +1458,7 @@ Event
 <p><a name="action:set_run_result"></a></p>
 <h2 id="set_run_result">set_run_result</h2>
 <p>Can be used to save a result for a flow. The result will be available in the context for the run as <span class="citation" data-cites="run.results">@run.results</span>.[name]. The optional category can be used as a way of categorizing results, this can be useful for reporting or analytics.</p>
-<p>Both the value and category fields may be templates. A <code>run_result_changed</code> event will be created with the final values.</p>
+<p>Both the value and category fields may be templates. A <a href="sessions.html#event:run_result_changed">run_result_changed</a> event will be created with the final values.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1488,7 +1488,7 @@ Event
 <p><a name="action:start_flow"></a></p>
 <h2 id="start_flow">start_flow</h2>
 <p>Can be used to start a contact down another flow. The current flow will pause until the subflow exits or expires.</p>
-<p>A <code>flow_entered</code> event will be created when the flow is started, a <code>flow_exited</code> event will be created upon the subflows exit.</p>
+<p>A <a href="sessions.html#event:flow_triggered">flow_triggered</a> event will be created to record that the flow was started.</p>
 <div class="input_action">
 <h3>
 Action
@@ -1519,7 +1519,7 @@ Event
 </div>
 <p><a name="action:start_session"></a></p>
 <h2 id="start_session">start_session</h2>
-<p>Can be used to trigger sessions for other contacts and groups</p>
+<p>Can be used to trigger sessions for other contacts and groups. A <a href="sessions.html#event:session_triggered">session_triggered</a> event will be created and it’s the responsibility of the caller to act on that by initiating a new session with the flow engine.</p>
 <div class="input_action">
 <h3>
 Action

--- a/docs/flows.html
+++ b/docs/flows.html
@@ -302,7 +302,7 @@
 <li><code>scheme</code> the scheme of the URN, e.g. “tel”, “twitter”</li>
 <li><code>path</code> the path of the URN, e.g. “+16303524567”</li>
 <li><code>display</code> the display portion of the URN, e.g. “+16303524567”</li>
-<li><code>channel</code> the preferred no link template for type context of the URN</li>
+<li><code>channel</code> the preferred <a href="flows.html#context:channel">channel</a> of the URN</li>
 </ul>
 <p>To render a URN in a human friendly format, use the <a href="flows.html#function:format_urn">format_urn</a> function.</p>
 <p>Examples:</p>

--- a/docs/md/flows.md
+++ b/docs/md/flows.md
@@ -401,7 +401,7 @@ It has several properties which can be accessed in expressions:
  * `scheme` the scheme of the URN, e.g. "tel", "twitter"
  * `path` the path of the URN, e.g. "+16303524567"
  * `display` the display portion of the URN, e.g. "+16303524567"
- * `channel` the preferred [channel](flows.html#context:channel) of the URN
+ * `channel` the preferred [channel](#context:channel) of the URN
 
 To render a URN in a human friendly format, use the [format_urn](flows.html#function:format_urn) function.
 
@@ -1829,7 +1829,7 @@ representation of a contact's state based on action performed on a flow so that 
 
 ## add_contact_groups
 
-Can be used to add a contact to one or more groups. An [contact_groups_added](sessions.html#event:contact_groups_added) event will be created
+Can be used to add a contact to one or more groups. A [contact_groups_added](sessions.html#event:contact_groups_added) event will be created
 for the groups which the contact has been added to.
 
 <div class="input_action"><h3>Action</h3>```json
@@ -1862,7 +1862,7 @@ for the groups which the contact has been added to.
 
 ## add_contact_urn
 
-Can be used to add a URN to the current contact. An [contact_urn_added](sessions.html#event:contact_urn_added) event
+Can be used to add a URN to the current contact. A [contact_urn_added](sessions.html#event:contact_urn_added) event
 will be created when this action is encountered. If there is no contact then this
 action will be ignored.
 

--- a/docs/md/flows.md
+++ b/docs/md/flows.md
@@ -401,7 +401,7 @@ It has several properties which can be accessed in expressions:
  * `scheme` the scheme of the URN, e.g. "tel", "twitter"
  * `path` the path of the URN, e.g. "+16303524567"
  * `display` the display portion of the URN, e.g. "+16303524567"
- * `channel` the preferred no link template for type context of the URN
+ * `channel` the preferred [channel](flows.html#context:channel) of the URN
 
 To render a URN in a human friendly format, use the [format_urn](flows.html#function:format_urn) function.
 

--- a/docs/md/flows.md
+++ b/docs/md/flows.md
@@ -401,9 +401,9 @@ It has several properties which can be accessed in expressions:
  * `scheme` the scheme of the URN, e.g. "tel", "twitter"
  * `path` the path of the URN, e.g. "+16303524567"
  * `display` the display portion of the URN, e.g. "+16303524567"
- * `channel` the preferred [channel](#context:channel) of the URN
+ * `channel` the preferred no link template for type context of the URN
 
-To render a URN in a human friendly format, use the [format_urn](#function:format_urn) function.
+To render a URN in a human friendly format, use the [format_urn](flows.html#function:format_urn) function.
 
 Examples:
 
@@ -1829,7 +1829,7 @@ representation of a contact's state based on action performed on a flow so that 
 
 ## add_contact_groups
 
-Can be used to add a contact to one or more groups. An `contact_groups_added` event will be created
+Can be used to add a contact to one or more groups. An [contact_groups_added](sessions.html#event:contact_groups_added) event will be created
 for the groups which the contact has been added to.
 
 <div class="input_action"><h3>Action</h3>```json
@@ -1862,7 +1862,7 @@ for the groups which the contact has been added to.
 
 ## add_contact_urn
 
-Can be used to add a URN to the current contact. An `contact_urn_added` event
+Can be used to add a URN to the current contact. An [contact_urn_added](sessions.html#event:contact_urn_added) event
 will be created when this action is encountered. If there is no contact then this
 action will be ignored.
 
@@ -1887,7 +1887,7 @@ action will be ignored.
 
 ## add_input_labels
 
-Can be used to add labels to the last user input on a flow. An `input_labels_added` event
+Can be used to add labels to the last user input on a flow. An [input_labels_added](sessions.html#event:input_labels_added) event
 will be created with the labels added when this action is encountered. If there is
 no user input at that point then this action will be ignored.
 
@@ -1924,7 +1924,7 @@ no user input at that point then this action will be ignored.
 
 Can be used to call a resthook.
 
-A `resthook_subscriber_called` event will be created based on the results of the HTTP call
+A [resthook_called](sessions.html#event:resthook_called) event will be created based on the results of the HTTP call
 to each subscriber of the resthook.
 
 <div class="input_action"><h3>Action</h3>```json
@@ -1959,7 +1959,7 @@ to each subscriber of the resthook.
 Can be used to call an external service. The body, header and url fields may be
 templates and will be evaluated at runtime.
 
-A `webhook_called` event will be created based on the results of the HTTP call.
+A [webhook_called](sessions.html#event:webhook_called) event will be created based on the results of the HTTP call.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -1989,7 +1989,7 @@ A `webhook_called` event will be created based on the results of the HTTP call.
 
 ## remove_contact_groups
 
-Can be used to remove a contact from one or more groups. A `contact_groups_removed` event will be created
+Can be used to remove a contact from one or more groups. A [contact_groups_removed](sessions.html#event:contact_groups_removed) event will be created
 for the groups which the contact is removed from. Groups can either be explicitly provided or `all_groups` can be set to true to remove
 the contact from all non-dynamic groups.
 
@@ -2027,7 +2027,7 @@ the contact from all non-dynamic groups.
 Can be used to send a message to one or more contacts. It accepts a list of URNs, a list of groups
 and a list of contacts.
 
-The URNs and text fields may be templates. A `send_broadcast` event will be created for each unique urn, contact and group
+The URNs and text fields may be templates. A [broadcast_created](sessions.html#event:broadcast_created) event will be created for each unique urn, contact and group
 with the evaluated text.
 
 <div class="input_action"><h3>Action</h3>```json
@@ -2065,7 +2065,7 @@ with the evaluated text.
 Can be used to send an email to one or more recipients. The subject, body and addresses
 can all contain expressions.
 
-An `email_created` event will be created for each email address.
+An [email_created](sessions.html#event:email_created) event will be created for each email address.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2097,7 +2097,7 @@ An `email_created` event will be created for each email address.
 
 Can be used to reply to the current contact in a flow. The text field may contain templates.
 
-A `broadcast_created` event will be created with the evaluated text.
+A [msg_created](sessions.html#event:msg_created) event will be created with the evaluated text.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2130,7 +2130,7 @@ A `broadcast_created` event will be created with the evaluated text.
 
 Can be used to update the preferred channel of the current contact.
 
-A `contact_channel_changed` event will be created with the set channel.
+A [contact_channel_changed](sessions.html#event:contact_channel_changed) event will be created with the set channel.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2160,7 +2160,7 @@ A `contact_channel_changed` event will be created with the set channel.
 
 Can be used to update a field value on the contact. The value is a localizable
 template and white space is trimmed from the final value. An empty string clears the value.
-A `contact_field_changed` event will be created with the corresponding value.
+A [contact_field_changed](sessions.html#event:contact_field_changed) event will be created with the corresponding value.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2192,7 +2192,7 @@ A `contact_field_changed` event will be created with the corresponding value.
 
 Can be used to update the name of the contact. The language is a localizable
 template and white space is trimmed from the final value. An empty string clears the language.
-A `contact_language_changed` event will be created with the corresponding value.
+A [contact_language_changed](sessions.html#event:contact_language_changed) event will be created with the corresponding value.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2216,7 +2216,7 @@ A `contact_language_changed` event will be created with the corresponding value.
 
 Can be used to update the name of the contact. The name is a localizable
 template and white space is trimmed from the final value. An empty string clears the name.
-A `contact_name_changed` event will be created with the corresponding value.
+A [contact_name_changed](sessions.html#event:contact_name_changed) event will be created with the corresponding value.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2240,7 +2240,7 @@ A `contact_name_changed` event will be created with the corresponding value.
 
 Can be used to update the timezone of the contact. The timezone is a localizable
 template and white space is trimmed from the final value. An empty string clears the timezone.
-A `contact_timezone_changed` event will be created with the corresponding value.
+A [contact_timezone_changed](sessions.html#event:contact_timezone_changed) event will be created with the corresponding value.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2266,7 +2266,7 @@ Can be used to save a result for a flow. The result will be available in the con
 for the run as @run.results.[name]. The optional category can be used as a way of categorizing results,
 this can be useful for reporting or analytics.
 
-Both the value and category fields may be templates. A `run_result_changed` event will be created with the
+Both the value and category fields may be templates. A [run_result_changed](sessions.html#event:run_result_changed) event will be created with the
 final values.
 
 <div class="input_action"><h3>Action</h3>```json
@@ -2296,7 +2296,7 @@ final values.
 
 Can be used to start a contact down another flow. The current flow will pause until the subflow exits or expires.
 
-A `flow_entered` event will be created when the flow is started, a `flow_exited` event will be created upon the subflows exit.
+A [flow_triggered](sessions.html#event:flow_triggered) event will be created to record that the flow was started.
 
 <div class="input_action"><h3>Action</h3>```json
 {
@@ -2325,7 +2325,8 @@ A `flow_entered` event will be created when the flow is started, a `flow_exited`
 
 ## start_session
 
-Can be used to trigger sessions for other contacts and groups
+Can be used to trigger sessions for other contacts and groups. A [session_triggered](sessions.html#event:session_triggered) event
+will be created and it's the responsibility of the caller to act on that by initiating a new session with the flow engine.
 
 <div class="input_action"><h3>Action</h3>```json
 {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -115,8 +115,7 @@ code .st {
     color: #888;
 }
 
-p code,
-li code {
+p code, li code {
     color: white;
     background-color: #444;
     border-radius: 3px;

--- a/flows/actions/add_contact_groups.go
+++ b/flows/actions/add_contact_groups.go
@@ -14,7 +14,7 @@ func init() {
 // TypeAddContactGroups is our type for the add to groups action
 const TypeAddContactGroups string = "add_contact_groups"
 
-// AddContactGroupsAction can be used to add a contact to one or more groups. An `contact_groups_added` event will be created
+// AddContactGroupsAction can be used to add a contact to one or more groups. An [event:contact_groups_added] event will be created
 // for the groups which the contact has been added to.
 //
 //   {

--- a/flows/actions/add_contact_groups.go
+++ b/flows/actions/add_contact_groups.go
@@ -14,7 +14,7 @@ func init() {
 // TypeAddContactGroups is our type for the add to groups action
 const TypeAddContactGroups string = "add_contact_groups"
 
-// AddContactGroupsAction can be used to add a contact to one or more groups. An [event:contact_groups_added] event will be created
+// AddContactGroupsAction can be used to add a contact to one or more groups. A [event:contact_groups_added] event will be created
 // for the groups which the contact has been added to.
 //
 //   {

--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -15,7 +15,7 @@ func init() {
 // TypeAddContactURN is our type for the add URN action
 const TypeAddContactURN string = "add_contact_urn"
 
-// AddContactURNAction can be used to add a URN to the current contact. An `contact_urn_added` event
+// AddContactURNAction can be used to add a URN to the current contact. An [event:contact_urn_added] event
 // will be created when this action is encountered. If there is no contact then this
 // action will be ignored.
 //

--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -15,7 +15,7 @@ func init() {
 // TypeAddContactURN is our type for the add URN action
 const TypeAddContactURN string = "add_contact_urn"
 
-// AddContactURNAction can be used to add a URN to the current contact. An [event:contact_urn_added] event
+// AddContactURNAction can be used to add a URN to the current contact. A [event:contact_urn_added] event
 // will be created when this action is encountered. If there is no contact then this
 // action will be ignored.
 //

--- a/flows/actions/add_input_labels.go
+++ b/flows/actions/add_input_labels.go
@@ -12,7 +12,7 @@ func init() {
 // TypeAddInputLabels is the type for the add label action
 const TypeAddInputLabels string = "add_input_labels"
 
-// AddInputLabelsAction can be used to add labels to the last user input on a flow. An `input_labels_added` event
+// AddInputLabelsAction can be used to add labels to the last user input on a flow. An [event:input_labels_added] event
 // will be created with the labels added when this action is encountered. If there is
 // no user input at that point then this action will be ignored.
 //

--- a/flows/actions/call_resthook.go
+++ b/flows/actions/call_resthook.go
@@ -17,7 +17,7 @@ const TypeCallResthook string = "call_resthook"
 
 // CallResthookAction can be used to call a resthook.
 //
-// A `resthook_subscriber_called` event will be created based on the results of the HTTP call
+// A [event:resthook_called] event will be created based on the results of the HTTP call
 // to each subscriber of the resthook.
 //
 //   {

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -19,7 +19,7 @@ const TypeCallWebhook string = "call_webhook"
 // CallWebhookAction can be used to call an external service. The body, header and url fields may be
 // templates and will be evaluated at runtime.
 //
-// A `webhook_called` event will be created based on the results of the HTTP call.
+// A [event:webhook_called] event will be created based on the results of the HTTP call.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/remove_contact_groups.go
+++ b/flows/actions/remove_contact_groups.go
@@ -14,7 +14,7 @@ func init() {
 // TypeRemoveContactGroups is the type for the remove from groups action
 const TypeRemoveContactGroups string = "remove_contact_groups"
 
-// RemoveContactGroupsAction can be used to remove a contact from one or more groups. A `contact_groups_removed` event will be created
+// RemoveContactGroupsAction can be used to remove a contact from one or more groups. A [event:contact_groups_removed] event will be created
 // for the groups which the contact is removed from. Groups can either be explicitly provided or `all_groups` can be set to true to remove
 // the contact from all non-dynamic groups.
 //

--- a/flows/actions/send_broadcast.go
+++ b/flows/actions/send_broadcast.go
@@ -17,7 +17,7 @@ const TypeSendBroadcast string = "send_broadcast"
 // SendBroadcastAction can be used to send a message to one or more contacts. It accepts a list of URNs, a list of groups
 // and a list of contacts.
 //
-// The URNs and text fields may be templates. A `send_broadcast` event will be created for each unique urn, contact and group
+// The URNs and text fields may be templates. A [event:broadcast_created] event will be created for each unique urn, contact and group
 // with the evaluated text.
 //
 //   {

--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -19,7 +19,7 @@ const TypeSendEmail string = "send_email"
 // SendEmailAction can be used to send an email to one or more recipients. The subject, body and addresses
 // can all contain expressions.
 //
-// An `email_created` event will be created for each email address.
+// An [event:email_created] event will be created for each email address.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -16,7 +16,7 @@ const TypeSendMsg string = "send_msg"
 
 // SendMsgAction can be used to reply to the current contact in a flow. The text field may contain templates.
 //
-// A `broadcast_created` event will be created with the evaluated text.
+// A [event:msg_created] event will be created with the evaluated text.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/set_contact_channel.go
+++ b/flows/actions/set_contact_channel.go
@@ -16,7 +16,7 @@ const TypeSetContactChannel string = "set_contact_channel"
 
 // SetContactChannelAction can be used to update the preferred channel of the current contact.
 //
-// A `contact_channel_changed` event will be created with the set channel.
+// A [event:contact_channel_changed] event will be created with the set channel.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -17,7 +17,7 @@ const TypeSetContactField string = "set_contact_field"
 
 // SetContactFieldAction can be used to update a field value on the contact. The value is a localizable
 // template and white space is trimmed from the final value. An empty string clears the value.
-// A `contact_field_changed` event will be created with the corresponding value.
+// A [event:contact_field_changed] event will be created with the corresponding value.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/set_contact_language.go
+++ b/flows/actions/set_contact_language.go
@@ -18,7 +18,7 @@ const TypeSetContactLanguage string = "set_contact_language"
 
 // SetContactLanguageAction can be used to update the name of the contact. The language is a localizable
 // template and white space is trimmed from the final value. An empty string clears the language.
-// A `contact_language_changed` event will be created with the corresponding value.
+// A [event:contact_language_changed] event will be created with the corresponding value.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/set_contact_name.go
+++ b/flows/actions/set_contact_name.go
@@ -17,7 +17,7 @@ const TypeSetContactName string = "set_contact_name"
 
 // SetContactNameAction can be used to update the name of the contact. The name is a localizable
 // template and white space is trimmed from the final value. An empty string clears the name.
-// A `contact_name_changed` event will be created with the corresponding value.
+// A [event:contact_name_changed] event will be created with the corresponding value.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/set_contact_timezone.go
+++ b/flows/actions/set_contact_timezone.go
@@ -18,7 +18,7 @@ const TypeSetContactTimezone string = "set_contact_timezone"
 
 // SetContactTimezoneAction can be used to update the timezone of the contact. The timezone is a localizable
 // template and white space is trimmed from the final value. An empty string clears the timezone.
-// A `contact_timezone_changed` event will be created with the corresponding value.
+// A [event:contact_timezone_changed] event will be created with the corresponding value.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/set_run_result.go
+++ b/flows/actions/set_run_result.go
@@ -17,7 +17,7 @@ const TypeSetRunResult string = "set_run_result"
 // for the run as @run.results.[name]. The optional category can be used as a way of categorizing results,
 // this can be useful for reporting or analytics.
 //
-// Both the value and category fields may be templates. A `run_result_changed` event will be created with the
+// Both the value and category fields may be templates. A [event:run_result_changed] event will be created with the
 // final values.
 //
 //   {

--- a/flows/actions/start_flow.go
+++ b/flows/actions/start_flow.go
@@ -16,7 +16,7 @@ const TypeStartFlow string = "start_flow"
 
 // StartFlowAction can be used to start a contact down another flow. The current flow will pause until the subflow exits or expires.
 //
-// A `flow_entered` event will be created when the flow is started, a `flow_exited` event will be created upon the subflows exit.
+// A [event:flow_triggered] event will be created to record that the flow was started.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/start_session.go
+++ b/flows/actions/start_session.go
@@ -15,7 +15,8 @@ func init() {
 // TypeStartSession is the type for the start session action
 const TypeStartSession string = "start_session"
 
-// StartSessionAction can be used to trigger sessions for other contacts and groups
+// StartSessionAction can be used to trigger sessions for other contacts and groups. A [event:session_triggered] event
+// will be created and it's the responsibility of the caller to act on that by initiating a new session with the flow engine.
 //
 //   {
 //     "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/urn.go
+++ b/flows/urn.go
@@ -42,9 +42,9 @@ func ValidateURNScheme(fl validator.FieldLevel) bool {
 //  * `scheme` the scheme of the URN, e.g. "tel", "twitter"
 //  * `path` the path of the URN, e.g. "+16303524567"
 //  * `display` the display portion of the URN, e.g. "+16303524567"
-//  * `channel` the preferred [channel](#context:channel) of the URN
+//  * `channel` the preferred [context:channel] of the URN
 //
-// To render a URN in a human friendly format, use the [format_urn](#function:format_urn) function.
+// To render a URN in a human friendly format, use the [function:format_urn] function.
 //
 // Examples:
 //

--- a/flows/urn.go
+++ b/flows/urn.go
@@ -42,7 +42,7 @@ func ValidateURNScheme(fl validator.FieldLevel) bool {
 //  * `scheme` the scheme of the URN, e.g. "tel", "twitter"
 //  * `path` the path of the URN, e.g. "+16303524567"
 //  * `display` the display portion of the URN, e.g. "+16303524567"
-//  * `channel` the preferred [context:channel] of the URN
+//  * `channel` the preferred [channel](#context:channel) of the URN
 //
 // To render a URN in a human friendly format, use the [function:format_urn] function.
 //


### PR DESCRIPTION
References to events in the documentation for an action that generates those events now link to the docs for those events and an error is thrown if docs try to reference something that doesn't exist.