### PR TITLE
pass flows.SessionAsset instead of AssertServer to NewSession and ReadSession

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -86,7 +86,8 @@ func main() {
 	la, _ := time.LoadLocation("America/Los_Angeles")
 	env := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, la, utils.LanguageList{}, utils.RedactionPolicyNone)
 
-	session := engine.NewSession(engine.NewMockAssetServer(assetCache), engine.NewDefaultConfig(), httpClient)
+	assets := engine.NewSessionAssets(engine.NewMockAssetServer(assetCache))
+	session := engine.NewSession(assets, engine.NewDefaultConfig(), httpClient)
 
 	contactJSON, err := ioutil.ReadFile(*contactFile)
 	if err != nil {
@@ -142,7 +143,8 @@ func main() {
 		callerEvents = append(callerEvents, []flows.Event{event})
 
 		// rebuild our session
-		session, err = engine.ReadSession(engine.NewMockAssetServer(assetCache), engine.NewDefaultConfig(), httpClient, outJSON)
+		assets := engine.NewSessionAssets(engine.NewMockAssetServer(assetCache))
+		session, err = engine.ReadSession(assets, engine.NewDefaultConfig(), httpClient, outJSON)
 		if err != nil {
 			log.Fatalf("Error unmarshalling output: %s", err)
 		}

--- a/cmd/flowrunner/runner_test.go
+++ b/cmd/flowrunner/runner_test.go
@@ -102,7 +102,8 @@ func runFlow(assetsFilename string, triggerEnvelope *utils.TypedEnvelope, caller
 		return runResult{}, fmt.Errorf("Error reading test assets '%s': %s", assetsFilename, err)
 	}
 
-	session := engine.NewSession(engine.NewMockAssetServer(assetCache), engine.NewDefaultConfig(), test.TestHTTPClient)
+	assets := engine.NewSessionAssets(engine.NewMockAssetServer(assetCache))
+	session := engine.NewSession(assets, engine.NewDefaultConfig(), test.TestHTTPClient)
 
 	trigger, err := triggers.ReadTrigger(session, triggerEnvelope)
 	if err != nil {
@@ -125,7 +126,8 @@ func runFlow(assetsFilename string, triggerEnvelope *utils.TypedEnvelope, caller
 		}
 		outputs = append(outputs, &Output{sessionJSON, marshalEventLog(session.Events())})
 
-		session, err = engine.ReadSession(engine.NewMockAssetServer(assetCache), engine.NewDefaultConfig(), test.TestHTTPClient, sessionJSON)
+		assets := engine.NewSessionAssets(engine.NewMockAssetServer(assetCache))
+		session, err = engine.ReadSession(assets, engine.NewDefaultConfig(), test.TestHTTPClient, sessionJSON)
 		if err != nil {
 			return runResult{}, fmt.Errorf("Error marshalling output: %s", err)
 		}

--- a/cmd/flowserver/handlers.go
+++ b/cmd/flowserver/handlers.go
@@ -98,7 +98,8 @@ func (s *FlowServer) handleStart(w http.ResponseWriter, r *http.Request) (interf
 	}
 
 	// build our session
-	session := engine.NewSession(assetServer, config, s.httpClient)
+	assets := engine.NewSessionAssets(assetServer)
+	session := engine.NewSession(assets, config, s.httpClient)
 
 	// read our trigger
 	trigger, err := triggers.ReadTrigger(session, start.Trigger)
@@ -155,7 +156,8 @@ func (s *FlowServer) handleResume(w http.ResponseWriter, r *http.Request) (inter
 	}
 
 	// read our session
-	session, err := engine.ReadSession(assetServer, config, s.httpClient, resume.Session)
+	assets := engine.NewSessionAssets(assetServer)
+	session, err := engine.ReadSession(assets, config, s.httpClient, resume.Session)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/flowserver/server_test.go
+++ b/cmd/flowserver/server_test.go
@@ -278,7 +278,8 @@ func (ts *ServerTestSuite) parseSessionResponse(body []byte) (flows.Session, []m
 	err := json.Unmarshal(body, &envelope)
 	ts.Require().NoError(err)
 
-	session, err := engine.ReadSession(engine.NewMockAssetServer(ts.flowServer.assetCache), engine.NewDefaultConfig(), test.TestHTTPClient, envelope.Session)
+	assets := engine.NewSessionAssets(engine.NewMockAssetServer(ts.flowServer.assetCache))
+	session, err := engine.ReadSession(assets, engine.NewDefaultConfig(), test.TestHTTPClient, envelope.Session)
 	ts.Require().NoError(err)
 
 	return session, envelope.Log

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -53,7 +53,8 @@ func TestFlowValidation(t *testing.T) {
 	err = assetCache.Include(assetsJSON)
 	assert.NoError(t, err)
 
-	session := engine.NewSession(engine.NewMockAssetServer(assetCache), engine.NewDefaultConfig(), test.TestHTTPClient)
+	assets := engine.NewSessionAssets(engine.NewMockAssetServer(assetCache))
+	session := engine.NewSession(assets, engine.NewDefaultConfig(), test.TestHTTPClient)
 	flow, err := session.Assets().GetFlow("76f0a02f-3b75-4b86-9064-e9195e1b3a02")
 	assert.NoError(t, err)
 

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/actions"
 	"github.com/nyaruka/goflow/flows/events"
@@ -44,10 +43,10 @@ type session struct {
 }
 
 // NewSession creates a new session
-func NewSession(assetServer assets.AssetServer, engineConfig flows.EngineConfig, httpClient *utils.HTTPClient) flows.Session {
+func NewSession(assets flows.SessionAssets, engineConfig flows.EngineConfig, httpClient *utils.HTTPClient) flows.Session {
 	return &session{
 		env:          utils.NewDefaultEnvironment(),
-		assets:       NewSessionAssets(assetServer),
+		assets:       assets,
 		status:       flows.SessionStatusActive,
 		newEvents:    []flows.Event{},
 		runsByUUID:   make(map[flows.RunUUID]flows.FlowRun),
@@ -483,7 +482,7 @@ type sessionEnvelope struct {
 }
 
 // ReadSession decodes a session from the passed in JSON
-func ReadSession(assetServer assets.AssetServer, engineConfig flows.EngineConfig, httpClient *utils.HTTPClient, data json.RawMessage) (flows.Session, error) {
+func ReadSession(assets flows.SessionAssets, engineConfig flows.EngineConfig, httpClient *utils.HTTPClient, data json.RawMessage) (flows.Session, error) {
 	var envelope sessionEnvelope
 	var err error
 
@@ -491,7 +490,7 @@ func ReadSession(assetServer assets.AssetServer, engineConfig flows.EngineConfig
 		return nil, fmt.Errorf("unable to read session: %s", err)
 	}
 
-	s := NewSession(assetServer, engineConfig, httpClient).(*session)
+	s := NewSession(assets, engineConfig, httpClient).(*session)
 	s.status = envelope.Status
 
 	// read our environment

--- a/test/session.go
+++ b/test/session.go
@@ -373,6 +373,7 @@ func CreateSession(sessionAssets json.RawMessage) (flows.Session, error) {
 	}
 
 	// create our engine session
-	session := engine.NewSession(engine.NewMockAssetServer(assetCache), engine.NewDefaultConfig(), TestHTTPClient)
+	assets := engine.NewSessionAssets(engine.NewMockAssetServer(assetCache))
+	session := engine.NewSession(assets, engine.NewDefaultConfig(), TestHTTPClient)
 	return session, nil
 }


### PR DESCRIPTION
Since we don't actually need an Asset server, just something that can return the appropriate objects for us.