### PR TITLE
💼 Asset references

### DIFF
--- a/assets/interfaces.go
+++ b/assets/interfaces.go
@@ -8,9 +8,6 @@ import (
 // ChannelUUID is the UUID of a channel
 type ChannelUUID utils.UUID
 
-// NilChannelUUID is an empty channel UUID
-const NilChannelUUID ChannelUUID = ChannelUUID("")
-
 // ChannelRole is a role that a channel can perform
 type ChannelRole string
 
@@ -30,7 +27,7 @@ type Channel interface {
 	Address() string
 	Schemes() []string
 	Roles() []ChannelRole
-	ParentUUID() ChannelUUID
+	Parent() *ChannelReference
 	Country() string
 	MatchPrefixes() []string
 }

--- a/assets/references.go
+++ b/assets/references.go
@@ -1,9 +1,8 @@
-package flows
+package assets
 
 import (
 	validator "gopkg.in/go-playground/validator.v9"
 
-	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/utils"
 )
 
@@ -14,35 +13,24 @@ func init() {
 
 // ChannelReference is used to reference a channel
 type ChannelReference struct {
-	UUID assets.ChannelUUID `json:"uuid" validate:"required,uuid"`
-	Name string             `json:"name"`
-}
-
-// NewChannelReference creates a new channel reference with the given UUID and name
-func NewChannelReference(uuid assets.ChannelUUID, name string) *ChannelReference {
-	return &ChannelReference{UUID: uuid, Name: name}
-}
-
-// ContactReference is used to reference a contact
-type ContactReference struct {
-	UUID ContactUUID `json:"uuid" validate:"required,uuid4"`
+	UUID ChannelUUID `json:"uuid" validate:"required,uuid"`
 	Name string      `json:"name"`
 }
 
-// NewContactReference creates a new contact reference with the given UUID and name
-func NewContactReference(uuid ContactUUID, name string) *ContactReference {
-	return &ContactReference{UUID: uuid, Name: name}
+// NewChannelReference creates a new channel reference with the given UUID and name
+func NewChannelReference(uuid ChannelUUID, name string) *ChannelReference {
+	return &ChannelReference{UUID: uuid, Name: name}
 }
 
 // GroupReference is used to reference a group
 type GroupReference struct {
-	UUID      assets.GroupUUID `json:"uuid,omitempty" validate:"omitempty,uuid4"`
-	Name      string           `json:"name,omitempty"`
-	NameMatch string           `json:"name_match,omitempty"`
+	UUID      GroupUUID `json:"uuid,omitempty" validate:"omitempty,uuid4"`
+	Name      string    `json:"name,omitempty"`
+	NameMatch string    `json:"name_match,omitempty"`
 }
 
 // NewGroupReference creates a new group reference with the given UUID and name
-func NewGroupReference(uuid assets.GroupUUID, name string) *GroupReference {
+func NewGroupReference(uuid GroupUUID, name string) *GroupReference {
 	return &GroupReference{UUID: uuid, Name: name}
 }
 
@@ -64,24 +52,24 @@ func NewFieldReference(key string, label string) *FieldReference {
 
 // FlowReference is used to reference a flow from another flow
 type FlowReference struct {
-	UUID assets.FlowUUID `json:"uuid" validate:"uuid4"`
-	Name string          `json:"name"`
+	UUID FlowUUID `json:"uuid" validate:"uuid4"`
+	Name string   `json:"name"`
 }
 
 // NewFlowReference creates a new flow reference with the given UUID and name
-func NewFlowReference(uuid assets.FlowUUID, name string) *FlowReference {
+func NewFlowReference(uuid FlowUUID, name string) *FlowReference {
 	return &FlowReference{UUID: uuid, Name: name}
 }
 
 // LabelReference is used to reference a label
 type LabelReference struct {
-	UUID      assets.LabelUUID `json:"uuid,omitempty" validate:"omitempty,uuid4"`
-	Name      string           `json:"name,omitempty"`
-	NameMatch string           `json:"name_match,omitempty"`
+	UUID      LabelUUID `json:"uuid,omitempty" validate:"omitempty,uuid4"`
+	Name      string    `json:"name,omitempty"`
+	NameMatch string    `json:"name_match,omitempty"`
 }
 
 // NewLabelReference creates a new label reference with the given UUID and name
-func NewLabelReference(uuid assets.LabelUUID, name string) *LabelReference {
+func NewLabelReference(uuid LabelUUID, name string) *LabelReference {
 	return &LabelReference{UUID: uuid, Name: name}
 }
 

--- a/assets/references_test.go
+++ b/assets/references_test.go
@@ -1,10 +1,9 @@
-package flows_test
+package assets_test
 
 import (
 	"testing"
 
 	"github.com/nyaruka/goflow/assets"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -12,45 +11,41 @@ import (
 
 func TestReferenceValidation(t *testing.T) {
 	// channel references must always be concrete
-	assert.NoError(t, utils.Validate(flows.NewChannelReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Nexmo")))
-	assert.EqualError(t, utils.Validate(flows.NewChannelReference("", "Nexmo")), "field 'uuid' is required")
-
-	// contact references must always be concrete
-	assert.NoError(t, utils.Validate(flows.NewContactReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Bob")))
-	assert.EqualError(t, utils.Validate(flows.NewContactReference("", "Bob")), "field 'uuid' is required")
+	assert.NoError(t, utils.Validate(assets.NewChannelReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Nexmo")))
+	assert.EqualError(t, utils.Validate(assets.NewChannelReference("", "Nexmo")), "field 'uuid' is required")
 
 	// group references can be concrete or a name match template
-	assert.NoError(t, utils.Validate(flows.NewGroupReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Testers")))
-	assert.NoError(t, utils.Validate(flows.NewVariableGroupReference("@contact.fields.district")))
+	assert.NoError(t, utils.Validate(assets.NewGroupReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Testers")))
+	assert.NoError(t, utils.Validate(assets.NewVariableGroupReference("@contact.fields.district")))
 
 	// but they can't be neither or both of those things
 	assert.EqualError(t,
-		utils.Validate(&flows.GroupReference{}),
+		utils.Validate(&assets.GroupReference{}),
 		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
 	)
 	assert.EqualError(t,
-		utils.Validate(&flows.GroupReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Bob", NameMatch: "@contact.fields.district"}),
+		utils.Validate(&assets.GroupReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Bob", NameMatch: "@contact.fields.district"}),
 		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
 	)
 
 	// label references can be concrete or a name match template
-	assert.NoError(t, utils.Validate(flows.NewLabelReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Spam")))
-	assert.NoError(t, utils.Validate(flows.NewVariableLabelReference("@contact.fields.district")))
+	assert.NoError(t, utils.Validate(assets.NewLabelReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Spam")))
+	assert.NoError(t, utils.Validate(assets.NewVariableLabelReference("@contact.fields.district")))
 
 	// but they can't be neither or both of those things
 	assert.EqualError(t,
-		utils.Validate(&flows.LabelReference{}),
+		utils.Validate(&assets.LabelReference{}),
 		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
 	)
 	assert.EqualError(t,
-		utils.Validate(&flows.LabelReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Spam", NameMatch: "@contact.fields.district"}),
+		utils.Validate(&assets.LabelReference{UUID: "61602f3e-f603-4c70-8a8f-c477505bf4bf", Name: "Spam", NameMatch: "@contact.fields.district"}),
 		"field 'uuid' is mutually exclusive with 'name_match', field 'name_match' is mutually exclusive with 'uuid'",
 	)
 }
 
 func TestChannelReferenceUnmarsal(t *testing.T) {
 	// check that UUIDs aren't required to be valid UUID4s
-	channel := &flows.ChannelReference{}
+	channel := &assets.ChannelReference{}
 	err := utils.UnmarshalAndValidate([]byte(`{"uuid": "ffffffff-9b24-92e1-ffff-ffffb207cdb4", "name": "Old Channel"}`), channel)
 	assert.NoError(t, err)
 	assert.Equal(t, assets.ChannelUUID("ffffffff-9b24-92e1-ffff-ffffb207cdb4"), channel.UUID)

--- a/assets/rest/types/channel.go
+++ b/assets/rest/types/channel.go
@@ -11,37 +11,37 @@ import (
 
 // json serializable implementation of a channel asset
 type channel struct {
-	UUID_          assets.ChannelUUID   `json:"uuid" validate:"required,uuid"`
-	Name_          string               `json:"name"`
-	Address_       string               `json:"address"`
-	Schemes_       []string             `json:"schemes" validate:"min=1"`
-	Roles_         []assets.ChannelRole `json:"roles" validate:"min=1,dive,eq=send|eq=receive|eq=call|eq=answer|eq=ussd"`
-	ParentUUID_    assets.ChannelUUID   `json:"parent_uuid" validate:"omitempty,uuid4"`
-	Country_       string               `json:"country,omitempty"`
-	MatchPrefixes_ []string             `json:"match_prefixes,omitempty"`
+	UUID_          assets.ChannelUUID       `json:"uuid" validate:"required,uuid"`
+	Name_          string                   `json:"name"`
+	Address_       string                   `json:"address"`
+	Schemes_       []string                 `json:"schemes" validate:"min=1"`
+	Roles_         []assets.ChannelRole     `json:"roles" validate:"min=1,dive,eq=send|eq=receive|eq=call|eq=answer|eq=ussd"`
+	Parent_        *assets.ChannelReference `json:"parent" validate:"omitempty,dive"`
+	Country_       string                   `json:"country,omitempty"`
+	MatchPrefixes_ []string                 `json:"match_prefixes,omitempty"`
 }
 
 // NewChannel creates a new channel
-func NewChannel(uuid assets.ChannelUUID, name string, address string, schemes []string, roles []assets.ChannelRole, parentUUID assets.ChannelUUID) assets.Channel {
+func NewChannel(uuid assets.ChannelUUID, name string, address string, schemes []string, roles []assets.ChannelRole, parent *assets.ChannelReference) assets.Channel {
 	return &channel{
-		UUID_:       uuid,
-		Name_:       name,
-		Address_:    address,
-		Schemes_:    schemes,
-		Roles_:      roles,
-		ParentUUID_: parentUUID,
+		UUID_:    uuid,
+		Name_:    name,
+		Address_: address,
+		Schemes_: schemes,
+		Roles_:   roles,
+		Parent_:  parent,
 	}
 }
 
 // NewTelChannel creates a new tel channel
-func NewTelChannel(uuid assets.ChannelUUID, name string, address string, roles []assets.ChannelRole, parentUUID assets.ChannelUUID, country string, matchPrefixes []string) assets.Channel {
+func NewTelChannel(uuid assets.ChannelUUID, name string, address string, roles []assets.ChannelRole, parent *assets.ChannelReference, country string, matchPrefixes []string) assets.Channel {
 	return &channel{
 		UUID_:          uuid,
 		Name_:          name,
 		Address_:       address,
 		Schemes_:       []string{urns.TelScheme},
 		Roles_:         roles,
-		ParentUUID_:    parentUUID,
+		Parent_:        parent,
 		Country_:       country,
 		MatchPrefixes_: matchPrefixes,
 	}
@@ -62,8 +62,8 @@ func (c *channel) Schemes() []string { return c.Schemes_ }
 // Roles returns the roles of this channel
 func (c *channel) Roles() []assets.ChannelRole { return c.Roles_ }
 
-// Parent returns the UUID of this channel's parent (if any)
-func (c *channel) ParentUUID() assets.ChannelUUID { return c.ParentUUID_ }
+// Parent returns a reference to this channel's parent (if any)
+func (c *channel) Parent() *assets.ChannelReference { return c.Parent_ }
 
 // Country returns this channel's associated country code (if any)
 func (c *channel) Country() string { return c.Country_ }

--- a/flows/actions/add_contact_groups.go
+++ b/flows/actions/add_contact_groups.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -31,7 +32,7 @@ type AddContactGroupsAction struct {
 	BaseAction
 	universalAction
 
-	Groups []*flows.GroupReference `json:"groups" validate:"required,dive"`
+	Groups []*assets.GroupReference `json:"groups" validate:"required,dive"`
 }
 
 // Type returns the type of this action
@@ -56,7 +57,7 @@ func (a *AddContactGroupsAction) Execute(run flows.FlowRun, step flows.Step, log
 		return err
 	}
 
-	groupRefs := make([]*flows.GroupReference, 0, len(groups))
+	groupRefs := make([]*assets.GroupReference, 0, len(groups))
 	for _, group := range groups {
 		// ignore group if contact is already in it
 		if contact.Groups().FindByUUID(group.UUID()) != nil {

--- a/flows/actions/add_input_labels.go
+++ b/flows/actions/add_input_labels.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -30,7 +31,7 @@ type AddInputLabelsAction struct {
 	BaseAction
 	universalAction
 
-	Labels []*flows.LabelReference `json:"labels" validate:"required,dive"`
+	Labels []*assets.LabelReference `json:"labels" validate:"required,dive"`
 }
 
 // Type returns the type of this action
@@ -55,7 +56,7 @@ func (a *AddInputLabelsAction) Execute(run flows.FlowRun, step flows.Step, log f
 		return err
 	}
 
-	labelRefs := make([]*flows.LabelReference, 0, len(labels))
+	labelRefs := make([]*assets.LabelReference, 0, len(labels))
 	for _, label := range labels {
 		labelRefs = append(labelRefs, label.Reference())
 	}

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
@@ -51,7 +52,7 @@ func (a *BaseAction) evaluateLocalizableTemplate(run flows.FlowRun, localization
 }
 
 // helper function for actions that have a set of group references that must be validated
-func (a *BaseAction) validateGroups(assets flows.SessionAssets, references []*flows.GroupReference) error {
+func (a *BaseAction) validateGroups(assets flows.SessionAssets, references []*assets.GroupReference) error {
 	for _, ref := range references {
 		if ref.UUID != "" {
 			if _, err := assets.Groups().Get(ref.UUID); err != nil {
@@ -63,7 +64,7 @@ func (a *BaseAction) validateGroups(assets flows.SessionAssets, references []*fl
 }
 
 // helper function for actions that have a set of label references that must be validated
-func (a *BaseAction) validateLabels(assets flows.SessionAssets, references []*flows.LabelReference) error {
+func (a *BaseAction) validateLabels(assets flows.SessionAssets, references []*assets.LabelReference) error {
 	for _, ref := range references {
 		if ref.UUID != "" {
 			if _, err := assets.Labels().Get(ref.UUID); err != nil {
@@ -75,7 +76,7 @@ func (a *BaseAction) validateLabels(assets flows.SessionAssets, references []*fl
 }
 
 // helper function for actions that have a set of group references that must be resolved to actual groups
-func (a *BaseAction) resolveGroups(run flows.FlowRun, step flows.Step, references []*flows.GroupReference, log flows.EventLog) ([]*flows.Group, error) {
+func (a *BaseAction) resolveGroups(run flows.FlowRun, step flows.Step, references []*assets.GroupReference, log flows.EventLog) ([]*flows.Group, error) {
 	groupSet := run.Session().Assets().Groups()
 	groups := make([]*flows.Group, 0, len(references))
 
@@ -112,7 +113,7 @@ func (a *BaseAction) resolveGroups(run flows.FlowRun, step flows.Step, reference
 }
 
 // helper function for actions that have a set of label references that must be resolved to actual labels
-func (a *BaseAction) resolveLabels(run flows.FlowRun, step flows.Step, references []*flows.LabelReference, log flows.EventLog) ([]*flows.Label, error) {
+func (a *BaseAction) resolveLabels(run flows.FlowRun, step flows.Step, references []*assets.LabelReference, log flows.EventLog) ([]*flows.Label, error) {
 	labelSet := run.Session().Assets().Labels()
 	labels := make([]*flows.Label, 0, len(references))
 
@@ -188,7 +189,7 @@ func (a *BaseAction) evaluateMessage(run flows.FlowRun, languages utils.Language
 	return evaluatedText, evaluatedAttachments, evaluatedQuickReplies
 }
 
-func (a *BaseAction) resolveContactsAndGroups(run flows.FlowRun, step flows.Step, actionURNs []urns.URN, actionContacts []*flows.ContactReference, actionGroups []*flows.GroupReference, actionLegacyVars []string, log flows.EventLog) ([]urns.URN, []*flows.ContactReference, []*flows.GroupReference, error) {
+func (a *BaseAction) resolveContactsAndGroups(run flows.FlowRun, step flows.Step, actionURNs []urns.URN, actionContacts []*flows.ContactReference, actionGroups []*assets.GroupReference, actionLegacyVars []string, log flows.EventLog) ([]urns.URN, []*flows.ContactReference, []*assets.GroupReference, error) {
 	groupSet := run.Session().Assets().Groups()
 
 	// copy URNs
@@ -208,7 +209,7 @@ func (a *BaseAction) resolveContactsAndGroups(run flows.FlowRun, step flows.Step
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	groupRefs := make([]*flows.GroupReference, 0, len(groups))
+	groupRefs := make([]*assets.GroupReference, 0, len(groups))
 	for _, group := range groups {
 		groupRefs = append(groupRefs, group.Reference())
 	}

--- a/flows/actions/remove_contact_groups.go
+++ b/flows/actions/remove_contact_groups.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -32,8 +33,8 @@ type RemoveContactGroupsAction struct {
 	BaseAction
 	universalAction
 
-	Groups    []*flows.GroupReference `json:"groups,omitempty" validate:"dive"`
-	AllGroups bool                    `json:"all_groups"`
+	Groups    []*assets.GroupReference `json:"groups,omitempty" validate:"dive"`
+	AllGroups bool                     `json:"all_groups"`
 }
 
 // Type returns the type of this action
@@ -72,7 +73,7 @@ func (a *RemoveContactGroupsAction) Execute(run flows.FlowRun, step flows.Step, 
 		}
 	}
 
-	groupRefs := make([]*flows.GroupReference, 0, len(groups))
+	groupRefs := make([]*assets.GroupReference, 0, len(groups))
 	for _, group := range groups {
 		// ignore group if contact isn't actually in it
 		if contact.Groups().FindByUUID(group.UUID()) == nil {

--- a/flows/actions/send_broadcast.go
+++ b/flows/actions/send_broadcast.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
@@ -37,7 +38,7 @@ type SendBroadcastAction struct {
 	QuickReplies []string                  `json:"quick_replies,omitempty"`
 	URNs         []urns.URN                `json:"urns,omitempty"`
 	Contacts     []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
-	Groups       []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
+	Groups       []*assets.GroupReference  `json:"groups,omitempty" validate:"dive"`
 	LegacyVars   []string                  `json:"legacy_vars,omitempty"`
 }
 

--- a/flows/actions/set_contact_channel.go
+++ b/flows/actions/set_contact_channel.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -29,7 +30,7 @@ type SetContactChannelAction struct {
 	BaseAction
 	onlineAction
 
-	Channel *flows.ChannelReference `json:"channel"`
+	Channel *assets.ChannelReference `json:"channel"`
 }
 
 // Type returns the type of this action

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -31,8 +32,8 @@ type SetContactFieldAction struct {
 	BaseAction
 	universalAction
 
-	Field *flows.FieldReference `json:"field" validate:"required"`
-	Value string                `json:"value"`
+	Field *assets.FieldReference `json:"field" validate:"required"`
+	Value string                 `json:"value"`
 }
 
 // Type returns the type of this action

--- a/flows/actions/start_flow.go
+++ b/flows/actions/start_flow.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -29,7 +30,7 @@ type StartFlowAction struct {
 	BaseAction
 	universalAction
 
-	Flow *flows.FlowReference `json:"flow" validate:"required"`
+	Flow *assets.FlowReference `json:"flow" validate:"required"`
 }
 
 // Type returns the type of this action

--- a/flows/actions/start_session.go
+++ b/flows/actions/start_session.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 )
@@ -34,9 +35,9 @@ type StartSessionAction struct {
 
 	URNs          []urns.URN                `json:"urns,omitempty"`
 	Contacts      []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
-	Groups        []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
+	Groups        []*assets.GroupReference  `json:"groups,omitempty" validate:"dive"`
 	LegacyVars    []string                  `json:"legacy_vars,omitempty"`
-	Flow          *flows.FlowReference      `json:"flow" validate:"required"`
+	Flow          *assets.FlowReference     `json:"flow" validate:"required"`
 	CreateContact bool                      `json:"create_contact,omitempty"`
 }
 

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -38,7 +38,9 @@ func NewChannel(asset assets.Channel) *Channel {
 func (c *Channel) Asset() assets.Channel { return c.Channel }
 
 // Reference returns a reference to this channel
-func (c *Channel) Reference() *ChannelReference { return NewChannelReference(c.UUID(), c.Name()) }
+func (c *Channel) Reference() *assets.ChannelReference {
+	return assets.NewChannelReference(c.UUID(), c.Name())
+}
 
 // SupportsScheme returns whether this channel supports the given URN scheme
 func (c *Channel) SupportsScheme(scheme string) bool {

--- a/flows/channel.go
+++ b/flows/channel.go
@@ -63,7 +63,7 @@ func (c *Channel) HasRole(role assets.ChannelRole) bool {
 }
 
 func (c *Channel) HasParent() bool {
-	return c.ParentUUID() != assets.NilChannelUUID
+	return c.Parent() != nil
 }
 
 // Resolve resolves the given key when this channel is referenced in an expression
@@ -192,7 +192,7 @@ func (s *ChannelAssets) getForSchemeAndRole(scheme string, role assets.ChannelRo
 // looks for a delegate for the given channel and defaults to the channel itself
 func (s *ChannelAssets) getDelegate(channel *Channel, role assets.ChannelRole) *Channel {
 	for _, ch := range s.all {
-		if ch.ParentUUID() == channel.UUID() && ch.HasRole(role) {
+		if ch.HasParent() && ch.Parent().UUID == channel.UUID() && ch.HasRole(role) {
 			return ch
 		}
 	}

--- a/flows/channel_test.go
+++ b/flows/channel_test.go
@@ -21,7 +21,7 @@ func TestChannel(t *testing.T) {
 	defer utils.SetUUIDGenerator(utils.DefaultUUIDGenerator)
 
 	rolesDefault := []assets.ChannelRole{assets.ChannelRoleSend, assets.ChannelRoleReceive}
-	ch := test.NewChannel("Android", "+250961111111", []string{"tel"}, rolesDefault, assets.NilChannelUUID)
+	ch := test.NewChannel("Android", "+250961111111", []string{"tel"}, rolesDefault, nil)
 
 	assert.Equal(t, assets.ChannelUUID("c00e5d67-c275-4389-aded-7d8b151cbd5b"), ch.UUID())
 	assert.Equal(t, "Android", ch.Name())
@@ -46,10 +46,10 @@ func TestChannelSetGetForURN(t *testing.T) {
 	rolesSend := []assets.ChannelRole{assets.ChannelRoleSend}
 	rolesDefault := []assets.ChannelRole{assets.ChannelRoleSend, assets.ChannelRoleReceive}
 
-	claro := test.NewTelChannel("Claro", "+593971111111", rolesDefault, assets.NilChannelUUID, "EC", nil)
-	mtn := test.NewTelChannel("MTN", "+250782222222", rolesDefault, assets.NilChannelUUID, "RW", nil)
-	tigo := test.NewTelChannel("Tigo", "+250723333333", rolesDefault, assets.NilChannelUUID, "RW", nil)
-	twitter := test.NewChannel("Twitter", "nyaruka", []string{"twitter", "twitterid"}, rolesDefault, assets.NilChannelUUID)
+	claro := test.NewTelChannel("Claro", "+593971111111", rolesDefault, nil, "EC", nil)
+	mtn := test.NewTelChannel("MTN", "+250782222222", rolesDefault, nil, "RW", nil)
+	tigo := test.NewTelChannel("Tigo", "+250723333333", rolesDefault, nil, "RW", nil)
+	twitter := test.NewChannel("Twitter", "nyaruka", []string{"twitter", "twitterid"}, rolesDefault, nil)
 	all := flows.NewChannelAssets([]assets.Channel{claro.Asset(), mtn.Asset(), tigo.Asset(), twitter.Asset()})
 
 	// nil if no channel
@@ -76,8 +76,8 @@ func TestChannelSetGetForURN(t *testing.T) {
 	assert.Equal(t, tigo, all.GetForURN(flows.NewContactURN(urns.URN("tel:+250962222222"), nil), assets.ChannelRoleSend))
 
 	// channels can be delegates for other channels
-	android := test.NewChannel("Android", "+250723333333", []string{"tel"}, rolesDefault, assets.NilChannelUUID)
-	bulk := test.NewChannel("Bulk Sender", "1234", []string{"tel"}, rolesSend, android.UUID())
+	android := test.NewChannel("Android", "+250723333333", []string{"tel"}, rolesDefault, nil)
+	bulk := test.NewChannel("Bulk Sender", "1234", []string{"tel"}, rolesSend, android.Reference())
 	all = flows.NewChannelAssets([]assets.Channel{android.Asset(), bulk.Asset()})
 
 	// delegate will always be used if it has the requested role
@@ -85,8 +85,8 @@ func TestChannelSetGetForURN(t *testing.T) {
 	assert.Equal(t, bulk, all.GetForURN(flows.NewContactURN(urns.URN("tel:+250721234567"), nil), assets.ChannelRoleSend))
 
 	// matching prefixes can be explicitly set too
-	short1 := test.NewTelChannel("Shortcode 1", "1234", rolesSend, assets.NilChannelUUID, "RW", []string{"25078", "25077"})
-	short2 := test.NewTelChannel("Shortcode 2", "1235", rolesSend, assets.NilChannelUUID, "RW", []string{"25072"})
+	short1 := test.NewTelChannel("Shortcode 1", "1234", rolesSend, nil, "RW", []string{"25078", "25077"})
+	short2 := test.NewTelChannel("Shortcode 2", "1235", rolesSend, nil, "RW", []string{"25072"})
 	all = flows.NewChannelAssets([]assets.Channel{short1.Asset(), short2.Asset()})
 
 	assert.Equal(t, short1, all.GetForURN(flows.NewContactURN(urns.URN("tel:+250781234567"), nil), assets.ChannelRoleSend))

--- a/flows/channel_test.go
+++ b/flows/channel_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +37,7 @@ func TestChannel(t *testing.T) {
 	assert.Equal(t, types.NewXText("Android"), ch.Reduce(env))
 	assert.Equal(t, types.NewXText(`{"address":"+250961111111","name":"Android","uuid":"c00e5d67-c275-4389-aded-7d8b151cbd5b"}`), ch.ToXJSON(env))
 
-	assert.Equal(t, flows.NewChannelReference(ch.UUID(), "Android"), ch.Reference())
+	assert.Equal(t, assets.NewChannelReference(ch.UUID(), "Android"), ch.Reference())
 	assert.True(t, ch.HasRole(assets.ChannelRoleSend))
 	assert.False(t, ch.HasRole(assets.ChannelRoleCall))
 }

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
@@ -365,6 +366,17 @@ func (c *Contact) ResolveQueryKey(env utils.Environment, key string) []interface
 
 var _ contactql.Queryable = (*Contact)(nil)
 
+// ContactReference is used to reference a contact
+type ContactReference struct {
+	UUID ContactUUID `json:"uuid" validate:"required,uuid4"`
+	Name string      `json:"name"`
+}
+
+// NewContactReference creates a new contact reference with the given UUID and name
+func NewContactReference(uuid ContactUUID, name string) *ContactReference {
+	return &ContactReference{UUID: uuid, Name: name}
+}
+
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding
 //------------------------------------------------------------------------------------------
@@ -386,7 +398,7 @@ type contactEnvelope struct {
 	Timezone  string                         `json:"timezone"`
 	CreatedOn time.Time                      `json:"created_on"`
 	URNs      []urns.URN                     `json:"urns" validate:"dive,urn"`
-	Groups    []*GroupReference              `json:"groups,omitempty" validate:"dive"`
+	Groups    []*assets.GroupReference       `json:"groups,omitempty" validate:"dive"`
 	Fields    map[string]*fieldValueEnvelope `json:"fields,omitempty"`
 }
 
@@ -473,7 +485,7 @@ func (c *Contact) MarshalJSON() ([]byte, error) {
 		ce.Timezone = c.timezone.String()
 	}
 
-	ce.Groups = make([]*GroupReference, c.groups.Count())
+	ce.Groups = make([]*assets.GroupReference, c.groups.Count())
 	for g, group := range c.groups.All() {
 		ce.Groups[g] = group.Reference()
 	}

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -98,8 +98,8 @@ func TestContactFormat(t *testing.T) {
 func TestContactSetPreferredChannel(t *testing.T) {
 	roles := []assets.ChannelRole{assets.ChannelRoleSend}
 
-	android := test.NewTelChannel("Android", "+250961111111", roles, assets.NilChannelUUID, "RW", nil)
-	twitter := test.NewChannel("Twitter", "nyaruka", []string{"twitter", "twitterid"}, roles, assets.NilChannelUUID)
+	android := test.NewTelChannel("Android", "+250961111111", roles, nil, "RW", nil)
+	twitter := test.NewChannel("Twitter", "nyaruka", []string{"twitter", "twitterid"}, roles, nil)
 
 	contact := flows.NewEmptyContact("Joe", utils.NilLanguage, nil)
 	contact.AddURN(urns.URN("twitter:joey"))

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -148,8 +148,9 @@ func (f *flow) ToXJSON(env utils.Environment) types.XText {
 
 var _ flows.Flow = (*flow)(nil)
 
-func (f *flow) Reference() *flows.FlowReference {
-	return flows.NewFlowReference(f.uuid, f.name)
+// Reference returns a reference to this flow asset
+func (f *flow) Reference() *assets.FlowReference {
+	return assets.NewFlowReference(f.uuid, f.name)
 }
 
 func (f *flow) buildNodeMap() error {

--- a/flows/events/broadcast_created.go
+++ b/flows/events/broadcast_created.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 )
@@ -51,11 +52,11 @@ type BroadcastCreatedEvent struct {
 	BaseLanguage utils.Language                           `json:"base_language" validate:"required"`
 	URNs         []urns.URN                               `json:"urns,omitempty" validate:"dive,urn"`
 	Contacts     []*flows.ContactReference                `json:"contacts,omitempty" validate:"dive"`
-	Groups       []*flows.GroupReference                  `json:"groups,omitempty" validate:"dive"`
+	Groups       []*assets.GroupReference                 `json:"groups,omitempty" validate:"dive"`
 }
 
 // NewBroadcastCreatedEvent creates a new outgoing msg event for the given recipients
-func NewBroadcastCreatedEvent(translations map[utils.Language]*BroadcastTranslation, baseLanguage utils.Language, urns []urns.URN, contacts []*flows.ContactReference, groups []*flows.GroupReference) *BroadcastCreatedEvent {
+func NewBroadcastCreatedEvent(translations map[utils.Language]*BroadcastTranslation, baseLanguage utils.Language, urns []urns.URN, contacts []*flows.ContactReference, groups []*assets.GroupReference) *BroadcastCreatedEvent {
 	event := BroadcastCreatedEvent{
 		BaseEvent:    NewBaseEvent(),
 		Translations: translations,

--- a/flows/events/contact_channel_changed.go
+++ b/flows/events/contact_channel_changed.go
@@ -3,6 +3,7 @@ package events
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -26,11 +27,11 @@ type ContactChannelChangedEvent struct {
 	BaseEvent
 	callerOrEngineEvent
 
-	Channel *flows.ChannelReference `json:"channel" validate:"required"`
+	Channel *assets.ChannelReference `json:"channel" validate:"required"`
 }
 
 // NewContactChannelChangedEvent returns a new preferred channel event
-func NewContactChannelChangedEvent(channel *flows.ChannelReference) *ContactChannelChangedEvent {
+func NewContactChannelChangedEvent(channel *assets.ChannelReference) *ContactChannelChangedEvent {
 	return &ContactChannelChangedEvent{
 		BaseEvent: NewBaseEvent(),
 		Channel:   channel,

--- a/flows/events/contact_field_changed.go
+++ b/flows/events/contact_field_changed.go
@@ -3,6 +3,7 @@ package events
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -27,12 +28,12 @@ type ContactFieldChangedEvent struct {
 	BaseEvent
 	callerOrEngineEvent
 
-	Field *flows.FieldReference `json:"field" validate:"required"`
-	Value string                `json:"value" validate:"required"`
+	Field *assets.FieldReference `json:"field" validate:"required"`
+	Value string                 `json:"value" validate:"required"`
 }
 
 // NewContactFieldChangedEvent returns a new save to contact event
-func NewContactFieldChangedEvent(field *flows.FieldReference, value string) *ContactFieldChangedEvent {
+func NewContactFieldChangedEvent(field *assets.FieldReference, value string) *ContactFieldChangedEvent {
 	return &ContactFieldChangedEvent{
 		BaseEvent: NewBaseEvent(),
 		Field:     field,

--- a/flows/events/contact_groups_added.go
+++ b/flows/events/contact_groups_added.go
@@ -3,6 +3,7 @@ package events
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -26,11 +27,11 @@ type ContactGroupsAddedEvent struct {
 	BaseEvent
 	callerOrEngineEvent
 
-	Groups []*flows.GroupReference `json:"groups" validate:"required,min=1,dive"`
+	Groups []*assets.GroupReference `json:"groups" validate:"required,min=1,dive"`
 }
 
 // NewContactGroupsAddedEvent returns a new contact_groups_added event
-func NewContactGroupsAddedEvent(groups []*flows.GroupReference) *ContactGroupsAddedEvent {
+func NewContactGroupsAddedEvent(groups []*assets.GroupReference) *ContactGroupsAddedEvent {
 	return &ContactGroupsAddedEvent{
 		BaseEvent: NewBaseEvent(),
 		Groups:    groups,

--- a/flows/events/contact_groups_removed.go
+++ b/flows/events/contact_groups_removed.go
@@ -3,6 +3,7 @@ package events
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -27,11 +28,11 @@ type ContactGroupsRemovedEvent struct {
 	BaseEvent
 	callerOrEngineEvent
 
-	Groups []*flows.GroupReference `json:"groups" validate:"required,min=1,dive"`
+	Groups []*assets.GroupReference `json:"groups" validate:"required,min=1,dive"`
 }
 
 // NewContactGroupsRemovedEvent returns a new remove from group event
-func NewContactGroupsRemovedEvent(groups []*flows.GroupReference) *ContactGroupsRemovedEvent {
+func NewContactGroupsRemovedEvent(groups []*assets.GroupReference) *ContactGroupsRemovedEvent {
 	return &ContactGroupsRemovedEvent{
 		BaseEvent: NewBaseEvent(),
 		Groups:    groups,

--- a/flows/events/flow_triggered.go
+++ b/flows/events/flow_triggered.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -25,12 +26,12 @@ type FlowTriggeredEvent struct {
 	BaseEvent
 	engineOnlyEvent
 
-	Flow          *flows.FlowReference `json:"flow" validate:"required"`
-	ParentRunUUID flows.RunUUID        `json:"parent_run_uuid" validate:"omitempty,uuid4"`
+	Flow          *assets.FlowReference `json:"flow" validate:"required"`
+	ParentRunUUID flows.RunUUID         `json:"parent_run_uuid" validate:"omitempty,uuid4"`
 }
 
 // NewFlowTriggeredEvent returns a new flow triggered event for the passed in flow and parent run
-func NewFlowTriggeredEvent(flow *flows.FlowReference, parentRunUUID flows.RunUUID) *FlowTriggeredEvent {
+func NewFlowTriggeredEvent(flow *assets.FlowReference, parentRunUUID flows.RunUUID) *FlowTriggeredEvent {
 	return &FlowTriggeredEvent{
 		BaseEvent:     NewBaseEvent(),
 		Flow:          flow,

--- a/flows/events/input_labels_added.go
+++ b/flows/events/input_labels_added.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -25,12 +26,12 @@ type InputLabelsAddedEvent struct {
 	BaseEvent
 	callerOrEngineEvent
 
-	InputUUID flows.InputUUID         `json:"input_uuid" validate:"required,uuid4"`
-	Labels    []*flows.LabelReference `json:"labels" validate:"required,min=1,dive"`
+	InputUUID flows.InputUUID          `json:"input_uuid" validate:"required,uuid4"`
+	Labels    []*assets.LabelReference `json:"labels" validate:"required,min=1,dive"`
 }
 
 // NewInputLabelsAddedEvent returns a new add to group event
-func NewInputLabelsAddedEvent(inputUUID flows.InputUUID, labels []*flows.LabelReference) *InputLabelsAddedEvent {
+func NewInputLabelsAddedEvent(inputUUID flows.InputUUID, labels []*assets.LabelReference) *InputLabelsAddedEvent {
 	return &InputLabelsAddedEvent{
 		BaseEvent: NewBaseEvent(),
 		InputUUID: inputUUID,

--- a/flows/events/session_triggered.go
+++ b/flows/events/session_triggered.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -47,16 +48,16 @@ type SessionTriggeredEvent struct {
 	BaseEvent
 	engineOnlyEvent
 
-	Flow          *flows.FlowReference      `json:"flow" validate:"required"`
+	Flow          *assets.FlowReference     `json:"flow" validate:"required"`
 	URNs          []urns.URN                `json:"urns,omitempty" validate:"dive,urn"`
 	Contacts      []*flows.ContactReference `json:"contacts,omitempty" validate:"dive"`
-	Groups        []*flows.GroupReference   `json:"groups,omitempty" validate:"dive"`
+	Groups        []*assets.GroupReference  `json:"groups,omitempty" validate:"dive"`
 	CreateContact bool                      `json:"create_contact,omitempty"`
 	Run           json.RawMessage           `json:"run"`
 }
 
 // NewSessionTriggeredEvent returns a new session triggered event
-func NewSessionTriggeredEvent(flow *flows.FlowReference, urns []urns.URN, contacts []*flows.ContactReference, groups []*flows.GroupReference, createContact bool, runSnapshot json.RawMessage) *SessionTriggeredEvent {
+func NewSessionTriggeredEvent(flow *assets.FlowReference, urns []urns.URN, contacts []*flows.ContactReference, groups []*assets.GroupReference, createContact bool, runSnapshot json.RawMessage) *SessionTriggeredEvent {
 	return &SessionTriggeredEvent{
 		BaseEvent:     NewBaseEvent(),
 		Flow:          flow,

--- a/flows/group.go
+++ b/flows/group.go
@@ -67,7 +67,9 @@ func (g *Group) CheckDynamicMembership(env utils.Environment, contact *Contact) 
 }
 
 // Reference returns a reference to this group
-func (g *Group) Reference() *GroupReference { return NewGroupReference(g.UUID(), g.Name()) }
+func (g *Group) Reference() *assets.GroupReference {
+	return assets.NewGroupReference(g.UUID(), g.Name())
+}
 
 // Resolve resolves the given key when this group is referenced in an expression
 func (g *Group) Resolve(env utils.Environment, key string) types.XValue {

--- a/flows/inputs/base.go
+++ b/flows/inputs/base.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
@@ -48,9 +49,9 @@ func (i *baseInput) Resolve(env utils.Environment, key string) types.XValue {
 //------------------------------------------------------------------------------------------
 
 type baseInputEnvelope struct {
-	UUID      flows.InputUUID         `json:"uuid"`
-	Channel   *flows.ChannelReference `json:"channel,omitempty" validate:"omitempty,dive"`
-	CreatedOn time.Time               `json:"created_on" validate:"required"`
+	UUID      flows.InputUUID          `json:"uuid"`
+	Channel   *assets.ChannelReference `json:"channel,omitempty" validate:"omitempty,dive"`
+	CreatedOn time.Time                `json:"created_on" validate:"required"`
 }
 
 // ReadInput reads an input from the given typed envelope

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -140,7 +140,7 @@ type Flow interface {
 	Nodes() []Node
 	GetNode(uuid NodeUUID) Node
 
-	Reference() *FlowReference
+	Reference() *assets.FlowReference
 }
 
 // Node is a single node in a flow
@@ -219,7 +219,7 @@ type Trigger interface {
 	types.XResolvable
 
 	Environment() utils.Environment
-	Flow() *FlowReference
+	Flow() *assets.FlowReference
 	Contact() *Contact
 	Params() types.XValue
 	TriggeredOn() time.Time

--- a/flows/label.go
+++ b/flows/label.go
@@ -21,7 +21,9 @@ func NewLabel(asset assets.Label) *Label {
 func (l *Label) Asset() assets.Label { return l.Label }
 
 // Reference returns a reference to this label
-func (l *Label) Reference() *LabelReference { return NewLabelReference(l.UUID(), l.Name()) }
+func (l *Label) Reference() *assets.LabelReference {
+	return assets.NewLabelReference(l.UUID(), l.Name())
+}
 
 var _ assets.Label = (*Label)(nil)
 

--- a/flows/msg.go
+++ b/flows/msg.go
@@ -2,17 +2,18 @@ package flows
 
 import (
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/utils"
 )
 
 // BaseMsg represents a incoming or outgoing message with the session contact
 type BaseMsg struct {
-	UUID_        MsgUUID           `json:"uuid"`
-	ID_          MsgID             `json:"id,omitempty"`
-	URN_         urns.URN          `json:"urn" validate:"omitempty,urn"`
-	Channel_     *ChannelReference `json:"channel,omitempty"`
-	Text_        string            `json:"text"`
-	Attachments_ []Attachment      `json:"attachments,omitempty"`
+	UUID_        MsgUUID                  `json:"uuid"`
+	ID_          MsgID                    `json:"id,omitempty"`
+	URN_         urns.URN                 `json:"urn" validate:"omitempty,urn"`
+	Channel_     *assets.ChannelReference `json:"channel,omitempty"`
+	Text_        string                   `json:"text"`
+	Attachments_ []Attachment             `json:"attachments,omitempty"`
 }
 
 // MsgIn represents a incoming message from the session contact
@@ -28,7 +29,7 @@ type MsgOut struct {
 
 // NewMsgIn creates a new incoming message
 func NewMsgIn(uuid MsgUUID, id MsgID, urn urns.URN, channel *Channel, text string, attachments []Attachment) *MsgIn {
-	var channelRef *ChannelReference
+	var channelRef *assets.ChannelReference
 	if channel != nil {
 		channelRef = channel.Reference()
 	}
@@ -47,7 +48,7 @@ func NewMsgIn(uuid MsgUUID, id MsgID, urn urns.URN, channel *Channel, text strin
 
 // NewMsgOut creates a new outgoing message
 func NewMsgOut(urn urns.URN, channel *Channel, text string, attachments []Attachment, quickReplies []string) *MsgOut {
-	var channelRef *ChannelReference
+	var channelRef *assets.ChannelReference
 	if channel != nil {
 		channelRef = channel.Reference()
 	}
@@ -74,7 +75,7 @@ func (m *BaseMsg) ID() MsgID { return m.ID_ }
 func (m *BaseMsg) URN() urns.URN { return m.URN_ }
 
 // Channel returns the channel of this message
-func (m *BaseMsg) Channel() *ChannelReference { return m.Channel_ }
+func (m *BaseMsg) Channel() *assets.ChannelReference { return m.Channel_ }
 
 // Text returns the text of this message
 func (m *BaseMsg) Text() string { return m.Text_ }

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
@@ -303,7 +304,7 @@ var _ flows.RunSummary = (*flowRun)(nil)
 
 type runEnvelope struct {
 	UUID   flows.RunUUID          `json:"uuid" validate:"required,uuid4"`
-	Flow   *flows.FlowReference   `json:"flow" validate:"required,dive"`
+	Flow   *assets.FlowReference  `json:"flow" validate:"required,dive"`
 	Path   []*step                `json:"path" validate:"dive"`
 	Events []*utils.TypedEnvelope `json:"events,omitempty"`
 

--- a/flows/runs/summary.go
+++ b/flows/runs/summary.go
@@ -3,6 +3,7 @@ package runs
 import (
 	"encoding/json"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 )
@@ -39,11 +40,11 @@ var _ flows.RunSummary = (*runSummary)(nil)
 //------------------------------------------------------------------------------------------
 
 type runSummaryEnvelope struct {
-	UUID    flows.RunUUID        `json:"uuid" validate:"uuid4"`
-	Flow    *flows.FlowReference `json:"flow" validate:"required,dive"`
-	Contact json.RawMessage      `json:"contact" validate:"required"`
-	Status  flows.RunStatus      `json:"status" validate:"required"`
-	Results flows.Results        `json:"results"`
+	UUID    flows.RunUUID         `json:"uuid" validate:"uuid4"`
+	Flow    *assets.FlowReference `json:"flow" validate:"required,dive"`
+	Contact json.RawMessage       `json:"contact" validate:"required"`
+	Status  flows.RunStatus       `json:"status" validate:"required"`
+	Results flows.Results         `json:"results"`
 }
 
 // ReadRunSummary reads a run summary from the given JSON

--- a/flows/triggers/base.go
+++ b/flows/triggers/base.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
@@ -21,14 +22,14 @@ func RegisterType(name string, f readFunc) {
 
 type baseTrigger struct {
 	environment utils.Environment
-	flow        *flows.FlowReference
+	flow        *assets.FlowReference
 	contact     *flows.Contact
 	params      types.XValue
 	triggeredOn time.Time
 }
 
 func (t *baseTrigger) Environment() utils.Environment { return t.environment }
-func (t *baseTrigger) Flow() *flows.FlowReference     { return t.flow }
+func (t *baseTrigger) Flow() *assets.FlowReference    { return t.flow }
 func (t *baseTrigger) Contact() *flows.Contact        { return t.contact }
 func (t *baseTrigger) Params() types.XValue           { return t.params }
 func (t *baseTrigger) TriggeredOn() time.Time         { return t.triggeredOn }
@@ -56,11 +57,11 @@ func (t *baseTrigger) Reduce(env utils.Environment) types.XPrimitive {
 //------------------------------------------------------------------------------------------
 
 type baseTriggerEnvelope struct {
-	Environment json.RawMessage      `json:"environment,omitempty"`
-	Flow        *flows.FlowReference `json:"flow" validate:"required"`
-	Contact     json.RawMessage      `json:"contact,omitempty"`
-	Params      json.RawMessage      `json:"params,omitempty"`
-	TriggeredOn time.Time            `json:"triggered_on" validate:"required"`
+	Environment json.RawMessage       `json:"environment,omitempty"`
+	Flow        *assets.FlowReference `json:"flow" validate:"required"`
+	Contact     json.RawMessage       `json:"contact,omitempty"`
+	Params      json.RawMessage       `json:"params,omitempty"`
+	TriggeredOn time.Time             `json:"triggered_on" validate:"required"`
 }
 
 // ReadTrigger reads a trigger from the given typed envelope

--- a/flows/triggers/campaign.go
+++ b/flows/triggers/campaign.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
@@ -51,7 +52,7 @@ type CampaignTrigger struct {
 }
 
 // NewCampaignTrigger creates a new campaign trigger with the passed in values
-func NewCampaignTrigger(env utils.Environment, flow *flows.FlowReference, contact *flows.Contact, event *CampaignEvent, triggeredOn time.Time) *CampaignTrigger {
+func NewCampaignTrigger(env utils.Environment, flow *assets.FlowReference, contact *flows.Contact, event *CampaignEvent, triggeredOn time.Time) *CampaignTrigger {
 	return &CampaignTrigger{
 		baseTrigger: baseTrigger{
 			environment: env,

--- a/flows/triggers/manual.go
+++ b/flows/triggers/manual.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
@@ -34,7 +35,7 @@ type ManualTrigger struct {
 }
 
 // NewManualTrigger creates a new manual trigger
-func NewManualTrigger(env utils.Environment, contact *flows.Contact, flow *flows.FlowReference, params types.XValue, triggeredOn time.Time) flows.Trigger {
+func NewManualTrigger(env utils.Environment, contact *flows.Contact, flow *assets.FlowReference, params types.XValue, triggeredOn time.Time) flows.Trigger {
 	return &ManualTrigger{baseTrigger{environment: env, contact: contact, flow: flow, triggeredOn: triggeredOn}}
 }
 

--- a/flows/urn.go
+++ b/flows/urn.go
@@ -129,9 +129,9 @@ func ReadURNList(a SessionAssets, rawURNs []urns.URN) (URNList, error) {
 		}
 
 		var channel *Channel
-		channelUUID := assets.ChannelUUID(parsedQuery.Get("channel"))
-		if channelUUID != assets.NilChannelUUID {
-			if channel, err = a.Channels().Get(channelUUID); err != nil {
+		channelUUID := parsedQuery.Get("channel")
+		if channelUUID != "" {
+			if channel, err = a.Channels().Get(assets.ChannelUUID(channelUUID)); err != nil {
 				return nil, err
 			}
 		}

--- a/legacy/definition.go
+++ b/legacy/definition.go
@@ -71,11 +71,11 @@ type LabelReference struct {
 	Name string
 }
 
-func (l *LabelReference) Migrate() *flows.LabelReference {
+func (l *LabelReference) Migrate() *assets.LabelReference {
 	if len(l.UUID) > 0 {
-		return flows.NewLabelReference(l.UUID, l.Name)
+		return assets.NewLabelReference(l.UUID, l.Name)
 	}
-	return flows.NewVariableLabelReference(l.Name)
+	return assets.NewVariableLabelReference(l.Name)
 }
 
 // UnmarshalJSON unmarshals a legacy label reference from the given JSON
@@ -121,11 +121,11 @@ type GroupReference struct {
 	Name string
 }
 
-func (g *GroupReference) Migrate() *flows.GroupReference {
+func (g *GroupReference) Migrate() *assets.GroupReference {
 	if len(g.UUID) > 0 {
-		return flows.NewGroupReference(g.UUID, g.Name)
+		return assets.NewGroupReference(g.UUID, g.Name)
 	}
-	return flows.NewVariableGroupReference(g.Name)
+	return assets.NewVariableGroupReference(g.Name)
 }
 
 // UnmarshalJSON unmarshals a legacy group reference from the given JSON
@@ -166,19 +166,19 @@ type FlowReference struct {
 	Name string          `json:"name"`
 }
 
-func (f *FlowReference) Migrate() *flows.FlowReference {
-	return flows.NewFlowReference(f.UUID, f.Name)
+func (f *FlowReference) Migrate() *assets.FlowReference {
+	return assets.NewFlowReference(f.UUID, f.Name)
 }
 
 // RulesetConfig holds the config dictionary for a legacy ruleset
 type RulesetConfig struct {
-	Flow           *flows.FlowReference `json:"flow"`
-	FieldDelimiter string               `json:"field_delimiter"`
-	FieldIndex     int                  `json:"field_index"`
-	Webhook        string               `json:"webhook"`
-	WebhookAction  string               `json:"webhook_action"`
-	WebhookHeaders []WebhookHeader      `json:"webhook_headers"`
-	Resthook       string               `json:"resthook"`
+	Flow           *assets.FlowReference `json:"flow"`
+	FieldDelimiter string                `json:"field_delimiter"`
+	FieldIndex     int                   `json:"field_index"`
+	Webhook        string                `json:"webhook"`
+	WebhookAction  string                `json:"webhook_action"`
+	WebhookHeaders []WebhookHeader       `json:"webhook_headers"`
+	Resthook       string                `json:"resthook"`
 }
 
 type WebhookHeader struct {
@@ -364,7 +364,7 @@ var testTypeMappings = map[string]string{
 func migrateAction(baseLanguage utils.Language, a Action, localization flows.Localization) (flows.Action, error) {
 	switch a.Type {
 	case "add_label":
-		labels := make([]*flows.LabelReference, len(a.Labels))
+		labels := make([]*assets.LabelReference, len(a.Labels))
 		for i, label := range a.Labels {
 			labels[i] = label.Migrate()
 		}
@@ -402,7 +402,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 		}, nil
 	case "channel":
 		return &actions.SetContactChannelAction{
-			Channel:    flows.NewChannelReference(a.Channel, a.Name),
+			Channel:    assets.NewChannelReference(a.Channel, a.Name),
 			BaseAction: actions.NewBaseAction(a.UUID),
 		}, nil
 	case "flow":
@@ -415,7 +415,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 		for i, contact := range a.Contacts {
 			contacts[i] = contact.Migrate()
 		}
-		groups := make([]*flows.GroupReference, len(a.Groups))
+		groups := make([]*assets.GroupReference, len(a.Groups))
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}
@@ -489,7 +489,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 		for i, contact := range a.Contacts {
 			contacts[i] = contact.Migrate()
 		}
-		groups := make([]*flows.GroupReference, len(a.Groups))
+		groups := make([]*assets.GroupReference, len(a.Groups))
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}
@@ -510,7 +510,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 		}, nil
 
 	case "add_group":
-		groups := make([]*flows.GroupReference, len(a.Groups))
+		groups := make([]*assets.GroupReference, len(a.Groups))
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}
@@ -520,7 +520,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 			BaseAction: actions.NewBaseAction(a.UUID),
 		}, nil
 	case "del_group":
-		groups := make([]*flows.GroupReference, len(a.Groups))
+		groups := make([]*assets.GroupReference, len(a.Groups))
 		for i, group := range a.Groups {
 			groups[i] = group.Migrate()
 		}
@@ -563,7 +563,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 		}
 
 		return &actions.SetContactFieldAction{
-			Field:      flows.NewFieldReference(a.Field, a.Label),
+			Field:      assets.NewFieldReference(a.Field, a.Label),
 			Value:      migratedValue,
 			BaseAction: actions.NewBaseAction(a.UUID),
 		}, nil

--- a/test/assets.go
+++ b/test/assets.go
@@ -15,10 +15,10 @@ func NewGroup(name string, query string) *flows.Group {
 	return flows.NewGroup(types.NewGroup(assets.GroupUUID(utils.NewUUID()), name, query))
 }
 
-func NewChannel(name string, address string, schemes []string, roles []assets.ChannelRole, parentUUID assets.ChannelUUID) *flows.Channel {
-	return flows.NewChannel(types.NewChannel(assets.ChannelUUID(utils.NewUUID()), name, address, schemes, roles, parentUUID))
+func NewChannel(name string, address string, schemes []string, roles []assets.ChannelRole, parent *assets.ChannelReference) *flows.Channel {
+	return flows.NewChannel(types.NewChannel(assets.ChannelUUID(utils.NewUUID()), name, address, schemes, roles, parent))
 }
 
-func NewTelChannel(name string, address string, roles []assets.ChannelRole, parentUUID assets.ChannelUUID, country string, matchPrefixes []string) *flows.Channel {
-	return flows.NewChannel(types.NewTelChannel(assets.ChannelUUID(utils.NewUUID()), name, address, roles, parentUUID, country, matchPrefixes))
+func NewTelChannel(name string, address string, roles []assets.ChannelRole, parent *assets.ChannelReference, country string, matchPrefixes []string) *flows.Channel {
+	return flows.NewChannel(types.NewTelChannel(assets.ChannelUUID(utils.NewUUID()), name, address, roles, parent, country, matchPrefixes))
 }


### PR DESCRIPTION
 * `Parent()` of a channel asset is a reference instead of just a UUID - this is the way it was before the Great Assets Refactor (#362), but required that..
 * Asset reference structs all move into the `goflow/assets` package.. which is where they belong anyway.