### PR TITLE
🚆 Regex fixes

### DIFF
--- a/docs/expressions.html
+++ b/docs/expressions.html
@@ -541,158 +541,167 @@
 <div class="sourceCode" id="cb49"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb49-1" data-line-number="1">@(read_chars(<span class="st">&quot;1234&quot;</span>)) → <span class="dv">1</span> <span class="dv">2</span> <span class="dv">3</span> <span class="dv">4</span></a>
 <a class="sourceLine" id="cb49-2" data-line-number="2">@(read_chars(<span class="st">&quot;abc&quot;</span>)) → a b c</a>
 <a class="sourceLine" id="cb49-3" data-line-number="3">@(read_chars(<span class="st">&quot;abcdef&quot;</span>)) → a b c , d e f</a></code></pre></div>
+<p><a name="function:regex_match"></a></p>
+<h2 id="regex_matchtext-pattern-group">regex_match(text, pattern [,group])</h2>
+<p>Returns the first match of the regular expression <code>pattern</code> in <code>text</code>.</p>
+<p>An optional third parameter <code>group</code> determines which matching group will be returned.</p>
+<div class="sourceCode" id="cb50"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb50-1" data-line-number="1">@(regex_match(<span class="st">&quot;sda34dfddg67&quot;</span>, <span class="st">&quot;\d+&quot;</span>)) → <span class="dv">34</span></a>
+<a class="sourceLine" id="cb50-2" data-line-number="2">@(regex_match(<span class="st">&quot;Bob Smith&quot;</span>, <span class="st">&quot;(\w+) (\w+)&quot;</span>, <span class="dv">1</span>)) → Bob</a>
+<a class="sourceLine" id="cb50-3" data-line-number="3">@(regex_match(<span class="st">&quot;Bob Smith&quot;</span>, <span class="st">&quot;(\w+) (\w+)&quot;</span>, <span class="dv">2</span>)) → Smith</a>
+<a class="sourceLine" id="cb50-4" data-line-number="4">@(regex_match(<span class="st">&quot;Bob Smith&quot;</span>, <span class="st">&quot;(\w+) (\w+)&quot;</span>, <span class="dv">5</span>)) → ERROR</a>
+<a class="sourceLine" id="cb50-5" data-line-number="5">@(regex_match(<span class="st">&quot;abc&quot;</span>, <span class="st">&quot;[\.&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:remove_first_word"></a></p>
 <h2 id="remove_first_wordtext">remove_first_word(text)</h2>
 <p>Removes the first word of <code>text</code>.</p>
-<div class="sourceCode" id="cb50"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb50-1" data-line-number="1">@(remove_first_word(<span class="st">&quot;foo bar&quot;</span>)) → bar</a></code></pre></div>
+<div class="sourceCode" id="cb51"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb51-1" data-line-number="1">@(remove_first_word(<span class="st">&quot;foo bar&quot;</span>)) → bar</a></code></pre></div>
 <p><a name="function:repeat"></a></p>
 <h2 id="repeattext-count">repeat(text, count)</h2>
 <p>Returns <code>text</code> repeated <code>count</code> number of times.</p>
-<div class="sourceCode" id="cb51"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb51-1" data-line-number="1">@(repeat(<span class="st">&quot;*&quot;</span>, <span class="dv">8</span>)) → ********</a>
-<a class="sourceLine" id="cb51-2" data-line-number="2">@(repeat(<span class="st">&quot;*&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb52"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb52-1" data-line-number="1">@(repeat(<span class="st">&quot;*&quot;</span>, <span class="dv">8</span>)) → ********</a>
+<a class="sourceLine" id="cb52-2" data-line-number="2">@(repeat(<span class="st">&quot;*&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:replace"></a></p>
 <h2 id="replacetext-needle-replacement">replace(text, needle, replacement)</h2>
 <p>Replaces all occurrences of <code>needle</code> with <code>replacement</code> in <code>text</code>.</p>
-<div class="sourceCode" id="cb52"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb52-1" data-line-number="1">@(replace(<span class="st">&quot;foo bar&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;zap&quot;</span>)) → zap bar</a>
-<a class="sourceLine" id="cb52-2" data-line-number="2">@(replace(<span class="st">&quot;foo bar&quot;</span>, <span class="st">&quot;baz&quot;</span>, <span class="st">&quot;zap&quot;</span>)) → foo bar</a></code></pre></div>
+<div class="sourceCode" id="cb53"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb53-1" data-line-number="1">@(replace(<span class="st">&quot;foo bar&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;zap&quot;</span>)) → zap bar</a>
+<a class="sourceLine" id="cb53-2" data-line-number="2">@(replace(<span class="st">&quot;foo bar&quot;</span>, <span class="st">&quot;baz&quot;</span>, <span class="st">&quot;zap&quot;</span>)) → foo bar</a></code></pre></div>
 <p><a name="function:right"></a></p>
 <h2 id="righttext-count">right(text, count)</h2>
 <p>Returns the <code>count</code> right-most characters in <code>text</code></p>
-<div class="sourceCode" id="cb53"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb53-1" data-line-number="1">@(right(<span class="st">&quot;hello&quot;</span>, <span class="dv">2</span>)) → lo</a>
-<a class="sourceLine" id="cb53-2" data-line-number="2">@(right(<span class="st">&quot;hello&quot;</span>, <span class="dv">7</span>)) → hello</a>
-<a class="sourceLine" id="cb53-3" data-line-number="3">@(right(<span class="st">&quot;😀😃😄😁&quot;</span>, <span class="dv">2</span>)) → 😄😁</a>
-<a class="sourceLine" id="cb53-4" data-line-number="4">@(right(<span class="st">&quot;hello&quot;</span>, <span class="dv">-1</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb54"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb54-1" data-line-number="1">@(right(<span class="st">&quot;hello&quot;</span>, <span class="dv">2</span>)) → lo</a>
+<a class="sourceLine" id="cb54-2" data-line-number="2">@(right(<span class="st">&quot;hello&quot;</span>, <span class="dv">7</span>)) → hello</a>
+<a class="sourceLine" id="cb54-3" data-line-number="3">@(right(<span class="st">&quot;😀😃😄😁&quot;</span>, <span class="dv">2</span>)) → 😄😁</a>
+<a class="sourceLine" id="cb54-4" data-line-number="4">@(right(<span class="st">&quot;hello&quot;</span>, <span class="dv">-1</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:round"></a></p>
 <h2 id="roundnum-places">round(num [,places])</h2>
 <p>Rounds <code>num</code> to the nearest value.</p>
 <p>You can optionally pass in the number of decimal places to round to as <code>places</code>. If <code>places</code> &lt; 0, it will round the integer part to the nearest 10^(-places).</p>
-<div class="sourceCode" id="cb54"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb54-1" data-line-number="1">@(round(<span class="dv">12</span>)) → <span class="dv">12</span></a>
-<a class="sourceLine" id="cb54-2" data-line-number="2">@(round(<span class="fl">12.141</span>)) → <span class="dv">12</span></a>
-<a class="sourceLine" id="cb54-3" data-line-number="3">@(round(<span class="fl">12.6</span>)) → <span class="dv">13</span></a>
-<a class="sourceLine" id="cb54-4" data-line-number="4">@(round(<span class="fl">12.141</span>, <span class="dv">2</span>)) → <span class="fl">12.14</span></a>
-<a class="sourceLine" id="cb54-5" data-line-number="5">@(round(<span class="fl">12.146</span>, <span class="dv">2</span>)) → <span class="fl">12.15</span></a>
-<a class="sourceLine" id="cb54-6" data-line-number="6">@(round(<span class="fl">12.146</span>, <span class="dv">-1</span>)) → <span class="dv">10</span></a>
-<a class="sourceLine" id="cb54-7" data-line-number="7">@(round(<span class="st">&quot;notnum&quot;</span>, <span class="dv">2</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb55"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb55-1" data-line-number="1">@(round(<span class="dv">12</span>)) → <span class="dv">12</span></a>
+<a class="sourceLine" id="cb55-2" data-line-number="2">@(round(<span class="fl">12.141</span>)) → <span class="dv">12</span></a>
+<a class="sourceLine" id="cb55-3" data-line-number="3">@(round(<span class="fl">12.6</span>)) → <span class="dv">13</span></a>
+<a class="sourceLine" id="cb55-4" data-line-number="4">@(round(<span class="fl">12.141</span>, <span class="dv">2</span>)) → <span class="fl">12.14</span></a>
+<a class="sourceLine" id="cb55-5" data-line-number="5">@(round(<span class="fl">12.146</span>, <span class="dv">2</span>)) → <span class="fl">12.15</span></a>
+<a class="sourceLine" id="cb55-6" data-line-number="6">@(round(<span class="fl">12.146</span>, <span class="dv">-1</span>)) → <span class="dv">10</span></a>
+<a class="sourceLine" id="cb55-7" data-line-number="7">@(round(<span class="st">&quot;notnum&quot;</span>, <span class="dv">2</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:round_down"></a></p>
 <h2 id="round_downnum-places">round_down(num [,places])</h2>
 <p>Rounds <code>num</code> down to the nearest integer value.</p>
 <p>You can optionally pass in the number of decimal places to round to as <code>places</code>.</p>
-<div class="sourceCode" id="cb55"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb55-1" data-line-number="1">@(round_down(<span class="dv">12</span>)) → <span class="dv">12</span></a>
-<a class="sourceLine" id="cb55-2" data-line-number="2">@(round_down(<span class="fl">12.141</span>)) → <span class="dv">12</span></a>
-<a class="sourceLine" id="cb55-3" data-line-number="3">@(round_down(<span class="fl">12.6</span>)) → <span class="dv">12</span></a>
-<a class="sourceLine" id="cb55-4" data-line-number="4">@(round_down(<span class="fl">12.141</span>, <span class="dv">2</span>)) → <span class="fl">12.14</span></a>
-<a class="sourceLine" id="cb55-5" data-line-number="5">@(round_down(<span class="fl">12.146</span>, <span class="dv">2</span>)) → <span class="fl">12.14</span></a>
-<a class="sourceLine" id="cb55-6" data-line-number="6">@(round_down(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb56"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb56-1" data-line-number="1">@(round_down(<span class="dv">12</span>)) → <span class="dv">12</span></a>
+<a class="sourceLine" id="cb56-2" data-line-number="2">@(round_down(<span class="fl">12.141</span>)) → <span class="dv">12</span></a>
+<a class="sourceLine" id="cb56-3" data-line-number="3">@(round_down(<span class="fl">12.6</span>)) → <span class="dv">12</span></a>
+<a class="sourceLine" id="cb56-4" data-line-number="4">@(round_down(<span class="fl">12.141</span>, <span class="dv">2</span>)) → <span class="fl">12.14</span></a>
+<a class="sourceLine" id="cb56-5" data-line-number="5">@(round_down(<span class="fl">12.146</span>, <span class="dv">2</span>)) → <span class="fl">12.14</span></a>
+<a class="sourceLine" id="cb56-6" data-line-number="6">@(round_down(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:round_up"></a></p>
 <h2 id="round_upnum-places">round_up(num [,places])</h2>
 <p>Rounds <code>num</code> up to the nearest integer value.</p>
 <p>You can optionally pass in the number of decimal places to round to as <code>places</code>.</p>
-<div class="sourceCode" id="cb56"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb56-1" data-line-number="1">@(round_up(<span class="dv">12</span>)) → <span class="dv">12</span></a>
-<a class="sourceLine" id="cb56-2" data-line-number="2">@(round_up(<span class="fl">12.141</span>)) → <span class="dv">13</span></a>
-<a class="sourceLine" id="cb56-3" data-line-number="3">@(round_up(<span class="fl">12.6</span>)) → <span class="dv">13</span></a>
-<a class="sourceLine" id="cb56-4" data-line-number="4">@(round_up(<span class="fl">12.141</span>, <span class="dv">2</span>)) → <span class="fl">12.15</span></a>
-<a class="sourceLine" id="cb56-5" data-line-number="5">@(round_up(<span class="fl">12.146</span>, <span class="dv">2</span>)) → <span class="fl">12.15</span></a>
-<a class="sourceLine" id="cb56-6" data-line-number="6">@(round_up(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb57"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb57-1" data-line-number="1">@(round_up(<span class="dv">12</span>)) → <span class="dv">12</span></a>
+<a class="sourceLine" id="cb57-2" data-line-number="2">@(round_up(<span class="fl">12.141</span>)) → <span class="dv">13</span></a>
+<a class="sourceLine" id="cb57-3" data-line-number="3">@(round_up(<span class="fl">12.6</span>)) → <span class="dv">13</span></a>
+<a class="sourceLine" id="cb57-4" data-line-number="4">@(round_up(<span class="fl">12.141</span>, <span class="dv">2</span>)) → <span class="fl">12.15</span></a>
+<a class="sourceLine" id="cb57-5" data-line-number="5">@(round_up(<span class="fl">12.146</span>, <span class="dv">2</span>)) → <span class="fl">12.15</span></a>
+<a class="sourceLine" id="cb57-6" data-line-number="6">@(round_up(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:split"></a></p>
 <h2 id="splittext-delimiters">split(text, delimiters)</h2>
 <p>Splits <code>text</code> based on the given characters in <code>delimiters</code>.</p>
 <p>Empty values are removed from the returned list.</p>
-<div class="sourceCode" id="cb57"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb57-1" data-line-number="1">@(split(<span class="st">&quot;a b c&quot;</span>, <span class="st">&quot; &quot;</span>)) → [<span class="st">&quot;a&quot;</span>,<span class="st">&quot;b&quot;</span>,<span class="st">&quot;c&quot;</span>]</a>
-<a class="sourceLine" id="cb57-2" data-line-number="2">@(split(<span class="st">&quot;a&quot;</span>, <span class="st">&quot; &quot;</span>)) → [<span class="st">&quot;a&quot;</span>]</a>
-<a class="sourceLine" id="cb57-3" data-line-number="3">@(split(<span class="st">&quot;abc..d&quot;</span>, <span class="st">&quot;.&quot;</span>)) → [<span class="st">&quot;abc&quot;</span>,<span class="st">&quot;d&quot;</span>]</a>
-<a class="sourceLine" id="cb57-4" data-line-number="4">@(split(<span class="st">&quot;a.b.c.&quot;</span>, <span class="st">&quot;.&quot;</span>)) → [<span class="st">&quot;a&quot;</span>,<span class="st">&quot;b&quot;</span>,<span class="st">&quot;c&quot;</span>]</a>
-<a class="sourceLine" id="cb57-5" data-line-number="5">@(split(<span class="st">&quot;a|b,c  d&quot;</span>, <span class="st">&quot; .|,&quot;</span>)) → [<span class="st">&quot;a&quot;</span>,<span class="st">&quot;b&quot;</span>,<span class="st">&quot;c&quot;</span>,<span class="st">&quot;d&quot;</span>]</a></code></pre></div>
+<div class="sourceCode" id="cb58"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb58-1" data-line-number="1">@(split(<span class="st">&quot;a b c&quot;</span>, <span class="st">&quot; &quot;</span>)) → [<span class="st">&quot;a&quot;</span>,<span class="st">&quot;b&quot;</span>,<span class="st">&quot;c&quot;</span>]</a>
+<a class="sourceLine" id="cb58-2" data-line-number="2">@(split(<span class="st">&quot;a&quot;</span>, <span class="st">&quot; &quot;</span>)) → [<span class="st">&quot;a&quot;</span>]</a>
+<a class="sourceLine" id="cb58-3" data-line-number="3">@(split(<span class="st">&quot;abc..d&quot;</span>, <span class="st">&quot;.&quot;</span>)) → [<span class="st">&quot;abc&quot;</span>,<span class="st">&quot;d&quot;</span>]</a>
+<a class="sourceLine" id="cb58-4" data-line-number="4">@(split(<span class="st">&quot;a.b.c.&quot;</span>, <span class="st">&quot;.&quot;</span>)) → [<span class="st">&quot;a&quot;</span>,<span class="st">&quot;b&quot;</span>,<span class="st">&quot;c&quot;</span>]</a>
+<a class="sourceLine" id="cb58-5" data-line-number="5">@(split(<span class="st">&quot;a|b,c  d&quot;</span>, <span class="st">&quot; .|,&quot;</span>)) → [<span class="st">&quot;a&quot;</span>,<span class="st">&quot;b&quot;</span>,<span class="st">&quot;c&quot;</span>,<span class="st">&quot;d&quot;</span>]</a></code></pre></div>
 <p><a name="function:text"></a></p>
 <h2 id="textvalue">text(value)</h2>
 <p>Tries to convert <code>value</code> to text.</p>
 <p>An error is returned if the value can’t be converted.</p>
-<div class="sourceCode" id="cb58"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb58-1" data-line-number="1">@(text(<span class="dv">3</span> = <span class="dv">3</span>)) → true</a>
-<a class="sourceLine" id="cb58-2" data-line-number="2">@(json(text(<span class="fl">123.45</span>))) → <span class="st">&quot;123.45&quot;</span></a>
-<a class="sourceLine" id="cb58-3" data-line-number="3">@(text(<span class="dv">1</span> / <span class="dv">0</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb59"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb59-1" data-line-number="1">@(text(<span class="dv">3</span> = <span class="dv">3</span>)) → true</a>
+<a class="sourceLine" id="cb59-2" data-line-number="2">@(json(text(<span class="fl">123.45</span>))) → <span class="st">&quot;123.45&quot;</span></a>
+<a class="sourceLine" id="cb59-3" data-line-number="3">@(text(<span class="dv">1</span> / <span class="dv">0</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:text_compare"></a></p>
 <h2 id="text_comparetext1-text2">text_compare(text1, text2)</h2>
 <p>Returns the dictionary order of <code>text1</code> and <code>text2</code>.</p>
 <p>The return value will be -1 if <code>text1</code> comes before <code>text2</code>, 0 if they are equal and 1 if <code>text1</code> comes after <code>text2</code>.</p>
-<div class="sourceCode" id="cb59"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb59-1" data-line-number="1">@(text_compare(<span class="st">&quot;abc&quot;</span>, <span class="st">&quot;abc&quot;</span>)) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb59-2" data-line-number="2">@(text_compare(<span class="st">&quot;abc&quot;</span>, <span class="st">&quot;def&quot;</span>)) → <span class="dv">-1</span></a>
-<a class="sourceLine" id="cb59-3" data-line-number="3">@(text_compare(<span class="st">&quot;zzz&quot;</span>, <span class="st">&quot;aaa&quot;</span>)) → <span class="dv">1</span></a></code></pre></div>
+<div class="sourceCode" id="cb60"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb60-1" data-line-number="1">@(text_compare(<span class="st">&quot;abc&quot;</span>, <span class="st">&quot;abc&quot;</span>)) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb60-2" data-line-number="2">@(text_compare(<span class="st">&quot;abc&quot;</span>, <span class="st">&quot;def&quot;</span>)) → <span class="dv">-1</span></a>
+<a class="sourceLine" id="cb60-3" data-line-number="3">@(text_compare(<span class="st">&quot;zzz&quot;</span>, <span class="st">&quot;aaa&quot;</span>)) → <span class="dv">1</span></a></code></pre></div>
 <p><a name="function:title"></a></p>
 <h2 id="titletext">title(text)</h2>
 <p>Capitalizes each word in <code>text</code>.</p>
-<div class="sourceCode" id="cb60"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb60-1" data-line-number="1">@(title(<span class="st">&quot;foo&quot;</span>)) → Foo</a>
-<a class="sourceLine" id="cb60-2" data-line-number="2">@(title(<span class="st">&quot;ryan lewis&quot;</span>)) → Ryan Lewis</a>
-<a class="sourceLine" id="cb60-3" data-line-number="3">@(title(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
+<div class="sourceCode" id="cb61"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb61-1" data-line-number="1">@(title(<span class="st">&quot;foo&quot;</span>)) → Foo</a>
+<a class="sourceLine" id="cb61-2" data-line-number="2">@(title(<span class="st">&quot;ryan lewis&quot;</span>)) → Ryan Lewis</a>
+<a class="sourceLine" id="cb61-3" data-line-number="3">@(title(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
 <p><a name="function:today"></a></p>
 <h2 id="today">today()</h2>
 <p>Returns the current date in the current timezone.</p>
 <p>The returned datetime has a time set to midnight in the current timezone.</p>
-<div class="sourceCode" id="cb61"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb61-1" data-line-number="1">@(today()) → <span class="dv">2018-04</span>-11T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a></code></pre></div>
+<div class="sourceCode" id="cb62"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb62-1" data-line-number="1">@(today()) → <span class="dv">2018-04</span>-11T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a></code></pre></div>
 <p><a name="function:tz"></a></p>
 <h2 id="tzdate">tz(date)</h2>
 <p>Returns the name of the timezone of <code>date</code>.</p>
 <p>If no timezone information is present in the date, then the current timezone will be returned.</p>
-<div class="sourceCode" id="cb62"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb62-1" data-line-number="1">@(tz(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → UTC</a>
-<a class="sourceLine" id="cb62-2" data-line-number="2">@(tz(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → America/Guayaquil</a>
-<a class="sourceLine" id="cb62-3" data-line-number="3">@(tz(<span class="st">&quot;2017-01-15&quot;</span>)) → America/Guayaquil</a>
-<a class="sourceLine" id="cb62-4" data-line-number="4">@(tz(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb63"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb63-1" data-line-number="1">@(tz(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → UTC</a>
+<a class="sourceLine" id="cb63-2" data-line-number="2">@(tz(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → America/Guayaquil</a>
+<a class="sourceLine" id="cb63-3" data-line-number="3">@(tz(<span class="st">&quot;2017-01-15&quot;</span>)) → America/Guayaquil</a>
+<a class="sourceLine" id="cb63-4" data-line-number="4">@(tz(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:tz_offset"></a></p>
 <h2 id="tz_offsetdate">tz_offset(date)</h2>
 <p>Returns the offset of the timezone of <code>date</code>.</p>
 <p>The offset is returned in the format <code>[+/-]HH:MM</code>. If no timezone information is present in the date, then the current timezone offset will be returned.</p>
-<div class="sourceCode" id="cb63"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb63-1" data-line-number="1">@(tz_offset(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → +<span class="dv">0000</span></a>
-<a class="sourceLine" id="cb63-2" data-line-number="2">@(tz_offset(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → <span class="dv">-0500</span></a>
-<a class="sourceLine" id="cb63-3" data-line-number="3">@(tz_offset(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">-0500</span></a>
-<a class="sourceLine" id="cb63-4" data-line-number="4">@(tz_offset(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb64"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb64-1" data-line-number="1">@(tz_offset(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → +<span class="dv">0000</span></a>
+<a class="sourceLine" id="cb64-2" data-line-number="2">@(tz_offset(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → <span class="dv">-0500</span></a>
+<a class="sourceLine" id="cb64-3" data-line-number="3">@(tz_offset(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">-0500</span></a>
+<a class="sourceLine" id="cb64-4" data-line-number="4">@(tz_offset(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:upper"></a></p>
 <h2 id="uppertext">upper(text)</h2>
 <p>Converts <code>text</code> to lowercase.</p>
-<div class="sourceCode" id="cb64"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb64-1" data-line-number="1">@(upper(<span class="st">&quot;Asdf&quot;</span>)) → ASDF</a>
-<a class="sourceLine" id="cb64-2" data-line-number="2">@(upper(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
+<div class="sourceCode" id="cb65"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb65-1" data-line-number="1">@(upper(<span class="st">&quot;Asdf&quot;</span>)) → ASDF</a>
+<a class="sourceLine" id="cb65-2" data-line-number="2">@(upper(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
 <p><a name="function:url_encode"></a></p>
 <h2 id="url_encodetext">url_encode(text)</h2>
 <p>Encodes <code>text</code> for use as a URL parameter.</p>
-<div class="sourceCode" id="cb65"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb65-1" data-line-number="1">@(url_encode(<span class="st">&quot;two words&quot;</span>)) → two+words</a>
-<a class="sourceLine" id="cb65-2" data-line-number="2">@(url_encode(<span class="dv">10</span>)) → <span class="dv">10</span></a></code></pre></div>
+<div class="sourceCode" id="cb66"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb66-1" data-line-number="1">@(url_encode(<span class="st">&quot;two words&quot;</span>)) → two+words</a>
+<a class="sourceLine" id="cb66-2" data-line-number="2">@(url_encode(<span class="dv">10</span>)) → <span class="dv">10</span></a></code></pre></div>
 <p><a name="function:weekday"></a></p>
 <h2 id="weekdaydate">weekday(date)</h2>
 <p>Returns the day of the week for <code>date</code>.</p>
 <p>The week is considered to start on Sunday so a Sunday returns 0, a Monday returns 1 etc.</p>
-<div class="sourceCode" id="cb66"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb66-1" data-line-number="1">@(weekday(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb66-2" data-line-number="2">@(weekday(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb67"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb67-1" data-line-number="1">@(weekday(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb67-2" data-line-number="2">@(weekday(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:word"></a></p>
 <h2 id="wordtext-index-delimiters">word(text, index [,delimiters])</h2>
 <p>Returns the word at <code>index</code> in <code>text</code>.</p>
 <p>Indexes start at zero. There is an optional final parameter <code>delimiters</code> which is string of characters used to split the text into words.</p>
-<div class="sourceCode" id="cb67"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb67-1" data-line-number="1">@(word(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
-<a class="sourceLine" id="cb67-2" data-line-number="2">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
-<a class="sourceLine" id="cb67-3" data-line-number="3">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">1</span>)) → cat</a>
-<a class="sourceLine" id="cb67-4" data-line-number="4">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">2</span>)) → dog</a>
-<a class="sourceLine" id="cb67-5" data-line-number="5">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-1</span>)) → dog</a>
-<a class="sourceLine" id="cb67-6" data-line-number="6">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-2</span>)) → cat</a>
-<a class="sourceLine" id="cb67-7" data-line-number="7">@(word(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;.*=|&quot;</span>)) → cat,dog</a>
-<a class="sourceLine" id="cb67-8" data-line-number="8">@(word(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
+<div class="sourceCode" id="cb68"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb68-1" data-line-number="1">@(word(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
+<a class="sourceLine" id="cb68-2" data-line-number="2">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
+<a class="sourceLine" id="cb68-3" data-line-number="3">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">1</span>)) → cat</a>
+<a class="sourceLine" id="cb68-4" data-line-number="4">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">2</span>)) → dog</a>
+<a class="sourceLine" id="cb68-5" data-line-number="5">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-1</span>)) → dog</a>
+<a class="sourceLine" id="cb68-6" data-line-number="6">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-2</span>)) → cat</a>
+<a class="sourceLine" id="cb68-7" data-line-number="7">@(word(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;.*=|&quot;</span>)) → cat,dog</a>
+<a class="sourceLine" id="cb68-8" data-line-number="8">@(word(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
 <p><a name="function:word_count"></a></p>
 <h2 id="word_counttext-delimiters">word_count(text [,delimiters])</h2>
 <p>Returns the number of words in <code>text</code>.</p>
 <p>There is an optional final parameter <code>delimiters</code> which is string of characters used to split the text into words.</p>
-<div class="sourceCode" id="cb68"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb68-1" data-line-number="1">@(word_count(<span class="st">&quot;foo bar&quot;</span>)) → <span class="dv">2</span></a>
-<a class="sourceLine" id="cb68-2" data-line-number="2">@(word_count(<span class="dv">10</span>)) → <span class="dv">1</span></a>
-<a class="sourceLine" id="cb68-3" data-line-number="3">@(word_count(<span class="st">&quot;&quot;</span>)) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb68-4" data-line-number="4">@(word_count(<span class="st">&quot;😀😃😄😁&quot;</span>)) → <span class="dv">4</span></a>
-<a class="sourceLine" id="cb68-5" data-line-number="5">@(word_count(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="st">&quot;.*=|&quot;</span>)) → <span class="dv">2</span></a>
-<a class="sourceLine" id="cb68-6" data-line-number="6">@(word_count(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="st">&quot; &quot;</span>)) → <span class="dv">2</span></a></code></pre></div>
+<div class="sourceCode" id="cb69"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb69-1" data-line-number="1">@(word_count(<span class="st">&quot;foo bar&quot;</span>)) → <span class="dv">2</span></a>
+<a class="sourceLine" id="cb69-2" data-line-number="2">@(word_count(<span class="dv">10</span>)) → <span class="dv">1</span></a>
+<a class="sourceLine" id="cb69-3" data-line-number="3">@(word_count(<span class="st">&quot;&quot;</span>)) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb69-4" data-line-number="4">@(word_count(<span class="st">&quot;😀😃😄😁&quot;</span>)) → <span class="dv">4</span></a>
+<a class="sourceLine" id="cb69-5" data-line-number="5">@(word_count(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="st">&quot;.*=|&quot;</span>)) → <span class="dv">2</span></a>
+<a class="sourceLine" id="cb69-6" data-line-number="6">@(word_count(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="st">&quot; &quot;</span>)) → <span class="dv">2</span></a></code></pre></div>
 <p><a name="function:word_slice"></a></p>
 <h2 id="word_slicetext-start-end-delimiters">word_slice(text, start, end [,delimiters])</h2>
 <p>Extracts a sub-sequence of words from <code>text</code>.</p>
 <p>The returned words are those from <code>start</code> up to but not-including <code>end</code>. Indexes start at zero and a negative end value means that all words after the start should be returned. There is an optional final parameter <code>delimiters</code> which is string of characters used to split the text into words.</p>
-<div class="sourceCode" id="cb69"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb69-1" data-line-number="1">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">1</span>)) → bee</a>
-<a class="sourceLine" id="cb69-2" data-line-number="2">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">2</span>)) → bee cat</a>
-<a class="sourceLine" id="cb69-3" data-line-number="3">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>)) → cat dog</a>
-<a class="sourceLine" id="cb69-4" data-line-number="4">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>)) → cat dog</a>
-<a class="sourceLine" id="cb69-5" data-line-number="5">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">2</span>, <span class="dv">3</span>)) → dog</a>
-<a class="sourceLine" id="cb69-6" data-line-number="6">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">3</span>, <span class="dv">10</span>)) →</a>
-<a class="sourceLine" id="cb69-7" data-line-number="7">@(word_slice(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>, <span class="st">&quot;.*=|,&quot;</span>)) → cat dog</a>
-<a class="sourceLine" id="cb69-8" data-line-number="8">@(word_slice(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="dv">2</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
+<div class="sourceCode" id="cb70"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb70-1" data-line-number="1">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">1</span>)) → bee</a>
+<a class="sourceLine" id="cb70-2" data-line-number="2">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">2</span>)) → bee cat</a>
+<a class="sourceLine" id="cb70-3" data-line-number="3">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>)) → cat dog</a>
+<a class="sourceLine" id="cb70-4" data-line-number="4">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>)) → cat dog</a>
+<a class="sourceLine" id="cb70-5" data-line-number="5">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">2</span>, <span class="dv">3</span>)) → dog</a>
+<a class="sourceLine" id="cb70-6" data-line-number="6">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">3</span>, <span class="dv">10</span>)) →</a>
+<a class="sourceLine" id="cb70-7" data-line-number="7">@(word_slice(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>, <span class="st">&quot;.*=|,&quot;</span>)) → cat dog</a>
+<a class="sourceLine" id="cb70-8" data-line-number="8">@(word_slice(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="dv">2</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
 </div>
 <h1 id="router-tests">Router Tests</h1>
 <p>Router tests are a special class of functions which are used within the switch router. They are called in the same way as normal functions, but all return a test result object which by default evalutes to true or false, but can also be used to find the matching portion of the test by using the <code>match</code> component of the result. The flow editor builds these expressions using UI widgets, but they can be used anywhere a normal template function is used.</p>
@@ -701,217 +710,217 @@
 <h2 id="has_all_wordstext-words">has_all_words(text, words)</h2>
 <p>Tests whether all the <code>words</code> are contained in <code>text</code></p>
 <p>The words can be in any order and may appear more than once.</p>
-<div class="sourceCode" id="cb70"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb70-1" data-line-number="1">@(has_all_words(<span class="st">&quot;the quick brown FOX&quot;</span>, <span class="st">&quot;the fox&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb70-2" data-line-number="2">@(has_all_words(<span class="st">&quot;the quick brown FOX&quot;</span>, <span class="st">&quot;the fox&quot;</span>).match) → the FOX</a>
-<a class="sourceLine" id="cb70-3" data-line-number="3">@(has_all_words(<span class="st">&quot;the quick brown fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb71"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb71-1" data-line-number="1">@(has_all_words(<span class="st">&quot;the quick brown FOX&quot;</span>, <span class="st">&quot;the fox&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb71-2" data-line-number="2">@(has_all_words(<span class="st">&quot;the quick brown FOX&quot;</span>, <span class="st">&quot;the fox&quot;</span>).match) → the FOX</a>
+<a class="sourceLine" id="cb71-3" data-line-number="3">@(has_all_words(<span class="st">&quot;the quick brown fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_any_word"></a></p>
 <h2 id="has_any_wordtext-words">has_any_word(text, words)</h2>
 <p>Tests whether any of the <code>words</code> are contained in the <code>text</code></p>
 <p>Only one of the words needs to match and it may appear more than once.</p>
-<div class="sourceCode" id="cb71"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb71-1" data-line-number="1">@(has_any_word(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;fox quick&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb71-2" data-line-number="2">@(has_any_word(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb71-3" data-line-number="3">@(has_any_word(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>).match) → Fox</a></code></pre></div>
+<div class="sourceCode" id="cb72"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb72-1" data-line-number="1">@(has_any_word(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;fox quick&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb72-2" data-line-number="2">@(has_any_word(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb72-3" data-line-number="3">@(has_any_word(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>).match) → Fox</a></code></pre></div>
 <p><a name="test:has_beginning"></a></p>
 <h2 id="has_beginningtext-beginning">has_beginning(text, beginning)</h2>
 <p>Tests whether <code>text</code> starts with <code>beginning</code></p>
 <p>Both text values are trimmed of surrounding whitespace, but otherwise matching is strict without any tokenization.</p>
-<div class="sourceCode" id="cb72"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb72-1" data-line-number="1">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;the quick&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb72-2" data-line-number="2">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;the quick&quot;</span>).match) → The Quick</a>
-<a class="sourceLine" id="cb72-3" data-line-number="3">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;the   quick&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb72-4" data-line-number="4">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;quick brown&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb73"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb73-1" data-line-number="1">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;the quick&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb73-2" data-line-number="2">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;the quick&quot;</span>).match) → The Quick</a>
+<a class="sourceLine" id="cb73-3" data-line-number="3">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;the   quick&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb73-4" data-line-number="4">@(has_beginning(<span class="st">&quot;The Quick Brown&quot;</span>, <span class="st">&quot;quick brown&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_date"></a></p>
 <h2 id="has_datetext">has_date(text)</h2>
 <p>Tests whether <code>text</code> contains a date formatted according to our environment</p>
-<div class="sourceCode" id="cb73"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb73-1" data-line-number="1">@(has_date(<span class="st">&quot;the date is 2017-01-15&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb73-2" data-line-number="2">@(has_date(<span class="st">&quot;the date is 2017-01-15&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb73-3" data-line-number="3">@(has_date(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb74"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb74-1" data-line-number="1">@(has_date(<span class="st">&quot;the date is 2017-01-15&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb74-2" data-line-number="2">@(has_date(<span class="st">&quot;the date is 2017-01-15&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb74-3" data-line-number="3">@(has_date(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_date_eq"></a></p>
 <h2 id="has_date_eqtext-date">has_date_eq(text, date)</h2>
 <p>Tests whether <code>text</code> a date equal to <code>date</code></p>
-<div class="sourceCode" id="cb74"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb74-1" data-line-number="1">@(has_date_eq(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-15&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb74-2" data-line-number="2">@(has_date_eq(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-15&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb74-3" data-line-number="3">@(has_date_eq(<span class="st">&quot;the date is 2017-01-15 15:00&quot;</span>, <span class="st">&quot;2017-01-15&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb74-4" data-line-number="4">@(has_date_eq(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb74-5" data-line-number="5">@(has_date_eq(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;not date&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb75"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb75-1" data-line-number="1">@(has_date_eq(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-15&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb75-2" data-line-number="2">@(has_date_eq(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-15&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb75-3" data-line-number="3">@(has_date_eq(<span class="st">&quot;the date is 2017-01-15 15:00&quot;</span>, <span class="st">&quot;2017-01-15&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb75-4" data-line-number="4">@(has_date_eq(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb75-5" data-line-number="5">@(has_date_eq(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;not date&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_date_gt"></a></p>
 <h2 id="has_date_gttext-min">has_date_gt(text, min)</h2>
 <p>Tests whether <code>text</code> a date after the date <code>min</code></p>
-<div class="sourceCode" id="cb75"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb75-1" data-line-number="1">@(has_date_gt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-01&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb75-2" data-line-number="2">@(has_date_gt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-01&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb75-3" data-line-number="3">@(has_date_gt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-03-15&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb75-4" data-line-number="4">@(has_date_gt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb75-5" data-line-number="5">@(has_date_gt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;not date&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb76"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb76-1" data-line-number="1">@(has_date_gt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-01&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb76-2" data-line-number="2">@(has_date_gt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-01-01&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb76-3" data-line-number="3">@(has_date_gt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-03-15&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb76-4" data-line-number="4">@(has_date_gt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb76-5" data-line-number="5">@(has_date_gt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;not date&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_date_lt"></a></p>
 <h2 id="has_date_lttext-max">has_date_lt(text, max)</h2>
 <p>Tests whether <code>text</code> contains a date before the date <code>max</code></p>
-<div class="sourceCode" id="cb76"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb76-1" data-line-number="1">@(has_date_lt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb76-2" data-line-number="2">@(has_date_lt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb76-3" data-line-number="3">@(has_date_lt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb76-4" data-line-number="4">@(has_date_lt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;not date&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb77"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb77-1" data-line-number="1">@(has_date_lt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb77-2" data-line-number="2">@(has_date_lt(<span class="st">&quot;the date is 2017-01-15&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>).match) → <span class="dv">2017-01</span>-15T13:<span class="dv">24</span>:<span class="fl">30.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb77-3" data-line-number="3">@(has_date_lt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;2017-06-01&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb77-4" data-line-number="4">@(has_date_lt(<span class="st">&quot;there is no date here, just a year 2017&quot;</span>, <span class="st">&quot;not date&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_district"></a></p>
 <h2 id="has_districttext-state">has_district(text, state)</h2>
 <p>Tests whether a district name is contained in the <code>text</code>. If <code>state</code> is also provided then the returned district must be within that state.</p>
-<div class="sourceCode" id="cb77"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb77-1" data-line-number="1">@(has_district(<span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb77-2" data-line-number="2">@(has_district(<span class="st">&quot;I live in Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb77-3" data-line-number="3">@(has_district(<span class="st">&quot;I live in Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo</a>
-<a class="sourceLine" id="cb77-4" data-line-number="4">@(has_district(<span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Boston&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb77-5" data-line-number="5">@(has_district(<span class="st">&quot;Gasabo&quot;</span>)) → true</a></code></pre></div>
+<div class="sourceCode" id="cb78"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb78-1" data-line-number="1">@(has_district(<span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb78-2" data-line-number="2">@(has_district(<span class="st">&quot;I live in Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb78-3" data-line-number="3">@(has_district(<span class="st">&quot;I live in Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo</a>
+<a class="sourceLine" id="cb78-4" data-line-number="4">@(has_district(<span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Boston&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb78-5" data-line-number="5">@(has_district(<span class="st">&quot;Gasabo&quot;</span>)) → true</a></code></pre></div>
 <p><a name="test:has_email"></a></p>
 <h2 id="has_emailtext">has_email(text)</h2>
 <p>Tests whether an email is contained in <code>text</code></p>
-<div class="sourceCode" id="cb78"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb78-1" data-line-number="1">@(has_email(<span class="st">&quot;my email is foo1@bar.com, please respond&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb78-2" data-line-number="2">@(has_email(<span class="st">&quot;my email is foo1@bar.com, please respond&quot;</span>).match) → foo1@bar.com</a>
-<a class="sourceLine" id="cb78-3" data-line-number="3">@(has_email(<span class="st">&quot;my email is &lt;foo@bar2.com&gt;&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb78-4" data-line-number="4">@(has_email(<span class="st">&quot;i&#39;m not sharing my email&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb79"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb79-1" data-line-number="1">@(has_email(<span class="st">&quot;my email is foo1@bar.com, please respond&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb79-2" data-line-number="2">@(has_email(<span class="st">&quot;my email is foo1@bar.com, please respond&quot;</span>).match) → foo1@bar.com</a>
+<a class="sourceLine" id="cb79-3" data-line-number="3">@(has_email(<span class="st">&quot;my email is &lt;foo@bar2.com&gt;&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb79-4" data-line-number="4">@(has_email(<span class="st">&quot;i&#39;m not sharing my email&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_group"></a></p>
 <h2 id="has_groupcontact-group_uuid">has_group(contact, group_uuid)</h2>
 <p>Returns whether the <code>contact</code> is part of group with the passed in UUID</p>
-<div class="sourceCode" id="cb79"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb79-1" data-line-number="1">@(has_group(contact, <span class="st">&quot;b7cf0d83-f1c9-411c-96fd-c511a4cfa86d&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb79-2" data-line-number="2">@(has_group(contact, <span class="st">&quot;b7cf0d83-f1c9-411c-96fd-c511a4cfa86d&quot;</span>).match) → Testers</a>
-<a class="sourceLine" id="cb79-3" data-line-number="3">@(has_group(contact, <span class="st">&quot;97fe7029-3a15-4005-b0c7-277b884fc1d5&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb80"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb80-1" data-line-number="1">@(has_group(contact, <span class="st">&quot;b7cf0d83-f1c9-411c-96fd-c511a4cfa86d&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb80-2" data-line-number="2">@(has_group(contact, <span class="st">&quot;b7cf0d83-f1c9-411c-96fd-c511a4cfa86d&quot;</span>).match) → Testers</a>
+<a class="sourceLine" id="cb80-3" data-line-number="3">@(has_group(contact, <span class="st">&quot;97fe7029-3a15-4005-b0c7-277b884fc1d5&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_number"></a></p>
 <h2 id="has_numbertext">has_number(text)</h2>
 <p>Tests whether <code>text</code> contains a number</p>
-<div class="sourceCode" id="cb80"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb80-1" data-line-number="1">@(has_number(<span class="st">&quot;the number is 42&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb80-2" data-line-number="2">@(has_number(<span class="st">&quot;the number is 42&quot;</span>).match) → <span class="dv">42</span></a>
-<a class="sourceLine" id="cb80-3" data-line-number="3">@(has_number(<span class="st">&quot;the number is forty two&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb81"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb81-1" data-line-number="1">@(has_number(<span class="st">&quot;the number is 42&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb81-2" data-line-number="2">@(has_number(<span class="st">&quot;the number is 42&quot;</span>).match) → <span class="dv">42</span></a>
+<a class="sourceLine" id="cb81-3" data-line-number="3">@(has_number(<span class="st">&quot;the number is forty two&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_number_between"></a></p>
 <h2 id="has_number_betweentext-min-max">has_number_between(text, min, max)</h2>
 <p>Tests whether <code>text</code> contains a number between <code>min</code> and <code>max</code> inclusive</p>
-<div class="sourceCode" id="cb81"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb81-1" data-line-number="1">@(has_number_between(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>, <span class="dv">44</span>)) → true</a>
-<a class="sourceLine" id="cb81-2" data-line-number="2">@(has_number_between(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>, <span class="dv">44</span>).match) → <span class="dv">42</span></a>
-<a class="sourceLine" id="cb81-3" data-line-number="3">@(has_number_between(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">50</span>, <span class="dv">60</span>)) → false</a>
-<a class="sourceLine" id="cb81-4" data-line-number="4">@(has_number_between(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">50</span>, <span class="dv">60</span>)) → false</a>
-<a class="sourceLine" id="cb81-5" data-line-number="5">@(has_number_between(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="dv">60</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb82"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb82-1" data-line-number="1">@(has_number_between(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>, <span class="dv">44</span>)) → true</a>
+<a class="sourceLine" id="cb82-2" data-line-number="2">@(has_number_between(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>, <span class="dv">44</span>).match) → <span class="dv">42</span></a>
+<a class="sourceLine" id="cb82-3" data-line-number="3">@(has_number_between(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">50</span>, <span class="dv">60</span>)) → false</a>
+<a class="sourceLine" id="cb82-4" data-line-number="4">@(has_number_between(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">50</span>, <span class="dv">60</span>)) → false</a>
+<a class="sourceLine" id="cb82-5" data-line-number="5">@(has_number_between(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="dv">60</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_number_eq"></a></p>
 <h2 id="has_number_eqtext-value">has_number_eq(text, value)</h2>
 <p>Tests whether <code>text</code> contains a number equal to the <code>value</code></p>
-<div class="sourceCode" id="cb82"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb82-1" data-line-number="1">@(has_number_eq(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → true</a>
-<a class="sourceLine" id="cb82-2" data-line-number="2">@(has_number_eq(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>).match) → <span class="dv">42</span></a>
-<a class="sourceLine" id="cb82-3" data-line-number="3">@(has_number_eq(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb82-4" data-line-number="4">@(has_number_eq(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb82-5" data-line-number="5">@(has_number_eq(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb83"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb83-1" data-line-number="1">@(has_number_eq(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → true</a>
+<a class="sourceLine" id="cb83-2" data-line-number="2">@(has_number_eq(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>).match) → <span class="dv">42</span></a>
+<a class="sourceLine" id="cb83-3" data-line-number="3">@(has_number_eq(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb83-4" data-line-number="4">@(has_number_eq(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb83-5" data-line-number="5">@(has_number_eq(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_number_gt"></a></p>
 <h2 id="has_number_gttext-min">has_number_gt(text, min)</h2>
 <p>Tests whether <code>text</code> contains a number greater than <code>min</code></p>
-<div class="sourceCode" id="cb83"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb83-1" data-line-number="1">@(has_number_gt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → true</a>
-<a class="sourceLine" id="cb83-2" data-line-number="2">@(has_number_gt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>).match) → <span class="dv">42</span></a>
-<a class="sourceLine" id="cb83-3" data-line-number="3">@(has_number_gt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → false</a>
-<a class="sourceLine" id="cb83-4" data-line-number="4">@(has_number_gt(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb83-5" data-line-number="5">@(has_number_gt(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb84"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb84-1" data-line-number="1">@(has_number_gt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → true</a>
+<a class="sourceLine" id="cb84-2" data-line-number="2">@(has_number_gt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>).match) → <span class="dv">42</span></a>
+<a class="sourceLine" id="cb84-3" data-line-number="3">@(has_number_gt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → false</a>
+<a class="sourceLine" id="cb84-4" data-line-number="4">@(has_number_gt(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb84-5" data-line-number="5">@(has_number_gt(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_number_gte"></a></p>
 <h2 id="has_number_gtetext-min">has_number_gte(text, min)</h2>
 <p>Tests whether <code>text</code> contains a number greater than or equal to <code>min</code></p>
-<div class="sourceCode" id="cb84"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb84-1" data-line-number="1">@(has_number_gte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → true</a>
-<a class="sourceLine" id="cb84-2" data-line-number="2">@(has_number_gte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>).match) → <span class="dv">42</span></a>
-<a class="sourceLine" id="cb84-3" data-line-number="3">@(has_number_gte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">45</span>)) → false</a>
-<a class="sourceLine" id="cb84-4" data-line-number="4">@(has_number_gte(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb84-5" data-line-number="5">@(has_number_gte(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb85"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb85-1" data-line-number="1">@(has_number_gte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → true</a>
+<a class="sourceLine" id="cb85-2" data-line-number="2">@(has_number_gte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>).match) → <span class="dv">42</span></a>
+<a class="sourceLine" id="cb85-3" data-line-number="3">@(has_number_gte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">45</span>)) → false</a>
+<a class="sourceLine" id="cb85-4" data-line-number="4">@(has_number_gte(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb85-5" data-line-number="5">@(has_number_gte(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_number_lt"></a></p>
 <h2 id="has_number_lttext-max">has_number_lt(text, max)</h2>
 <p>Tests whether <code>text</code> contains a number less than <code>max</code></p>
-<div class="sourceCode" id="cb85"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb85-1" data-line-number="1">@(has_number_lt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">44</span>)) → true</a>
-<a class="sourceLine" id="cb85-2" data-line-number="2">@(has_number_lt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">44</span>).match) → <span class="dv">42</span></a>
-<a class="sourceLine" id="cb85-3" data-line-number="3">@(has_number_lt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb85-4" data-line-number="4">@(has_number_lt(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb85-5" data-line-number="5">@(has_number_lt(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb86"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb86-1" data-line-number="1">@(has_number_lt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">44</span>)) → true</a>
+<a class="sourceLine" id="cb86-2" data-line-number="2">@(has_number_lt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">44</span>).match) → <span class="dv">42</span></a>
+<a class="sourceLine" id="cb86-3" data-line-number="3">@(has_number_lt(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb86-4" data-line-number="4">@(has_number_lt(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb86-5" data-line-number="5">@(has_number_lt(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_number_lte"></a></p>
 <h2 id="has_number_ltetext-max">has_number_lte(text, max)</h2>
 <p>Tests whether <code>text</code> contains a number less than or equal to <code>max</code></p>
-<div class="sourceCode" id="cb86"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb86-1" data-line-number="1">@(has_number_lte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → true</a>
-<a class="sourceLine" id="cb86-2" data-line-number="2">@(has_number_lte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">44</span>).match) → <span class="dv">42</span></a>
-<a class="sourceLine" id="cb86-3" data-line-number="3">@(has_number_lte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb86-4" data-line-number="4">@(has_number_lte(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
-<a class="sourceLine" id="cb86-5" data-line-number="5">@(has_number_lte(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb87"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb87-1" data-line-number="1">@(has_number_lte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">42</span>)) → true</a>
+<a class="sourceLine" id="cb87-2" data-line-number="2">@(has_number_lte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">44</span>).match) → <span class="dv">42</span></a>
+<a class="sourceLine" id="cb87-3" data-line-number="3">@(has_number_lte(<span class="st">&quot;the number is 42&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb87-4" data-line-number="4">@(has_number_lte(<span class="st">&quot;the number is not there&quot;</span>, <span class="dv">40</span>)) → false</a>
+<a class="sourceLine" id="cb87-5" data-line-number="5">@(has_number_lte(<span class="st">&quot;the number is not there&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="test:has_only_phrase"></a></p>
 <h2 id="has_only_phrasetext-phrase">has_only_phrase(text, phrase)</h2>
 <p>Tests whether the <code>text</code> contains only <code>phrase</code></p>
 <p>The phrase must be the only text in the text to match</p>
-<div class="sourceCode" id="cb87"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb87-1" data-line-number="1">@(has_only_phrase(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;quick brown&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb87-2" data-line-number="2">@(has_only_phrase(<span class="st">&quot;Quick Brown&quot;</span>, <span class="st">&quot;quick brown&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb87-3" data-line-number="3">@(has_only_phrase(<span class="st">&quot;the Quick Brown fox&quot;</span>, <span class="st">&quot;&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb87-4" data-line-number="4">@(has_only_phrase(<span class="st">&quot;&quot;</span>, <span class="st">&quot;&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb87-5" data-line-number="5">@(has_only_phrase(<span class="st">&quot;Quick Brown&quot;</span>, <span class="st">&quot;quick brown&quot;</span>).match) → Quick Brown</a>
-<a class="sourceLine" id="cb87-6" data-line-number="6">@(has_only_phrase(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb88"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb88-1" data-line-number="1">@(has_only_phrase(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;quick brown&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb88-2" data-line-number="2">@(has_only_phrase(<span class="st">&quot;Quick Brown&quot;</span>, <span class="st">&quot;quick brown&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb88-3" data-line-number="3">@(has_only_phrase(<span class="st">&quot;the Quick Brown fox&quot;</span>, <span class="st">&quot;&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb88-4" data-line-number="4">@(has_only_phrase(<span class="st">&quot;&quot;</span>, <span class="st">&quot;&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb88-5" data-line-number="5">@(has_only_phrase(<span class="st">&quot;Quick Brown&quot;</span>, <span class="st">&quot;quick brown&quot;</span>).match) → Quick Brown</a>
+<a class="sourceLine" id="cb88-6" data-line-number="6">@(has_only_phrase(<span class="st">&quot;The Quick Brown Fox&quot;</span>, <span class="st">&quot;red fox&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_pattern"></a></p>
 <h2 id="has_patterntext-pattern">has_pattern(text, pattern)</h2>
 <p>Tests whether <code>text</code> matches the regex <code>pattern</code></p>
 <p>Both text values are trimmed of surrounding whitespace and matching is case-insensitive.</p>
-<div class="sourceCode" id="cb88"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb88-1" data-line-number="1">@(has_pattern(<span class="st">&quot;Sell cheese please&quot;</span>, <span class="st">&quot;buy (\w+)&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb88-2" data-line-number="2">@(has_pattern(<span class="st">&quot;Buy cheese please&quot;</span>, <span class="st">&quot;buy (\w+)&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb88-3" data-line-number="3">@(has_pattern(<span class="st">&quot;Buy cheese please&quot;</span>, <span class="st">&quot;buy (\w+)&quot;</span>).match) → Buy cheese</a></code></pre></div>
+<div class="sourceCode" id="cb89"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb89-1" data-line-number="1">@(has_pattern(<span class="st">&quot;Sell cheese please&quot;</span>, <span class="st">&quot;buy (\w+)&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb89-2" data-line-number="2">@(has_pattern(<span class="st">&quot;Buy cheese please&quot;</span>, <span class="st">&quot;buy (\w+)&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb89-3" data-line-number="3">@(has_pattern(<span class="st">&quot;Buy cheese please&quot;</span>, <span class="st">&quot;buy (\w+)&quot;</span>).match) → Buy cheese</a></code></pre></div>
 <p><a name="test:has_phone"></a></p>
 <h2 id="has_phonetext-country_code">has_phone(text, country_code)</h2>
 <p>Tests whether a phone number (in the passed in <code>country_code</code>) is contained in the <code>text</code></p>
-<div class="sourceCode" id="cb89"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb89-1" data-line-number="1">@(has_phone(<span class="st">&quot;my number is 2067799294&quot;</span>, <span class="st">&quot;US&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb89-2" data-line-number="2">@(has_phone(<span class="st">&quot;my number is 206 779 9294&quot;</span>, <span class="st">&quot;US&quot;</span>).match) → +<span class="dv">12067799294</span></a>
-<a class="sourceLine" id="cb89-3" data-line-number="3">@(has_phone(<span class="st">&quot;my number is none of your business&quot;</span>, <span class="st">&quot;US&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb90"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb90-1" data-line-number="1">@(has_phone(<span class="st">&quot;my number is 2067799294&quot;</span>, <span class="st">&quot;US&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb90-2" data-line-number="2">@(has_phone(<span class="st">&quot;my number is 206 779 9294&quot;</span>, <span class="st">&quot;US&quot;</span>).match) → +<span class="dv">12067799294</span></a>
+<a class="sourceLine" id="cb90-3" data-line-number="3">@(has_phone(<span class="st">&quot;my number is none of your business&quot;</span>, <span class="st">&quot;US&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:has_phrase"></a></p>
 <h2 id="has_phrasetext-phrase">has_phrase(text, phrase)</h2>
 <p>Tests whether <code>phrase</code> is contained in <code>text</code></p>
 <p>The words in the test phrase must appear in the same order with no other words in between.</p>
-<div class="sourceCode" id="cb90"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb90-1" data-line-number="1">@(has_phrase(<span class="st">&quot;the quick brown fox&quot;</span>, <span class="st">&quot;brown fox&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb90-2" data-line-number="2">@(has_phrase(<span class="st">&quot;the Quick Brown fox&quot;</span>, <span class="st">&quot;quick fox&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb90-3" data-line-number="3">@(has_phrase(<span class="st">&quot;the Quick Brown fox&quot;</span>, <span class="st">&quot;&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb90-4" data-line-number="4">@(has_phrase(<span class="st">&quot;the.quick.brown.fox&quot;</span>, <span class="st">&quot;the quick&quot;</span>).match) → the quick</a></code></pre></div>
+<div class="sourceCode" id="cb91"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb91-1" data-line-number="1">@(has_phrase(<span class="st">&quot;the quick brown fox&quot;</span>, <span class="st">&quot;brown fox&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb91-2" data-line-number="2">@(has_phrase(<span class="st">&quot;the Quick Brown fox&quot;</span>, <span class="st">&quot;quick fox&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb91-3" data-line-number="3">@(has_phrase(<span class="st">&quot;the Quick Brown fox&quot;</span>, <span class="st">&quot;&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb91-4" data-line-number="4">@(has_phrase(<span class="st">&quot;the.quick.brown.fox&quot;</span>, <span class="st">&quot;the quick&quot;</span>).match) → the quick</a></code></pre></div>
 <p><a name="test:has_state"></a></p>
 <h2 id="has_statetext">has_state(text)</h2>
 <p>Tests whether a state name is contained in the <code>text</code></p>
-<div class="sourceCode" id="cb91"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb91-1" data-line-number="1">@(has_state(<span class="st">&quot;Kigali&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb91-2" data-line-number="2">@(has_state(<span class="st">&quot;Boston&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb91-3" data-line-number="3">@(has_state(<span class="st">&quot;¡Kigali!&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb91-4" data-line-number="4">@(has_state(<span class="st">&quot;¡Kigali!&quot;</span>).match) → Rwanda &gt; Kigali City</a>
-<a class="sourceLine" id="cb91-5" data-line-number="5">@(has_state(<span class="st">&quot;I live in Kigali&quot;</span>)) → true</a></code></pre></div>
+<div class="sourceCode" id="cb92"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb92-1" data-line-number="1">@(has_state(<span class="st">&quot;Kigali&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb92-2" data-line-number="2">@(has_state(<span class="st">&quot;Boston&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb92-3" data-line-number="3">@(has_state(<span class="st">&quot;¡Kigali!&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb92-4" data-line-number="4">@(has_state(<span class="st">&quot;¡Kigali!&quot;</span>).match) → Rwanda &gt; Kigali City</a>
+<a class="sourceLine" id="cb92-5" data-line-number="5">@(has_state(<span class="st">&quot;I live in Kigali&quot;</span>)) → true</a></code></pre></div>
 <p><a name="test:has_text"></a></p>
 <h2 id="has_texttext">has_text(text)</h2>
 <p>Tests whether there the text has any characters in it</p>
-<div class="sourceCode" id="cb92"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb92-1" data-line-number="1">@(has_text(<span class="st">&quot;quick brown&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb92-2" data-line-number="2">@(has_text(<span class="st">&quot;quick brown&quot;</span>).match) → quick brown</a>
-<a class="sourceLine" id="cb92-3" data-line-number="3">@(has_text(<span class="st">&quot;&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb92-4" data-line-number="4">@(has_text(<span class="st">&quot; </span><span class="sc">\n</span><span class="st">&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb92-5" data-line-number="5">@(has_text(<span class="dv">123</span>)) → true</a></code></pre></div>
+<div class="sourceCode" id="cb93"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb93-1" data-line-number="1">@(has_text(<span class="st">&quot;quick brown&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb93-2" data-line-number="2">@(has_text(<span class="st">&quot;quick brown&quot;</span>).match) → quick brown</a>
+<a class="sourceLine" id="cb93-3" data-line-number="3">@(has_text(<span class="st">&quot;&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb93-4" data-line-number="4">@(has_text(<span class="st">&quot; </span><span class="sc">\n</span><span class="st">&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb93-5" data-line-number="5">@(has_text(<span class="dv">123</span>)) → true</a></code></pre></div>
 <p><a name="test:has_value"></a></p>
 <h2 id="has_valuevalue">has_value(value)</h2>
 <p>Returns whether <code>value</code> is non-nil and not an error</p>
 <p>Note that <code>contact.fields</code> and <code>run.results</code> are considered dynamic, so it is not an error to try to retrieve a value from fields or results which don’t exist, rather these return an empty value.</p>
-<div class="sourceCode" id="cb93"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb93-1" data-line-number="1">@(has_value(datetime(<span class="st">&quot;foo&quot;</span>))) → false</a>
-<a class="sourceLine" id="cb93-2" data-line-number="2">@(has_value(not.existing)) → false</a>
-<a class="sourceLine" id="cb93-3" data-line-number="3">@(has_value(contact.fields.unset)) → false</a>
-<a class="sourceLine" id="cb93-4" data-line-number="4">@(has_value(<span class="st">&quot;&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb93-5" data-line-number="5">@(has_value(<span class="st">&quot;hello&quot;</span>)) → true</a></code></pre></div>
+<div class="sourceCode" id="cb94"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb94-1" data-line-number="1">@(has_value(datetime(<span class="st">&quot;foo&quot;</span>))) → false</a>
+<a class="sourceLine" id="cb94-2" data-line-number="2">@(has_value(not.existing)) → false</a>
+<a class="sourceLine" id="cb94-3" data-line-number="3">@(has_value(contact.fields.unset)) → false</a>
+<a class="sourceLine" id="cb94-4" data-line-number="4">@(has_value(<span class="st">&quot;&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb94-5" data-line-number="5">@(has_value(<span class="st">&quot;hello&quot;</span>)) → true</a></code></pre></div>
 <p><a name="test:has_wait_timed_out"></a></p>
 <h2 id="has_wait_timed_outrun">has_wait_timed_out(run)</h2>
 <p>Returns whether the last wait timed out.</p>
-<div class="sourceCode" id="cb94"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb94-1" data-line-number="1">@(has_wait_timed_out(run)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb95"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb95-1" data-line-number="1">@(has_wait_timed_out(run)) → false</a></code></pre></div>
 <p><a name="test:has_ward"></a></p>
 <h2 id="has_wardtext-district-state">has_ward(text, district, state)</h2>
 <p>Tests whether a ward name is contained in the <code>text</code></p>
-<div class="sourceCode" id="cb95"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb95-1" data-line-number="1">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb95-2" data-line-number="2">@(has_ward(<span class="st">&quot;I live in Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb95-3" data-line-number="3">@(has_ward(<span class="st">&quot;I live in Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</a>
-<a class="sourceLine" id="cb95-4" data-line-number="4">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb95-5" data-line-number="5">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb95-6" data-line-number="6">@(has_ward(<span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb95-7" data-line-number="7">@(has_ward(<span class="st">&quot;Gasabo&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb95-8" data-line-number="8">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>)) → true</a></code></pre></div>
+<div class="sourceCode" id="cb96"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb96-1" data-line-number="1">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb96-2" data-line-number="2">@(has_ward(<span class="st">&quot;I live in Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb96-3" data-line-number="3">@(has_ward(<span class="st">&quot;I live in Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</a>
+<a class="sourceLine" id="cb96-4" data-line-number="4">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb96-5" data-line-number="5">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb96-6" data-line-number="6">@(has_ward(<span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb96-7" data-line-number="7">@(has_ward(<span class="st">&quot;Gasabo&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb96-8" data-line-number="8">@(has_ward(<span class="st">&quot;Gisozi&quot;</span>)) → true</a></code></pre></div>
 <p><a name="test:is_error"></a></p>
 <h2 id="is_errorvalue">is_error(value)</h2>
 <p>Returns whether <code>value</code> is an error</p>
 <p>Note that <code>contact.fields</code> and <code>run.results</code> are considered dynamic, so it is not an error to try to retrieve a value from fields or results which don’t exist, rather these return an empty value.</p>
-<div class="sourceCode" id="cb96"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb96-1" data-line-number="1">@(is_error(datetime(<span class="st">&quot;foo&quot;</span>))) → true</a>
-<a class="sourceLine" id="cb96-2" data-line-number="2">@(is_error(run.not.existing)) → true</a>
-<a class="sourceLine" id="cb96-3" data-line-number="3">@(is_error(contact.fields.unset)) → true</a>
-<a class="sourceLine" id="cb96-4" data-line-number="4">@(is_error(<span class="st">&quot;hello&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb97"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb97-1" data-line-number="1">@(is_error(datetime(<span class="st">&quot;foo&quot;</span>))) → true</a>
+<a class="sourceLine" id="cb97-2" data-line-number="2">@(is_error(run.not.existing)) → true</a>
+<a class="sourceLine" id="cb97-3" data-line-number="3">@(is_error(contact.fields.unset)) → true</a>
+<a class="sourceLine" id="cb97-4" data-line-number="4">@(is_error(<span class="st">&quot;hello&quot;</span>)) → false</a></code></pre></div>
 <p><a name="test:is_text_eq"></a></p>
 <h2 id="is_text_eqtext1-text2">is_text_eq(text1, text2)</h2>
 <p>Returns whether two text values are equal (case sensitive). In the case that they are, it will return the text as the match.</p>
-<div class="sourceCode" id="cb97"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb97-1" data-line-number="1">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb97-2" data-line-number="2">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot;FOO&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb97-3" data-line-number="3">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot;bar&quot;</span>)) → false</a>
-<a class="sourceLine" id="cb97-4" data-line-number="4">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot; foo &quot;</span>)) → false</a>
-<a class="sourceLine" id="cb97-5" data-line-number="5">@(is_text_eq(run.status, <span class="st">&quot;completed&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb97-6" data-line-number="6">@(is_text_eq(results.webhook.category, <span class="st">&quot;Success&quot;</span>)) → true</a>
-<a class="sourceLine" id="cb97-7" data-line-number="7">@(is_text_eq(results.webhook.category, <span class="st">&quot;Failure&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb98"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb98-1" data-line-number="1">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot;foo&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb98-2" data-line-number="2">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot;FOO&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb98-3" data-line-number="3">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot;bar&quot;</span>)) → false</a>
+<a class="sourceLine" id="cb98-4" data-line-number="4">@(is_text_eq(<span class="st">&quot;foo&quot;</span>, <span class="st">&quot; foo &quot;</span>)) → false</a>
+<a class="sourceLine" id="cb98-5" data-line-number="5">@(is_text_eq(run.status, <span class="st">&quot;completed&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb98-6" data-line-number="6">@(is_text_eq(results.webhook.category, <span class="st">&quot;Success&quot;</span>)) → true</a>
+<a class="sourceLine" id="cb98-7" data-line-number="7">@(is_text_eq(results.webhook.category, <span class="st">&quot;Failure&quot;</span>)) → false</a></code></pre></div>
 </div>
 
     </body>

--- a/docs/md/expressions.md
+++ b/docs/md/expressions.md
@@ -923,6 +923,23 @@ splitting in 3s or 4s if appropriate.
 @(read_chars("abcdef")) → a b c , d e f
 ```
 
+<a name="function:regex_match"></a>
+
+## regex_match(text, pattern [,group])
+
+Returns the first match of the regular expression `pattern` in `text`.
+
+An optional third parameter `group` determines which matching group will be returned.
+
+
+```objectivec
+@(regex_match("sda34dfddg67", "\d+")) → 34
+@(regex_match("Bob Smith", "(\w+) (\w+)", 1)) → Bob
+@(regex_match("Bob Smith", "(\w+) (\w+)", 2)) → Smith
+@(regex_match("Bob Smith", "(\w+) (\w+)", 5)) → ERROR
+@(regex_match("abc", "[\.")) → ERROR
+```
+
 <a name="function:remove_first_word"></a>
 
 ## remove_first_word(text)

--- a/excellent/functions/functions_test.go
+++ b/excellent/functions/functions_test.go
@@ -320,6 +320,10 @@ var funcTests = []struct {
 	{"read_chars", []types.XValue{xs("12")}, xs("1 , 2")},
 	{"read_chars", []types.XValue{}, ERROR},
 
+	{"regex_match", []types.XValue{xs("zAbc"), xs(`a\w`)}, xs(`Ab`)},
+	{"regex_match", []types.XValue{xs("<html>"), xs(`<(\w+)>`), xn("1")}, xs(`html`)},
+	{"regex_match", []types.XValue{xs("<html>"), xs(`<(\w+)>`), xn("2")}, ERROR},
+
 	{"remove_first_word", []types.XValue{xs("hello World")}, xs("World")},
 	{"remove_first_word", []types.XValue{xs("hello")}, xs("")},
 	{"remove_first_word", []types.XValue{xs("😁hello")}, xs("hello")},

--- a/flows/routers/tests/tests.go
+++ b/flows/routers/tests/tests.go
@@ -322,7 +322,7 @@ func HasBeginning(env utils.Environment, text types.XText, beginning types.XText
 //
 // @test has_pattern(text, pattern)
 func HasPattern(env utils.Environment, text types.XText, pattern types.XText) types.XValue {
-	regex, err := regexp.Compile("(?i)" + strings.TrimSpace(pattern.Native()))
+	regex, err := regexp.Compile("(?mi)" + strings.TrimSpace(pattern.Native()))
 	if err != nil {
 		return types.NewXErrorf("must be called with a valid regular expression")
 	}

--- a/flows/routers/tests/tests_test.go
+++ b/flows/routers/tests/tests_test.go
@@ -106,6 +106,9 @@ var testTests = []struct {
 	{"has_beginning", []types.XValue{xs("but this world"), xs("this world")}, false, nil, false},
 	{"has_beginning", []types.XValue{xs("one"), xs("two"), xs("three")}, false, nil, true},
 
+	{"has_pattern", []types.XValue{xs("<html>x</html>"), xs(`<\w+>`)}, true, xs("<html>"), false},
+	{"has_pattern", []types.XValue{xs("<html>x</html>"), xs(`[`)}, false, nil, true},
+
 	{"has_number", []types.XValue{xs("the number 10")}, true, xn("10"), false},
 	{"has_number", []types.XValue{xs("24ans")}, true, xn("24"), false},
 	{"has_number", []types.XValue{xs("J'AI 20ANS")}, true, xn("20"), false},

--- a/legacy/expressions/functions.go
+++ b/legacy/expressions/functions.go
@@ -137,7 +137,7 @@ var callMigrators = map[string]callMigrator{
 	"rand":              asIs(),
 	"randbetween":       asRename(`rand_between`),
 	"read_digits":       asRename(`read_chars`),
-	"regex_group":       asIs(),
+	"regex_group":       asRename(`regex_match`),
 	"remove_first_word": asIs(),
 	"rept":              asRename(`repeat`),
 	"right":             asIs(),

--- a/legacy/expressions/migrate.go
+++ b/legacy/expressions/migrate.go
@@ -260,3 +260,14 @@ func convertTimeToSeconds(operand string) (string, bool) {
 	}
 	return operand, converted
 }
+
+func MigrateStringLiteral(s string) string {
+	// strip surrounding quotes
+	s = s[1 : len(s)-1]
+
+	// replace any escaped quotes
+	s = strings.Replace(s, `""`, `\"`, -1)
+
+	// re-quote
+	return `"` + s + `"`
+}

--- a/legacy/expressions/migrate_test.go
+++ b/legacy/expressions/migrate_test.go
@@ -127,8 +127,9 @@ func TestMigrateTemplate(t *testing.T) {
 		{old: `@("you" & " are " & contact.gender)`, new: `@("you" & " are " & contact.fields.gender)`},
 
 		// functions
-		{old: `@(EPOCH(NOW()))`, new: `@(epoch(now()))`},
 		{old: `@(REMOVE_FIRST_WORD(flow.favorite_color))`, new: `@(remove_first_word(results.favorite_color))`},
+		{old: `@(REGEX_GROUP(flow.favorite_color, "\w\w+"))`, new: `@(regex_match(results.favorite_color, "\w\w+"))`},
+		{old: `@(REGEX_GROUP(flow.favorite_color, "\w(\w+)", 1))`, new: `@(regex_match(results.favorite_color, "\w(\w+)", 1))`},
 		{old: `@(WORD_SLICE(flow.favorite_color, 2))`, new: `@(word_slice(results.favorite_color, 1))`},
 		{old: `@(WORD_SLICE(flow.favorite_color, 2, 4))`, new: `@(word_slice(results.favorite_color, 1, 3))`},
 		{old: `@(WORD_SLICE(flow.favorite_color, 2, 4, TRUE))`, new: `@(word_slice(results.favorite_color, 1, 3, " \t"))`},
@@ -144,11 +145,16 @@ func TestMigrateTemplate(t *testing.T) {
 		{old: `@(WORD_COUNT(flow.favorite_color))`, new: `@(word_count(results.favorite_color))`},
 		{old: `@(WORD_COUNT(flow.favorite_color, TRUE))`, new: `@(word_count(results.favorite_color, " \t"))`},
 		{old: `@(WORD_COUNT(flow.favorite_color, FALSE))`, new: `@(word_count(results.favorite_color, NULL))`},
+
+		// math and logic functions
 		{old: `@(ABS(-5))`, new: `@(abs(-5))`},
 		{old: `@(AVERAGE(1, 2, 3, 4, 5))`, new: `@(mean(1, 2, 3, 4, 5))`},
 		{old: `@(AND(contact.age > 30, flow.amount < 5))`, new: `@(and(contact.fields.age > 30, results.amount < 5))`},
+
+		// date functions
 		{old: `@(DATEVALUE("2012-02-03"))`, new: `@(datetime("2012-02-03"))`},
 		{old: `@(EDATE("2012-02-03", 1))`, new: `@(datetime_add("2012-02-03", 1, "M"))`},
+		{old: `@(EPOCH(NOW()))`, new: `@(epoch(now()))`},
 		{old: `@(DATEDIF(contact.join_date, date.now, "M"))`, new: `@(datetime_diff(contact.fields.join_date, now(), "M"))`},
 		{old: `@(DAYS("2016-02-28", "2015-02-28"))`, new: `@(datetime_diff("2016-02-28", "2015-02-28", "D"))`},
 		{old: `@(DAY(contact.join_date))`, new: `@(format_date(contact.fields.join_date, "D"))`},
@@ -416,4 +422,12 @@ func TestLegacyTests(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestMigrateStringLiteral(t *testing.T) {
+	assert.Equal(t, `""`, expressions.MigrateStringLiteral(`""`))
+	assert.Equal(t, `"abc"`, expressions.MigrateStringLiteral(`"abc"`))
+	assert.Equal(t, `"\"hello\""`, expressions.MigrateStringLiteral(`"""hello"""`))
+	assert.Equal(t, `"line1\nline2\ttabbed"`, expressions.MigrateStringLiteral(`"line1\nline2\ttabbed"`))
+	assert.Equal(t, `"\D\w+[\.*]"`, expressions.MigrateStringLiteral(`"\D\w+[\.*]"`))
 }

--- a/legacy/expressions/visitor.go
+++ b/legacy/expressions/visitor.go
@@ -53,15 +53,7 @@ func (v *legacyVisitor) VisitDotLookup(ctx *gen.DotLookupContext) interface{} {
 
 // VisitStringLiteral deals with string literals such as "asdf"
 func (v *legacyVisitor) VisitStringLiteral(ctx *gen.StringLiteralContext) interface{} {
-	// strip surrounding quotes
-	value := ctx.GetText()
-	unquoted := value[1 : len(value)-1]
-
-	// replace any escaped quotes
-	unquoted = strings.Replace(unquoted, `""`, `"`, -1)
-
-	// re-escape
-	return strconv.Quote(unquoted)
+	return MigrateStringLiteral(ctx.GetText())
 }
 
 // VisitFunctionCall deals with function calls like TITLE(foo.bar)

--- a/legacy/testdata/tests.json
+++ b/legacy/testdata/tests.json
@@ -347,7 +347,7 @@
         "legacy_test": {
             "type": "regex",
             "test": {
-                "eng": "[Yy]eah?",
+                "eng": "[Yy]eah? \\w",
                 "fra": "[Oo]ui"
             }
         },
@@ -355,7 +355,7 @@
             "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
             "type": "has_pattern",
             "arguments": [
-                "[Yy]eah?"
+                "[Yy]eah? \\w"
             ],
             "exit_uuid": "c072ecb5-0686-40ea-8ed3-898dc1349783"
         },


### PR DESCRIPTION
 * Add missing `regex_match` func and migrate to that from `regex_group` calls in legacy flows
 * Fix migration of string literals in legacy flows so regular expressions aren't escaped

Fixes #370 