### PR TITLE
🔢 Number formats

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	// create our environment
 	la, _ := time.LoadLocation("America/Los_Angeles")
-	env := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, la, utils.NilLanguage, nil, utils.RedactionPolicyNone)
+	env := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, la, utils.NilLanguage, nil, utils.DefaultNumberFormat, utils.RedactionPolicyNone)
 
 	assets, err := engine.NewSessionAssets(rest.NewMockServerSource(assetCache))
 	if err != nil {

--- a/docs/expressions.html
+++ b/docs/expressions.html
@@ -374,9 +374,9 @@
 <div class="sourceCode" id="cb27"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb27-1" data-line-number="1">@(format_location(<span class="st">&quot;Rwanda&quot;</span>)) → Rwanda</a>
 <a class="sourceLine" id="cb27-2" data-line-number="2">@(format_location(<span class="st">&quot;Rwanda &gt; Kigali&quot;</span>)) → Kigali</a></code></pre></div>
 <p><a name="function:format_number"></a></p>
-<h2 id="format_numbernumber-places-commas">format_number(number, places [, commas])</h2>
+<h2 id="format_numbernumber-places-humanize">format_number(number, places [, humanize])</h2>
 <p>Formats <code>number</code> to the given number of decimal <code>places</code>.</p>
-<p>An optional third argument <code>commas</code> can be false to disable the use of commas as thousand separators.</p>
+<p>An optional third argument <code>humanize</code> can be false to disable the use of thousand separators.</p>
 <div class="sourceCode" id="cb28"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb28-1" data-line-number="1">@(format_number(<span class="dv">31337</span>)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
 <a class="sourceLine" id="cb28-2" data-line-number="2">@(format_number(<span class="dv">31337</span>, <span class="dv">2</span>)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
 <a class="sourceLine" id="cb28-3" data-line-number="3">@(format_number(<span class="dv">31337</span>, <span class="dv">2</span>, true)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>

--- a/docs/functions.json
+++ b/docs/functions.json
@@ -383,9 +383,9 @@
         ]
     },
     {
-        "signature": "format_number(number, places [, commas])",
+        "signature": "format_number(number, places [, humanize])",
         "summary": "Formats `number` to the given number of decimal `places`.",
-        "detail": "An optional third argument `commas` can be false to disable the use of commas as thousand separators.",
+        "detail": "An optional third argument `humanize` can be false to disable the use of thousand separators.",
         "examples": [
             {
                 "template": "@(format_number(31337))",

--- a/docs/md/expressions.md
+++ b/docs/md/expressions.md
@@ -588,11 +588,11 @@ Formats the given `location` as its name.
 
 <a name="function:format_number"></a>
 
-## format_number(number, places [, commas])
+## format_number(number, places [, humanize])
 
 Formats `number` to the given number of decimal `places`.
 
-An optional third argument `commas` can be false to disable the use of commas as thousand separators.
+An optional third argument `humanize` can be false to disable the use of thousand separators.
 
 
 ```objectivec

--- a/excellent/functions/functions_test.go
+++ b/excellent/functions/functions_test.go
@@ -468,7 +468,7 @@ var funcTests = []struct {
 }
 
 func TestFunctions(t *testing.T) {
-	env := utils.NewEnvironment(utils.DateFormatDayMonthYear, utils.TimeFormatHourMinute, time.UTC, utils.NilLanguage, nil, utils.RedactionPolicyNone)
+	env := utils.NewEnvironment(utils.DateFormatDayMonthYear, utils.TimeFormatHourMinute, time.UTC, utils.NilLanguage, nil, utils.DefaultNumberFormat, utils.RedactionPolicyNone)
 
 	defer utils.SetRand(utils.DefaultRand)
 	defer utils.SetTimeSource(utils.DefaultTimeSource)

--- a/excellent/functions/functions_test.go
+++ b/excellent/functions/functions_test.go
@@ -1,7 +1,6 @@
 package functions_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"math"
 	"testing"
 	"time"
@@ -10,7 +9,9 @@ import (
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
 
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var errorArg = types.NewXErrorf("I am error")
@@ -496,5 +497,27 @@ func TestFunctions(t *testing.T) {
 				assert.Fail(t, "", "unexpected value, expected %T{%s}, got %T{%s} for function %s(%T{%s})", test.expected, test.expected, result, result, test.name, test.args, test.args)
 			}
 		}
+	}
+}
+
+func TestFormatDecimal(t *testing.T) {
+	fmtTests := []struct {
+		input       decimal.Decimal
+		format      *utils.NumberFormat
+		places      int
+		groupDigits bool
+		expected    string
+	}{
+		{decimal.RequireFromString("1234"), utils.DefaultNumberFormat, 2, true, "1,234.00"},
+		{decimal.RequireFromString("1234"), utils.DefaultNumberFormat, 0, false, "1234"},
+		{decimal.RequireFromString("1234.567"), utils.DefaultNumberFormat, 2, true, "1,234.57"},
+		{decimal.RequireFromString("1234.567"), utils.DefaultNumberFormat, 2, false, "1234.57"},
+		{decimal.RequireFromString("1234.567"), &utils.NumberFormat{DecimalSymbol: ",", DigitGroupingSymbol: "."}, 2, true, "1.234,57"},
+	}
+
+	for _, test := range fmtTests {
+		val := functions.FormatDecimal(test.input, test.format, test.places, test.groupDigits)
+
+		assert.Equal(t, test.expected, val, "format decimal failed for input '%s'", test.input)
 	}
 }

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -71,7 +71,7 @@ func TestContact(t *testing.T) {
 }
 
 func TestContactFormat(t *testing.T) {
-	env := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, time.UTC, utils.NilLanguage, nil, utils.RedactionPolicyNone)
+	env := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, time.UTC, utils.NilLanguage, nil, utils.DefaultNumberFormat, utils.RedactionPolicyNone)
 
 	// name takes precedence if set
 	contact := flows.NewEmptyContact("Joe", utils.NilLanguage, nil)
@@ -86,7 +86,7 @@ func TestContactFormat(t *testing.T) {
 	contact.AddURN(urns.URN("twitter:joey"))
 	assert.Equal(t, "joey", contact.Format(env))
 
-	anonEnv := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, time.UTC, utils.NilLanguage, nil, utils.RedactionPolicyURNs)
+	anonEnv := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, time.UTC, utils.NilLanguage, nil, utils.DefaultNumberFormat, utils.RedactionPolicyURNs)
 
 	// unless URNs are redacted
 	assert.Equal(t, "1234", contact.Format(anonEnv))

--- a/flows/routers/tests/tests.go
+++ b/flows/routers/tests/tests.go
@@ -375,7 +375,7 @@ func HasNumberBetween(env utils.Environment, arg1 types.XValue, arg2 types.XValu
 
 	// for each of our values, try to evaluate to a decimal
 	for _, value := range strings.Fields(str.Native()) {
-		parsed, err := ParseDecimalFuzzy(env, value)
+		parsed, err := ParseDecimalFuzzy(value, env.NumberFormat())
 		if err == nil {
 			num := types.NewXNumber(parsed)
 			if num.Compare(min) >= 0 && num.Compare(max) <= 0 {
@@ -812,17 +812,17 @@ func hasOnlyPhraseTest(origHays []string, hays []string, pins []string) XTestRes
 
 var parseableNumberRegex = regexp.MustCompile(`^[$£€]?([\d,][\d,\.]*([\.,]\d+)?)\D*$`)
 
-func ParseDecimalFuzzy(env utils.Environment, val string) (decimal.Decimal, error) {
+func ParseDecimalFuzzy(val string, format *utils.NumberFormat) (decimal.Decimal, error) {
 	// common SMS foibles
 	cleaned := strings.Replace(val, "l", "1", -1)
 	cleaned = strings.Replace(cleaned, "O", "0", -1)
 	cleaned = strings.Replace(cleaned, "o", "0", -1)
 
 	// remove digit grouping symbol
-	cleaned = strings.Replace(cleaned, env.NumberFormat().DigitGroupingSymbol, "", -1)
+	cleaned = strings.Replace(cleaned, format.DigitGroupingSymbol, "", -1)
 
 	// replace non-period decimal symbols
-	cleaned = strings.Replace(cleaned, env.NumberFormat().DecimalSymbol, ".", -1)
+	cleaned = strings.Replace(cleaned, format.DecimalSymbol, ".", -1)
 
 	num, err := decimal.NewFromString(cleaned)
 	if err == nil {
@@ -845,7 +845,7 @@ type decimalTest func(value decimal.Decimal, test decimal.Decimal) bool
 func testNumber(env utils.Environment, str types.XText, testNum types.XNumber, testFunc decimalTest) types.XValue {
 	// for each of our values, try to evaluate to a decimal
 	for _, value := range strings.Fields(str.Native()) {
-		num, xerr := ParseDecimalFuzzy(env, value)
+		num, xerr := ParseDecimalFuzzy(value, env.NumberFormat())
 		if xerr == nil {
 			if testFunc(num, testNum.Native()) {
 				return NewTrueResult(types.NewXNumber(num))

--- a/flows/routers/tests/tests_test.go
+++ b/flows/routers/tests/tests_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/goflow/flows/routers/tests"
 	"github.com/nyaruka/goflow/utils"
 
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -207,7 +208,7 @@ func TestTests(t *testing.T) {
 	utils.SetTimeSource(utils.NewFixedTimeSource(time.Date(2018, 4, 11, 13, 24, 30, 123456000, time.UTC)))
 	defer utils.SetTimeSource(utils.DefaultTimeSource)
 
-	env := utils.NewEnvironment(utils.DateFormatDayMonthYear, utils.TimeFormatHourMinuteSecond, time.UTC, utils.NilLanguage, nil, utils.RedactionPolicyNone)
+	env := utils.NewEnvironment(utils.DateFormatDayMonthYear, utils.TimeFormatHourMinuteSecond, time.UTC, utils.NilLanguage, nil, utils.DefaultNumberFormat, utils.RedactionPolicyNone)
 
 	for _, test := range testTests {
 		testFunc := tests.XTESTS[test.name]
@@ -269,4 +270,33 @@ func TestEvaluateTemplateAsString(t *testing.T) {
 			assert.Equal(t, test.expected, eval, "actual '%s' does not match expected '%s' evaluating template: '%s'", eval, test.expected, test.template)
 		}
 	}
+}
+
+func TestParseDecimalFuzzy(t *testing.T) {
+	parseTests := []struct {
+		input    string
+		expected decimal.Decimal
+		format   *utils.NumberFormat
+	}{
+		{"1234", decimal.RequireFromString("1234"), utils.DefaultNumberFormat},
+		{"1,234.567", decimal.RequireFromString("1234.567"), utils.DefaultNumberFormat},
+		{"1.234,567", decimal.RequireFromString("1234.567"), &utils.NumberFormat{DecimalSymbol: ",", DigitGroupingSymbol: "."}},
+		{"lOO", decimal.RequireFromString("100"), utils.DefaultNumberFormat},
+		{"$100", decimal.RequireFromString("100"), utils.DefaultNumberFormat},
+		{"£100.00", decimal.RequireFromString("100.00"), utils.DefaultNumberFormat},
+		{"100ans", decimal.RequireFromString("100"), utils.DefaultNumberFormat},
+		{"100C", decimal.RequireFromString("100"), utils.DefaultNumberFormat},
+	}
+
+	for _, test := range parseTests {
+		env := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, nil, utils.NilLanguage, nil, test.format, utils.RedactionPolicyNone)
+		val, err := tests.ParseDecimalFuzzy(env, test.input)
+
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, val, "parse decimal failed for input '%s'", test.input)
+	}
+
+	// don't allow both prefixes/suffixes and substitutions
+	_, err := tests.ParseDecimalFuzzy(utils.NewDefaultEnvironment(), "lOOans")
+	assert.Error(t, err)
 }

--- a/flows/routers/tests/tests_test.go
+++ b/flows/routers/tests/tests_test.go
@@ -289,14 +289,13 @@ func TestParseDecimalFuzzy(t *testing.T) {
 	}
 
 	for _, test := range parseTests {
-		env := utils.NewEnvironment(utils.DateFormatYearMonthDay, utils.TimeFormatHourMinute, nil, utils.NilLanguage, nil, test.format, utils.RedactionPolicyNone)
-		val, err := tests.ParseDecimalFuzzy(env, test.input)
+		val, err := tests.ParseDecimalFuzzy(test.input, test.format)
 
 		assert.NoError(t, err)
 		assert.Equal(t, test.expected, val, "parse decimal failed for input '%s'", test.input)
 	}
 
 	// don't allow both prefixes/suffixes and substitutions
-	_, err := tests.ParseDecimalFuzzy(utils.NewDefaultEnvironment(), "lOOans")
+	_, err := tests.ParseDecimalFuzzy("lOOans", utils.DefaultNumberFormat)
 	assert.Error(t, err)
 }

--- a/legacy/expressions/migrate_test.go
+++ b/legacy/expressions/migrate_test.go
@@ -403,7 +403,7 @@ func TestLegacyTests(t *testing.T) {
 			tz, err := time.LoadLocation(tc.Context.Timezone)
 			require.NoError(t, err)
 
-			env := utils.NewEnvironment(utils.DateFormatDayMonthYear, utils.TimeFormatHourMinute, tz, utils.NilLanguage, nil, utils.RedactionPolicyNone)
+			env := utils.NewEnvironment(utils.DateFormatDayMonthYear, utils.TimeFormatHourMinute, tz, utils.NilLanguage, nil, utils.DefaultNumberFormat, utils.RedactionPolicyNone)
 			if tc.Context.Now != nil {
 				utils.SetTimeSource(utils.NewFixedTimeSource(*tc.Context.Now))
 				defer utils.SetTimeSource(utils.DefaultTimeSource)

--- a/utils/dates_test.go
+++ b/utils/dates_test.go
@@ -85,7 +85,7 @@ func TestDateFromString(t *testing.T) {
 		timezone, err := time.LoadLocation(test.Timezone)
 		require.NoError(t, err)
 
-		env := utils.NewEnvironment(test.DateFormat, test.TimeFormat, timezone, utils.NilLanguage, nil, utils.RedactionPolicyNone)
+		env := utils.NewEnvironment(test.DateFormat, test.TimeFormat, timezone, utils.NilLanguage, nil, utils.DefaultNumberFormat, utils.RedactionPolicyNone)
 
 		if err != nil {
 			t.Errorf("Error parsing expected timezone: %s", err)


### PR DESCRIPTION
Adds support for parsing/formatting numbers with configurable decimal symbols and thousands separator symbols. Defaults to current RapidPro expectations of `1,234.56`