### PR TITLE
📪 Use new status of subscriber_gone when resthook call returns 410

### DIFF
--- a/flows/actions/call_resthook.go
+++ b/flows/actions/call_resthook.go
@@ -78,12 +78,12 @@ func (a *CallResthookAction) Execute(run flows.FlowRun, step flows.Step) error {
 
 		req.Header.Add("Content-Type", "application/json")
 
-		webhook, err := flows.MakeWebhookCall(run.Session(), req)
+		webhook, err := flows.MakeWebhookCall(run.Session(), req, a.Resthook)
 		if err != nil {
 			a.logError(run, step, err)
 		} else {
 			webhooks = append(webhooks, webhook)
-			a.log(run, step, events.NewWebhookCalledEvent(webhook, a.Resthook))
+			a.log(run, step, events.NewWebhookCalledEvent(webhook))
 		}
 	}
 

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -107,12 +107,12 @@ func (a *CallWebhookAction) Execute(run flows.FlowRun, step flows.Step) error {
 		req.Header.Add(key, headerValue)
 	}
 
-	webhook, err := flows.MakeWebhookCall(run.Session(), req)
+	webhook, err := flows.MakeWebhookCall(run.Session(), req, "")
 
 	if err != nil {
 		a.logError(run, step, err)
 	} else {
-		a.log(run, step, events.NewWebhookCalledEvent(webhook, ""))
+		a.log(run, step, events.NewWebhookCalledEvent(webhook))
 		if a.ResultName != "" {
 			a.saveWebhookResult(run, step, a.ResultName, webhook)
 		}

--- a/flows/events/webhook_called.go
+++ b/flows/events/webhook_called.go
@@ -38,11 +38,11 @@ type WebhookCalledEvent struct {
 }
 
 // NewWebhookCalledEvent returns a new webhook called event
-func NewWebhookCalledEvent(webhook *flows.WebhookCall, resthook string) *WebhookCalledEvent {
+func NewWebhookCalledEvent(webhook *flows.WebhookCall) *WebhookCalledEvent {
 	return &WebhookCalledEvent{
 		BaseEvent: NewBaseEvent(TypeWebhookCalled),
 		URL:       webhook.URL(),
-		Resthook:  resthook,
+		Resthook:  webhook.Resthook(),
 		Status:    webhook.Status(),
 		ElapsedMS: int(webhook.TimeTaken().Nanoseconds() / 1e6),
 		Request:   webhook.Request(),

--- a/flows/webhook_test.go
+++ b/flows/webhook_test.go
@@ -98,11 +98,12 @@ func TestWebhookParsing(t *testing.T) {
 		request, err := http.NewRequest(tc.call.method, tc.call.url, strings.NewReader(tc.call.body))
 		require.NoError(t, err)
 
-		webhook, err := flows.MakeWebhookCall(session, request)
+		webhook, err := flows.MakeWebhookCall(session, request, "")
 		if tc.isError {
 			assert.Error(t, err)
 		} else {
 			assert.Equal(t, tc.call.url, webhook.URL(), "URL mismatch for call %s", tc.call)
+			assert.Equal(t, "", webhook.Resthook(), "resthook mismatch for call %s", tc.call)
 			assert.Equal(t, tc.call.method, webhook.Method(), "method mismatch for call %s", tc.call)
 			assert.Equal(t, tc.webhook.request, webhook.Request(), "request trace mismatch for call %s", tc.call)
 			assert.Equal(t, tc.webhook.response, webhook.Response(), "response mismatch for call %s", tc.call)


### PR DESCRIPTION
Addresses #416 