### PR TITLE
🌐 Don't url encode msg attachment expressions automatically

### DIFF
--- a/cmd/docgen/renderers.go
+++ b/cmd/docgen/renderers.go
@@ -219,7 +219,7 @@ func checkExample(session flows.Session, line string) error {
 	expected := strings.Replace(strings.TrimSpace(pieces[1]), "\\n", "\n", -1)
 
 	// evaluate our expression
-	val, err := session.Runs()[0].EvaluateTemplateAsString(test, false)
+	val, err := session.Runs()[0].EvaluateTemplateAsString(test)
 
 	if expected == "ERROR" {
 		if err == nil {

--- a/cmd/exptester/main.go
+++ b/cmd/exptester/main.go
@@ -31,5 +31,5 @@ func expTester(template string) (string, error) {
 
 	run := session.Runs()[0]
 
-	return run.EvaluateTemplateAsString(template, false)
+	return run.EvaluateTemplateAsString(template)
 }

--- a/cmd/flowserver/handlers.go
+++ b/cmd/flowserver/handlers.go
@@ -240,7 +240,7 @@ func (s *FlowServer) handleExpression(w http.ResponseWriter, r *http.Request) (i
 	context := types.JSONToXValue(expression.Context)
 
 	// evaluate it
-	result, err := excellent.EvaluateTemplateAsString(utils.NewDefaultEnvironment(), context, expression.Expression, false, nil)
+	result, err := excellent.EvaluateTemplateAsString(utils.NewDefaultEnvironment(), context, expression.Expression, nil)
 	if err != nil {
 		return expressionResponse{Result: result, Errors: []string{err.Error()}}, nil
 	}

--- a/docs/expressions.html
+++ b/docs/expressions.html
@@ -660,7 +660,7 @@
 <p><a name="function:url_encode"></a></p>
 <h2 id="url_encodetext">url_encode(text)</h2>
 <p>Encodes <code>text</code> for use as a URL parameter.</p>
-<div class="sourceCode" id="cb66"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb66-1" data-line-number="1">@(url_encode(<span class="st">&quot;two words&quot;</span>)) → two+words</a>
+<div class="sourceCode" id="cb66"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb66-1" data-line-number="1">@(url_encode(<span class="st">&quot;two &amp; words&quot;</span>)) → two%<span class="dv">20</span>%<span class="dv">26</span>%20words</a>
 <a class="sourceLine" id="cb66-2" data-line-number="2">@(url_encode(<span class="dv">10</span>)) → <span class="dv">10</span></a></code></pre></div>
 <p><a name="function:weekday"></a></p>
 <h2 id="weekdaydate">weekday(date)</h2>

--- a/docs/functions.json
+++ b/docs/functions.json
@@ -1166,8 +1166,8 @@
         "detail": "",
         "examples": [
             {
-                "template": "@(url_encode(\"two words\"))",
-                "output": "two+words"
+                "template": "@(url_encode(\"two & words\"))",
+                "output": "two%20%26%20words"
             },
             {
                 "template": "@(url_encode(10))",

--- a/docs/md/expressions.md
+++ b/docs/md/expressions.md
@@ -1172,7 +1172,7 @@ Encodes `text` for use as a URL parameter.
 
 
 ```objectivec
-@(url_encode("two words")) → two+words
+@(url_encode("two & words")) → two%20%26%20words
 @(url_encode(10)) → 10
 ```
 

--- a/excellent/evaluator.go
+++ b/excellent/evaluator.go
@@ -58,12 +58,12 @@ func EvaluateTemplate(env utils.Environment, context types.XValue, template stri
 	}
 
 	// otherwise fallback to full template evaluation
-	asStr, err := EvaluateTemplateAsString(env, context, template, false, allowedTopLevels)
+	asStr, err := EvaluateTemplateAsString(env, context, template, allowedTopLevels)
 	return types.NewXText(asStr), err
 }
 
 // EvaluateTemplateAsString evaluates the passed in template returning the string value of its execution
-func EvaluateTemplateAsString(env utils.Environment, context types.XValue, template string, urlEncode bool, allowedTopLevels []string) (string, error) {
+func EvaluateTemplateAsString(env utils.Environment, context types.XValue, template string, allowedTopLevels []string) (string, error) {
 	var buf bytes.Buffer
 	scanner := NewXScanner(strings.NewReader(template), allowedTopLevels)
 	errors := NewTemplateErrors()
@@ -79,9 +79,6 @@ func EvaluateTemplateAsString(env utils.Environment, context types.XValue, templ
 				errors.Add(fmt.Sprintf("@%s", token), value.(error).Error())
 			} else {
 				strValue, _ := types.ToXText(env, value)
-				if urlEncode {
-					strValue = types.NewXText(utils.URLEscape(strValue.Native()))
-				}
 
 				buf.WriteString(strValue.Native())
 			}
@@ -92,9 +89,6 @@ func EvaluateTemplateAsString(env utils.Environment, context types.XValue, templ
 				errors.Add(fmt.Sprintf("@(%s)", token), value.(error).Error())
 			} else {
 				strValue, _ := types.ToXText(env, value)
-				if urlEncode {
-					strValue = types.NewXText(utils.URLEscape(strValue.Native()))
-				}
 
 				buf.WriteString(strValue.Native())
 			}

--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -306,7 +306,7 @@ func TestEvaluateTemplateAsString(t *testing.T) {
 			}
 		}()
 
-		eval, err := EvaluateTemplateAsString(env, vars, test.template, false, vars.Keys())
+		eval, err := EvaluateTemplateAsString(env, vars, test.template, vars.Keys())
 
 		if test.hasError {
 			assert.Error(t, err, "expected error evaluating template '%s'", test.template)
@@ -318,21 +318,6 @@ func TestEvaluateTemplateAsString(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestURLEncoding(t *testing.T) {
-	vars := types.NewXMap(map[string]types.XValue{
-		"foo": types.NewXText("hello & world?"),
-	})
-	env := utils.NewDefaultEnvironment()
-
-	eval, err := EvaluateTemplateAsString(env, vars, `@foo`, true, vars.Keys())
-	assert.NoError(t, err)
-	assert.Equal(t, "hello%20%26%20world%3F", eval)
-
-	eval, err = EvaluateTemplateAsString(env, vars, `@(foo)`, true, vars.Keys())
-	assert.NoError(t, err)
-	assert.Equal(t, "hello%20%26%20world%3F", eval)
 }
 
 var errorTests = []struct {
@@ -375,7 +360,7 @@ func TestEvaluationErrors(t *testing.T) {
 	env := utils.NewDefaultEnvironment()
 
 	for _, tc := range errorTests {
-		result, err := EvaluateTemplateAsString(env, vars, tc.template, false, vars.Keys())
+		result, err := EvaluateTemplateAsString(env, vars, tc.template, vars.Keys())
 		assert.Equal(t, "", result)
 		assert.NotNil(t, err)
 
@@ -393,7 +378,7 @@ func BenchmarkEvaluationErrors(b *testing.B) {
 		env := utils.NewDefaultEnvironment()
 
 		for _, tc := range errorTests {
-			EvaluateTemplateAsString(env, vars, tc.template, false, vars.Keys())
+			EvaluateTemplateAsString(env, vars, tc.template, vars.Keys())
 		}
 	}
 }

--- a/excellent/functions/functions.go
+++ b/excellent/functions/functions.go
@@ -749,12 +749,14 @@ func Percent(env utils.Environment, num types.XNumber) types.XValue {
 
 // URLEncode encodes `text` for use as a URL parameter.
 //
-//   @(url_encode("two words")) -> two+words
+//   @(url_encode("two & words")) -> two%20%26%20words
 //   @(url_encode(10)) -> 10
 //
 // @function url_encode(text)
 func URLEncode(env utils.Environment, text types.XText) types.XValue {
-	return types.NewXText(url.QueryEscape(text.Native()))
+	// escapes spaces as %20 matching urllib.quote(s, safe="") in Python
+	encoded := strings.Replace(url.QueryEscape(text.Native()), "+", "%20", -1)
+	return types.NewXText(encoded)
 }
 
 //------------------------------------------------------------------------------------------

--- a/excellent/functions/functions_test.go
+++ b/excellent/functions/functions_test.go
@@ -466,7 +466,7 @@ var funcTests = []struct {
 	{"weekday", []types.XValue{xs("xxx")}, ERROR},
 	{"weekday", []types.XValue{}, ERROR},
 
-	{"url_encode", []types.XValue{xs(`hi-% ?/`)}, xs(`hi-%25+%3F%2F`)},
+	{"url_encode", []types.XValue{xs(`hi-% ?/`)}, xs(`hi-%25%20%3F%2F`)},
 	{"url_encode", []types.XValue{ERROR}, ERROR},
 	{"url_encode", []types.XValue{}, ERROR},
 }

--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -58,7 +58,7 @@ func (a *AddContactURNAction) Execute(run flows.FlowRun, step flows.Step) error 
 		return nil
 	}
 
-	evaluatedPath, err := run.EvaluateTemplateAsString(a.Path, false)
+	evaluatedPath, err := run.EvaluateTemplateAsString(a.Path)
 
 	// if we received an error, log it although it might just be a non-expression like foo@bar.com
 	if err != nil {

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -52,7 +52,7 @@ func (a *BaseAction) UUID() flows.ActionUUID { return a.UUID_ }
 
 func (a *BaseAction) evaluateLocalizableTemplate(run flows.FlowRun, localizationKey string, defaultValue string) (string, error) {
 	localizedTemplate := run.GetText(utils.UUID(a.UUID()), localizationKey, defaultValue)
-	return run.EvaluateTemplateAsString(localizedTemplate, false)
+	return run.EvaluateTemplateAsString(localizedTemplate)
 }
 
 // helper function for actions that have a set of group references that must be validated
@@ -108,7 +108,7 @@ func (a *BaseAction) resolveGroups(run flows.FlowRun, step flows.Step, reference
 			}
 		} else {
 			// group is an expression that evaluates to an existing group's name
-			evaluatedGroupName, err := run.EvaluateTemplateAsString(ref.NameMatch, false)
+			evaluatedGroupName, err := run.EvaluateTemplateAsString(ref.NameMatch)
 			if err != nil {
 				a.logError(run, step, err)
 			} else {
@@ -145,7 +145,7 @@ func (a *BaseAction) resolveLabels(run flows.FlowRun, step flows.Step, reference
 			}
 		} else {
 			// label is an expression that evaluates to an existing label's name
-			evaluatedLabelName, err := run.EvaluateTemplateAsString(ref.NameMatch, false)
+			evaluatedLabelName, err := run.EvaluateTemplateAsString(ref.NameMatch)
 			if err != nil {
 				a.logError(run, step, err)
 			} else {
@@ -169,7 +169,7 @@ func (a *BaseAction) resolveLabels(run flows.FlowRun, step flows.Step, reference
 func (a *BaseAction) evaluateMessage(run flows.FlowRun, step flows.Step, languages []utils.Language, actionText string, actionAttachments []string, actionQuickReplies []string) (string, []flows.Attachment, []string) {
 	// localize and evaluate the message text
 	localizedText := run.GetTranslatedTextArray(utils.UUID(a.UUID()), "text", []string{actionText}, languages)[0]
-	evaluatedText, err := run.EvaluateTemplateAsString(localizedText, false)
+	evaluatedText, err := run.EvaluateTemplateAsString(localizedText)
 	if err != nil {
 		a.logError(run, step, err)
 	}
@@ -178,7 +178,7 @@ func (a *BaseAction) evaluateMessage(run flows.FlowRun, step flows.Step, languag
 	translatedAttachments := run.GetTranslatedTextArray(utils.UUID(a.UUID()), "attachments", actionAttachments, languages)
 	evaluatedAttachments := make([]flows.Attachment, 0, len(translatedAttachments))
 	for n := range translatedAttachments {
-		evaluatedAttachment, err := run.EvaluateTemplateAsString(translatedAttachments[n], false)
+		evaluatedAttachment, err := run.EvaluateTemplateAsString(translatedAttachments[n])
 		if err != nil {
 			a.logError(run, step, err)
 		} else if evaluatedAttachment == "" {
@@ -192,7 +192,7 @@ func (a *BaseAction) evaluateMessage(run flows.FlowRun, step flows.Step, languag
 	translatedQuickReplies := run.GetTranslatedTextArray(utils.UUID(a.UUID()), "quick_replies", actionQuickReplies, languages)
 	evaluatedQuickReplies := make([]string, 0, len(translatedQuickReplies))
 	for n := range translatedQuickReplies {
-		evaluatedQuickReply, err := run.EvaluateTemplateAsString(translatedQuickReplies[n], false)
+		evaluatedQuickReply, err := run.EvaluateTemplateAsString(translatedQuickReplies[n])
 		if err != nil {
 			a.logError(run, step, err)
 		} else if evaluatedQuickReply == "" {
@@ -232,7 +232,7 @@ func (a *BaseAction) resolveContactsAndGroups(run flows.FlowRun, step flows.Step
 
 	// evaluate the legacy variables
 	for _, legacyVar := range actionLegacyVars {
-		evaluatedLegacyVar, err := run.EvaluateTemplateAsString(legacyVar, false)
+		evaluatedLegacyVar, err := run.EvaluateTemplateAsString(legacyVar)
 		if err != nil {
 			a.logError(run, step, err)
 		}

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -178,7 +178,7 @@ func (a *BaseAction) evaluateMessage(run flows.FlowRun, step flows.Step, languag
 	translatedAttachments := run.GetTranslatedTextArray(utils.UUID(a.UUID()), "attachments", actionAttachments, languages)
 	evaluatedAttachments := make([]flows.Attachment, 0, len(translatedAttachments))
 	for n := range translatedAttachments {
-		evaluatedAttachment, err := run.EvaluateTemplateAsString(translatedAttachments[n], true)
+		evaluatedAttachment, err := run.EvaluateTemplateAsString(translatedAttachments[n], false)
 		if err != nil {
 			a.logError(run, step, err)
 		} else if evaluatedAttachment == "" {

--- a/flows/actions/call_resthook.go
+++ b/flows/actions/call_resthook.go
@@ -60,7 +60,7 @@ func (a *CallResthookAction) Execute(run flows.FlowRun, step flows.Step) error {
 	}
 
 	// build our payload
-	payload, err := run.EvaluateTemplateAsString(flows.DefaultWebhookPayload, false)
+	payload, err := run.EvaluateTemplateAsString(flows.DefaultWebhookPayload)
 	if err != nil {
 		a.logError(run, step, err)
 	}

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -70,7 +70,7 @@ func (a *CallWebhookAction) Validate(assets flows.SessionAssets, context *flows.
 func (a *CallWebhookAction) Execute(run flows.FlowRun, step flows.Step) error {
 
 	// substitute any variables in our url
-	url, err := run.EvaluateTemplateAsString(a.URL, true)
+	url, err := run.EvaluateTemplateAsString(a.URL)
 	if err != nil {
 		a.logError(run, step, err)
 	}
@@ -84,7 +84,7 @@ func (a *CallWebhookAction) Execute(run flows.FlowRun, step flows.Step) error {
 
 	// substitute any body variables
 	if body != "" {
-		body, err = run.EvaluateTemplateAsString(body, false)
+		body, err = run.EvaluateTemplateAsString(body)
 		if err != nil {
 			a.logError(run, step, err)
 		}
@@ -98,7 +98,7 @@ func (a *CallWebhookAction) Execute(run flows.FlowRun, step flows.Step) error {
 
 	// add the custom headers, substituting any template vars
 	for key, value := range a.Headers {
-		headerValue, err := run.EvaluateTemplateAsString(value, false)
+		headerValue, err := run.EvaluateTemplateAsString(value)
 		if err != nil {
 			a.logError(run, step, err)
 		}

--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -56,7 +56,7 @@ func (a *SendEmailAction) Validate(assets flows.SessionAssets, context *flows.Va
 
 // Execute creates the email events
 func (a *SendEmailAction) Execute(run flows.FlowRun, step flows.Step) error {
-	subject, err := run.EvaluateTemplateAsString(a.Subject, false)
+	subject, err := run.EvaluateTemplateAsString(a.Subject)
 	if err != nil {
 		a.logError(run, step, err)
 	}
@@ -70,7 +70,7 @@ func (a *SendEmailAction) Execute(run flows.FlowRun, step flows.Step) error {
 		return nil
 	}
 
-	body, err := run.EvaluateTemplateAsString(a.Body, false)
+	body, err := run.EvaluateTemplateAsString(a.Body)
 	if err != nil {
 		a.logError(run, step, err)
 	}
@@ -82,7 +82,7 @@ func (a *SendEmailAction) Execute(run flows.FlowRun, step flows.Step) error {
 	evaluatedAddresses := make([]string, 0)
 
 	for _, address := range a.Addresses {
-		evaluatedAddress, err := run.EvaluateTemplateAsString(address, false)
+		evaluatedAddress, err := run.EvaluateTemplateAsString(address)
 		if err != nil {
 			a.logError(run, step, err)
 		}

--- a/flows/actions/set_run_result.go
+++ b/flows/actions/set_run_result.go
@@ -56,7 +56,7 @@ func (a *SetRunResultAction) Validate(assets flows.SessionAssets, context *flows
 func (a *SetRunResultAction) Execute(run flows.FlowRun, step flows.Step) error {
 	// get our localized value if any
 	template := run.GetText(utils.UUID(a.UUID()), "value", a.Value)
-	value, err := run.EvaluateTemplateAsString(template, false)
+	value, err := run.EvaluateTemplateAsString(template)
 
 	// log any error received
 	if err != nil {

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -95,7 +95,7 @@ func TestEvaluateTemplateAsString(t *testing.T) {
 	run := session.Runs()[0]
 
 	for _, test := range tests {
-		eval, err := run.EvaluateTemplateAsString(test.template, false)
+		eval, err := run.EvaluateTemplateAsString(test.template)
 
 		var actualErrorMsg string
 		if err != nil {
@@ -143,7 +143,7 @@ func TestContextToJSON(t *testing.T) {
 
 	for _, test := range tests {
 		template := fmt.Sprintf("@(json(%s))", test.path)
-		eval, err := run.EvaluateTemplateAsString(template, false)
+		eval, err := run.EvaluateTemplateAsString(template)
 
 		assert.NoError(t, err, "unexpected error evaluating template '%s'", template)
 		assert.Equal(t, test.expected, eval, "json() returned unexpected value for template '%s'", template)

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -429,7 +429,7 @@ type FlowRun interface {
 	Events() []Event
 
 	EvaluateTemplate(template string) (types.XValue, error)
-	EvaluateTemplateAsString(template string, urlEncode bool) (string, error)
+	EvaluateTemplateAsString(template string) (string, error)
 
 	GetText(utils.UUID, string, string) string
 	GetTextArray(utils.UUID, string, []string) []string

--- a/flows/routers/tests/tests_test.go
+++ b/flows/routers/tests/tests_test.go
@@ -268,7 +268,7 @@ func TestEvaluateTemplateAsString(t *testing.T) {
 
 	env := utils.NewDefaultEnvironment()
 	for _, test := range evalTests {
-		eval, err := excellent.EvaluateTemplateAsString(env, vars, test.template, false, vars.Keys())
+		eval, err := excellent.EvaluateTemplateAsString(env, vars, test.template, vars.Keys())
 
 		if test.hasError {
 			assert.Error(t, err, "expected error evaluating template '%s'", test.template)

--- a/flows/runs/legacy_test.go
+++ b/flows/runs/legacy_test.go
@@ -43,7 +43,7 @@ func TestLegacyExtra(t *testing.T) {
 		{"@legacy_extra", `{"address":{"state":"WA"},"bool":true,"dict":{"foo":"bar"},"list":[1,"x"],"number":123.34,"source":"website","text":"hello","webhook":"{\"bool\": true, \"number\": 123.34, \"text\": \"hello\", \"dict\": {\"foo\": \"bar\"}, \"list\": [1, \"x\"]}"}`},
 	}
 	for _, tc := range tests {
-		output, err := run.EvaluateTemplateAsString(tc.template, false)
+		output, err := run.EvaluateTemplateAsString(tc.template)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.output, output, "evaluate failed for %s", tc.template)
 	}
@@ -52,7 +52,7 @@ func TestLegacyExtra(t *testing.T) {
 	result := flows.NewResult("webhook", "200", "Success", "", flows.NodeUUID(""), nil, []byte(`[{"foo": 123}, {"foo": 345}]`), utils.Now())
 	run.SaveResult(result)
 
-	output, err := run.EvaluateTemplateAsString(`@legacy_extra.0`, false)
+	output, err := run.EvaluateTemplateAsString(`@legacy_extra.0`)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"foo":123}`, output)
 }

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -197,8 +197,8 @@ func (r *flowRun) EvaluateTemplate(template string) (types.XValue, error) {
 }
 
 // EvaluateTemplateAsString evaluates the given template as a string in the context of this run
-func (r *flowRun) EvaluateTemplateAsString(template string, urlEncode bool) (string, error) {
-	return excellent.EvaluateTemplateAsString(r.Environment(), r.Context(), template, urlEncode, RunContextTopLevels)
+func (r *flowRun) EvaluateTemplateAsString(template string) (string, error) {
+	return excellent.EvaluateTemplateAsString(r.Environment(), r.Context(), template, RunContextTopLevels)
 }
 
 // get the ordered list of languages to be used for localization in this run

--- a/legacy/definition.go
+++ b/legacy/definition.go
@@ -506,7 +506,7 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 
 		return actions.NewSetContactFieldAction(a.UUID, assets.NewFieldReference(a.Field, a.Label), migratedValue), nil
 	case "api":
-		migratedURL, _ := expressions.MigrateTemplate(a.Webhook, nil)
+		migratedURL, _ := expressions.MigrateTemplate(a.Webhook, &expressions.MigrateOptions{URLEncode: true})
 
 		headers := make(map[string]string, len(a.WebhookHeaders))
 		body := ""

--- a/legacy/expressions/migrate.go
+++ b/legacy/expressions/migrate.go
@@ -23,12 +23,24 @@ var datePrefixes = []string{
 	"timevalue",
 }
 
-// MigrateTemplate will take a legacy expression and translate it to the new syntax
-func MigrateTemplate(template string, defaultToSelf bool) (string, error) {
-	return migrateLegacyTemplateAsString(migrationContext, template, defaultToSelf)
+// MigrateOptions are options for how expressions are migrated
+type MigrateOptions struct {
+	DefaultToSelf bool
+	URLEncode     bool
 }
 
-func migrateLegacyTemplateAsString(resolver Resolvable, template string, defaultToSelf bool) (string, error) {
+var defaultOptions = &MigrateOptions{DefaultToSelf: false, URLEncode: false}
+
+// MigrateTemplate will take a legacy expression and translate it to the new syntax
+func MigrateTemplate(template string, options *MigrateOptions) (string, error) {
+	if options == nil {
+		options = defaultOptions
+	}
+
+	return migrateLegacyTemplateAsString(migrationContext, template, options)
+}
+
+func migrateLegacyTemplateAsString(resolver Resolvable, template string, options *MigrateOptions) (string, error) {
 	var buf bytes.Buffer
 	scanner := excellent.NewXScanner(strings.NewReader(template), ContextTopLevels)
 	scanner.SetUnescapeBody(false)
@@ -48,7 +60,7 @@ func migrateLegacyTemplateAsString(resolver Resolvable, template string, default
 				strValue, _ := toString(value)
 
 				var errorAs string
-				if defaultToSelf {
+				if options.DefaultToSelf {
 					errorAs = "@" + token
 				}
 
@@ -67,7 +79,7 @@ func migrateLegacyTemplateAsString(resolver Resolvable, template string, default
 				strValue, _ := toString(value)
 
 				var errorAs string
-				if defaultToSelf {
+				if options.DefaultToSelf {
 					errorAs = "@(" + token + ")"
 				}
 

--- a/legacy/expressions/migrate_test.go
+++ b/legacy/expressions/migrate_test.go
@@ -268,7 +268,8 @@ func TestMigrateTemplate(t *testing.T) {
 	for _, tc := range tests {
 
 		for i := 0; i < 1; i++ {
-			migratedTemplate, err := expressions.MigrateTemplate(tc.old, tc.defaultToSelf)
+			options := &expressions.MigrateOptions{DefaultToSelf: tc.defaultToSelf}
+			migratedTemplate, err := expressions.MigrateTemplate(tc.old, options)
 
 			defer func() {
 				if r := recover(); r != nil {
@@ -389,7 +390,7 @@ func TestLegacyTests(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range tests {
-		migratedTemplate, err := expressions.MigrateTemplate(tc.Template, false)
+		migratedTemplate, err := expressions.MigrateTemplate(tc.Template, nil)
 
 		defer func() {
 			if r := recover(); r != nil {
@@ -413,7 +414,7 @@ func TestLegacyTests(t *testing.T) {
 			migratedVars := tc.Context.Variables.Migrate()
 			migratedVarsJSON, _ := json.Marshal(migratedVars)
 
-			_, err = excellent.EvaluateTemplateAsString(env, migratedVars, migratedTemplate, tc.URLEncode, runs.RunContextTopLevels)
+			_, err = excellent.EvaluateTemplateAsString(env, migratedVars, migratedTemplate, runs.RunContextTopLevels)
 
 			if len(tc.Errors) > 0 {
 				assert.Error(t, err, "expecting error evaluating template '%s' (migrated from '%s') with context %s", migratedTemplate, tc.Template, migratedVarsJSON)

--- a/legacy/testdata/actions.json
+++ b/legacy/testdata/actions.json
@@ -65,7 +65,7 @@
             "type": "call_webhook",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "method": "GET",
-            "url": "http://example.com?contact=@(format_urn(contact.urns.tel))"
+            "url": "http://example.com?contact=@(url_encode(format_urn(contact.urns.tel)))"
         },
         "expected_localization": {}
     },
@@ -86,7 +86,7 @@
             "type": "call_webhook",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "method": "POST",
-            "url": "http://example.com?contact=@(format_urn(contact.urns.tel))",
+            "url": "http://example.com?contact=@(url_encode(format_urn(contact.urns.tel)))",
             "headers": {
                 "Content-Type": "application/json",
                 "User-Agent": "rapidpro"
@@ -111,7 +111,7 @@
             "type": "call_webhook",
             "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
             "method": "POST",
-            "url": "http://example.com?contact=@(format_urn(contact.urns.tel))",
+            "url": "http://example.com?contact=@(url_encode(format_urn(contact.urns.tel)))",
             "headers": {
                 "Content-Type": "application/json",
                 "User-Agent": "rapidpro"

--- a/test/testdata/flows/all_actions.json
+++ b/test/testdata/flows/all_actions.json
@@ -154,7 +154,7 @@
                             "type": "send_msg",
                             "text": "This is a reply with attachments and quick replies",
                             "attachments": [
-                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=@(format_location(contact.fields.state))"
+                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=@(url_encode(format_location(contact.fields.state)))"
                             ],
                             "quick_replies": [
                                 "Yes",

--- a/test/testdata/flows/all_actions.json
+++ b/test/testdata/flows/all_actions.json
@@ -110,7 +110,7 @@
                             ],
                             "text": "Hi @contact.name, are you ready for these attachments?",
                             "attachments": [
-                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=@(format_location(contact.fields.state))"
+                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=@(url_encode(format_location(contact.fields.state)))"
                             ]
                         },
                         {

--- a/test/testdata/flows/all_actions.json
+++ b/test/testdata/flows/all_actions.json
@@ -200,7 +200,7 @@
                             "uuid": "06153fbd-3e2c-413a-b0df-ed15d631835a",
                             "type": "call_webhook",
                             "method": "GET",
-                            "url": "http://localhost/?cmd=success&name=@contact.name"
+                            "url": "http://localhost/?cmd=success&name=@(url_encode(contact.name))"
                         }
                     ],
                     "exits": [

--- a/test/testdata/flows/all_actions_test.json
+++ b/test/testdata/flows/all_actions_test.json
@@ -185,13 +185,13 @@
                     "translations": {
                         "eng": {
                             "attachments": [
-                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
+                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
                             ],
                             "text": "Hi Ben Haggerty, are you ready for these attachments?"
                         },
                         "spa": {
                             "attachments": [
-                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
+                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
                             ],
                             "text": "Hi Ben Haggerty, are you ready for these attachments?"
                         }
@@ -295,7 +295,7 @@
                     "created_on": "2018-07-06T12:30:39.123456789Z",
                     "msg": {
                         "attachments": [
-                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
+                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
                         ],
                         "channel": {
                             "name": "Android Channel",
@@ -631,13 +631,13 @@
                                 "translations": {
                                     "eng": {
                                         "attachments": [
-                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
+                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
                                         ],
                                         "text": "Hi Ben Haggerty, are you ready for these attachments?"
                                     },
                                     "spa": {
                                         "attachments": [
-                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
+                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
                                         ],
                                         "text": "Hi Ben Haggerty, are you ready for these attachments?"
                                     }
@@ -741,7 +741,7 @@
                                 "created_on": "2018-07-06T12:30:39.123456789Z",
                                 "msg": {
                                     "attachments": [
-                                        "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
+                                        "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
                                     ],
                                     "channel": {
                                         "name": "Android Channel",

--- a/test/testdata/flows/all_actions_test.json
+++ b/test/testdata/flows/all_actions_test.json
@@ -185,13 +185,13 @@
                     "translations": {
                         "eng": {
                             "attachments": [
-                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
+                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
                             ],
                             "text": "Hi Ben Haggerty, are you ready for these attachments?"
                         },
                         "spa": {
                             "attachments": [
-                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
+                                "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
                             ],
                             "text": "Hi Ben Haggerty, are you ready for these attachments?"
                         }
@@ -295,7 +295,7 @@
                     "created_on": "2018-07-06T12:30:39.123456789Z",
                     "msg": {
                         "attachments": [
-                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
+                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
                         ],
                         "channel": {
                             "name": "Android Channel",
@@ -372,12 +372,12 @@
                 {
                     "created_on": "2018-07-06T12:30:59.123456789Z",
                     "elapsed_ms": 1000,
-                    "request": "GET /?cmd=success&name=Jeff+Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                    "request": "GET /?cmd=success&name=Jeff%20Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }",
                     "status": "success",
                     "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                     "type": "webhook_called",
-                    "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff+Jefferson"
+                    "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff%20Jefferson"
                 }
             ],
             "session": {
@@ -631,13 +631,13 @@
                                 "translations": {
                                     "eng": {
                                         "attachments": [
-                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
+                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
                                         ],
                                         "text": "Hi Ben Haggerty, are you ready for these attachments?"
                                     },
                                     "spa": {
                                         "attachments": [
-                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
+                                            "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
                                         ],
                                         "text": "Hi Ben Haggerty, are you ready for these attachments?"
                                     }
@@ -741,7 +741,7 @@
                                 "created_on": "2018-07-06T12:30:39.123456789Z",
                                 "msg": {
                                     "attachments": [
-                                        "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali+City"
+                                        "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
                                     ],
                                     "channel": {
                                         "name": "Android Channel",
@@ -818,12 +818,12 @@
                             {
                                 "created_on": "2018-07-06T12:30:59.123456789Z",
                                 "elapsed_ms": 1000,
-                                "request": "GET /?cmd=success&name=Jeff+Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                                "request": "GET /?cmd=success&name=Jeff%20Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                                 "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }",
                                 "status": "success",
                                 "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                                 "type": "webhook_called",
-                                "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff+Jefferson"
+                                "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff%20Jefferson"
                             }
                         ],
                         "exited_on": "2018-07-06T12:31:06.123456789Z",

--- a/test/testdata/flows/all_actions_test.json
+++ b/test/testdata/flows/all_actions_test.json
@@ -372,12 +372,12 @@
                 {
                     "created_on": "2018-07-06T12:30:59.123456789Z",
                     "elapsed_ms": 1000,
-                    "request": "GET /?cmd=success&name=Jeff%20Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                    "request": "GET /?cmd=success&name=Jeff+Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }",
                     "status": "success",
                     "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                     "type": "webhook_called",
-                    "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff%20Jefferson"
+                    "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff+Jefferson"
                 }
             ],
             "session": {
@@ -818,12 +818,12 @@
                             {
                                 "created_on": "2018-07-06T12:30:59.123456789Z",
                                 "elapsed_ms": 1000,
-                                "request": "GET /?cmd=success&name=Jeff%20Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+                                "request": "GET /?cmd=success&name=Jeff+Jefferson HTTP/1.1\r\nHost: 127.0.0.1:49999\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                                 "response": "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }",
                                 "status": "success",
                                 "step_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
                                 "type": "webhook_called",
-                                "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff%20Jefferson"
+                                "url": "http://127.0.0.1:49999/?cmd=success&name=Jeff+Jefferson"
                             }
                         ],
                         "exited_on": "2018-07-06T12:31:06.123456789Z",

--- a/utils/text.go
+++ b/utils/text.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"net/url"
 	"regexp"
 	"strings"
 )

--- a/utils/text.go
+++ b/utils/text.go
@@ -17,11 +17,6 @@ func Snakify(text string) string {
 	return strings.Trim(strings.ToLower(snakedChars.ReplaceAllString(text, "_")), "_")
 }
 
-// URLEscape escapes spaces as %20 matching urllib.quote(s, safe="") in Python
-func URLEscape(s string) string {
-	return strings.Replace(url.QueryEscape(s), "+", "%20", -1)
-}
-
 // TokenizeString returns the words in the passed in string, split by non word characters including emojis
 func TokenizeString(str string) []string {
 	return wordTokenRegex.FindAllString(str, -1)

--- a/utils/text_test.go
+++ b/utils/text_test.go
@@ -26,21 +26,6 @@ func TestSnakify(t *testing.T) {
 	}
 }
 
-func TestURLEscape(t *testing.T) {
-	var urlTests = []struct {
-		input    string
-		expected string
-	}{
-		{"", ""},
-		{"hello_world-there", "hello_world-there"},
-		{"foo: bar ? & some/thing", "foo%3A%20bar%20%3F%20%26%20some%2Fthing"},
-	}
-
-	for _, test := range urlTests {
-		assert.Equal(t, test.expected, utils.URLEscape(test.input), "unexpected result URL escaping '%s'", test.input)
-	}
-}
-
 func TestTokenizeString(t *testing.T) {
 	tokenizerTests := []struct {
 		text   string


### PR DESCRIPTION
Unlike webhook URLs, these aren't url encoded in the old engine, and the problem arises when an expression is used for the entire attachment URL and not just a query param. 