### PR TITLE
⏰ Failing waits

### DIFF
--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -202,7 +202,7 @@ func (s *session) prepareForSprint() error {
 // Resume resumes a waiting session
 func (s *session) tryToResume(waitingRun flows.FlowRun, resume flows.Resume) error {
 	// figure out where in the flow we began waiting on
-	step, _, err := waitingRun.PathLocation()
+	step, node, err := waitingRun.PathLocation()
 	if err != nil {
 		return err
 	}
@@ -210,9 +210,10 @@ func (s *session) tryToResume(waitingRun flows.FlowRun, resume flows.Resume) err
 	// set up our flow stack based on the current run hierarchy
 	s.flowStack = flowStackFromRun(waitingRun)
 
-	// try to end our wait which will return and error if it can't be ended with this resume
-	if err := s.wait.End(resume); err != nil {
-		return err
+	// try to end our wait which will return and log an error if it can't be ended with this resume
+	if err := s.wait.End(resume, node); err != nil {
+		s.LogEvent(events.NewErrorEvent(err))
+		return nil
 	}
 	s.wait = nil
 	s.status = flows.SessionStatusActive
@@ -222,15 +223,11 @@ func (s *session) tryToResume(waitingRun flows.FlowRun, resume flows.Resume) err
 		return err
 	}
 
-	var destination flows.NodeUUID
+	waitingRun.SetStatus(flows.RunStatusActive)
 
-	if waitingRun.Status() == flows.RunStatusWaiting {
-		waitingRun.SetStatus(flows.RunStatusActive)
-
-		destination, err = s.findResumeDestination(waitingRun)
-		if err != nil {
-			return err
-		}
+	destination, err := s.findResumeDestination(waitingRun)
+	if err != nil {
+		return err
 	}
 
 	// off to the races again...

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -215,7 +215,7 @@ type Wait interface {
 	TimeoutOn() *time.Time
 
 	Begin(FlowRun, Step) bool
-	End(Resume) error
+	End(Resume, Node) error
 }
 
 // Localization provide a way to get the translations for a specific language

--- a/flows/waits/base.go
+++ b/flows/waits/base.go
@@ -48,17 +48,20 @@ func (w *baseWait) Begin(run flows.FlowRun) bool {
 }
 
 // End ends this wait or returns an error
-func (w *baseWait) End(resume flows.Resume) error {
+func (w *baseWait) End(resume flows.Resume, node flows.Node) error {
 	switch resume.Type() {
 	case resumes.TypeRunExpiration:
 		// expired runs always end a wait
 		return nil
 	case resumes.TypeWaitTimeout:
+		if node.Wait().Timeout() == nil {
+			return fmt.Errorf("can't end with timeout as node no longer has a wait timeout")
+		}
 		if w.Timeout() == nil || w.TimeoutOn() == nil {
-			return fmt.Errorf("can only be applied when session wait has timeout")
+			return fmt.Errorf("can't end with timeout as session wait has no timeout")
 		}
 		if utils.Now().Before(*w.TimeoutOn()) {
-			return fmt.Errorf("can't apply before wait has timed out")
+			return fmt.Errorf("can't end with timeout before wait has timed out")
 		}
 	}
 	return nil

--- a/flows/waits/msg.go
+++ b/flows/waits/msg.go
@@ -62,12 +62,13 @@ func (w *MsgWait) Begin(run flows.FlowRun, step flows.Step) bool {
 }
 
 // End ends this wait or returns an error
-func (w *MsgWait) End(resume flows.Resume) error {
+func (w *MsgWait) End(resume flows.Resume, node flows.Node) error {
+	// if we have a message we can definitely resume
 	if resume.Type() == resumes.TypeMsg {
 		return nil
 	}
 
-	return w.baseWait.End(resume)
+	return w.baseWait.End(resume, node)
 }
 
 var _ flows.Wait = (*MsgWait)(nil)


### PR DESCRIPTION
* Waits should check if node still has timeout when they receive a timeout resume
* A wait refusing to end should log an error but no error the session