### PR TITLE
🧮 Don't do I>1 O>0 substitutions when parsing numbers

### DIFF
--- a/flows/routers/tests/tests.go
+++ b/flows/routers/tests/tests.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/excellent/functions"
@@ -818,25 +817,8 @@ func hasOnlyPhraseTest(origHays []string, hays []string, pins []string) XTestRes
 
 // ParseDecimalFuzzy parses a decimal from a string
 func ParseDecimalFuzzy(val string, format *utils.NumberFormat) (decimal.Decimal, error) {
-	// must contain at least one real digit - prevents things like ll becoming 11
-	containsDigit := false
-	for _, c := range val {
-		if unicode.IsDigit(c) {
-			containsDigit = true
-			break
-		}
-	}
-	if !containsDigit {
-		return decimal.Zero, fmt.Errorf("must contain at least one digit")
-	}
-
-	// common SMS foibles
-	cleaned := strings.Replace(val, "l", "1", -1)
-	cleaned = strings.Replace(cleaned, "O", "0", -1)
-	cleaned = strings.Replace(cleaned, "o", "0", -1)
-
 	// remove digit grouping symbol
-	cleaned = strings.Replace(cleaned, format.DigitGroupingSymbol, "", -1)
+	cleaned := strings.Replace(val, format.DigitGroupingSymbol, "", -1)
 
 	// replace non-period decimal symbols
 	cleaned = strings.Replace(cleaned, format.DecimalSymbol, ".", -1)

--- a/flows/routers/tests/tests_test.go
+++ b/flows/routers/tests/tests_test.go
@@ -122,6 +122,7 @@ var testTests = []struct {
 	{"has_number", []types.XValue{xs("another is -12.51")}, true, xn("-12.51"), false},
 	{"has_number", []types.XValue{xs("hi.51")}, true, xn("51"), false},
 	{"has_number", []types.XValue{xs("nothing here")}, false, nil, false},
+	{"has_number", []types.XValue{xs("1OO l00")}, false, nil, false}, // no longer do substitutions
 	{"has_number", []types.XValue{xs("one"), xs("two"), xs("three")}, false, nil, true},
 
 	{"has_number_lt", []types.XValue{xs("the number 10"), xs("11")}, true, xn("10"), false},

--- a/flows/routers/tests/tests_test.go
+++ b/flows/routers/tests/tests_test.go
@@ -117,8 +117,7 @@ var testTests = []struct {
 	{"has_number", []types.XValue{xs("24ans")}, true, xn("24"), false},
 	{"has_number", []types.XValue{xs("J'AI 20ANS")}, true, xn("20"), false},
 	{"has_number", []types.XValue{xs("1,000,000")}, true, xn("1000000"), false},
-	{"has_number", []types.XValue{xs("the number 1O")}, true, xn("10"), false},
-	{"has_number", []types.XValue{xs("the number l0")}, true, xn("10"), false},
+	{"has_number", []types.XValue{xs("the number 10")}, true, xn("10"), false},
 	{"has_number", []types.XValue{xs("O número é 500")}, true, xn("500"), false},
 	{"has_number", []types.XValue{xs("another is -12.51")}, true, xn("-12.51"), false},
 	{"has_number", []types.XValue{xs("hi.51")}, true, xn("51"), false},
@@ -291,7 +290,6 @@ func TestParseDecimalFuzzy(t *testing.T) {
 		{"1234", decimal.RequireFromString("1234"), utils.DefaultNumberFormat},
 		{"1,234.567", decimal.RequireFromString("1234.567"), utils.DefaultNumberFormat},
 		{"1.234,567", decimal.RequireFromString("1234.567"), &utils.NumberFormat{DecimalSymbol: ",", DigitGroupingSymbol: "."}},
-		{"l00", decimal.RequireFromString("100"), utils.DefaultNumberFormat},
 		{"100.00", decimal.RequireFromString("100.00"), utils.DefaultNumberFormat},
 	}
 
@@ -301,8 +299,4 @@ func TestParseDecimalFuzzy(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, test.expected, val, "parse decimal failed for input '%s'", test.input)
 	}
-
-	// don't allow both prefixes/suffixes and substitutions
-	_, err := tests.ParseDecimalFuzzy("l00ans", utils.DefaultNumberFormat)
-	assert.Error(t, err)
 }


### PR DESCRIPTION
As discussed at https://github.com/rapidpro/rapidpro/issues/828