### PR TITLE
simplify signature for ParseRawURN to only need channels assets

### DIFF
--- a/flows/urn.go
+++ b/flows/urn.go
@@ -67,7 +67,7 @@ func NewContactURN(urn urns.URN, channel *Channel) *ContactURN {
 }
 
 // ParseRawURN converts a raw URN to a ContactURN by extracting it's channel reference
-func ParseRawURN(a SessionAssets, rawURN urns.URN) (*ContactURN, error) {
+func ParseRawURN(ca *ChannelAssets, rawURN urns.URN) (*ContactURN, error) {
 	_, _, query, _ := rawURN.ToParts()
 
 	parsedQuery, err := url.ParseQuery(query)
@@ -78,7 +78,7 @@ func ParseRawURN(a SessionAssets, rawURN urns.URN) (*ContactURN, error) {
 	var channel *Channel
 	channelUUID := parsedQuery.Get("channel")
 	if channelUUID != "" {
-		if channel, err = a.Channels().Get(assets.ChannelUUID(channelUUID)); err != nil {
+		if channel, err = ca.Get(assets.ChannelUUID(channelUUID)); err != nil {
 			return nil, err
 		}
 	}
@@ -174,7 +174,7 @@ func ReadURNList(a SessionAssets, rawURNs []urns.URN) (URNList, error) {
 	l := make(URNList, len(rawURNs))
 
 	for u := range rawURNs {
-		parsed, err := ParseRawURN(a, rawURNs[u])
+		parsed, err := ParseRawURN(a.Channels(), rawURNs[u])
 		if err != nil {
 			return nil, err
 		}

--- a/flows/urn_test.go
+++ b/flows/urn_test.go
@@ -38,19 +38,21 @@ func TestContactURN(t *testing.T) {
 	sessionAssets, err := engine.NewSessionAssets(source)
 	require.NoError(t, err)
 
-	channel, err := sessionAssets.Channels().Get("57f1078f-88aa-46f4-a59a-948a5739c03d")
+	channels := sessionAssets.Channels()
+
+	channel, err := channels.Get("57f1078f-88aa-46f4-a59a-948a5739c03d")
 	require.NoError(t, err)
 
 	// check that parsing a URN properly extracts its channel affinity
-	urn, err := flows.ParseRawURN(sessionAssets, urns.URN("tel:+250781234567?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=3"))
+	urn, err := flows.ParseRawURN(channels, urns.URN("tel:+250781234567?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=3"))
 	assert.NoError(t, err)
 	assert.Equal(t, urns.URN("tel:+250781234567?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=3"), urn.URN())
 	assert.Equal(t, channel, urn.Channel())
 	assert.Equal(t, "tel:+250781234567?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=3", urn.String())
 
 	// check equality
-	urn2, _ := flows.ParseRawURN(sessionAssets, urns.URN("tel:+250781234567?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=3"))
-	urn3, _ := flows.ParseRawURN(sessionAssets, urns.URN("tel:+250781234567?id=3"))
+	urn2, _ := flows.ParseRawURN(channels, urns.URN("tel:+250781234567?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=3"))
+	urn3, _ := flows.ParseRawURN(channels, urns.URN("tel:+250781234567?id=3"))
 	assert.True(t, urn.Equal(urn2))
 	assert.False(t, urn.Equal(urn3))
 


### PR DESCRIPTION
Need to use the utility methods in goflow for finding the right channel for a URN and this simplifies the signature so I can do so just with ChannelAssets instead of the whole pile of SessionAssets which is more expensive to build.