### PR TITLE
add full constructor for sprint

### DIFF
--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -128,7 +128,7 @@ func (s *session) HTTPClient() *utils.HTTPClient    { return s.httpClient }
 
 // Start initializes this session with the given trigger and runs the flow to the first wait
 func (s *session) Start(trigger flows.Trigger) (flows.Sprint, error) {
-	sprint := NewSprint()
+	sprint := NewEmptySprint()
 	s.trigger = trigger
 
 	if err := s.prepareForSprint(); err != nil {
@@ -149,7 +149,7 @@ func (s *session) Start(trigger flows.Trigger) (flows.Sprint, error) {
 
 // Resume tries to resume a waiting session
 func (s *session) Resume(resume flows.Resume) (flows.Sprint, error) {
-	sprint := NewSprint()
+	sprint := NewEmptySprint()
 
 	if err := s.prepareForSprint(); err != nil {
 		return sprint, err

--- a/flows/engine/sprint.go
+++ b/flows/engine/sprint.go
@@ -9,16 +9,16 @@ type sprint struct {
 	events    []flows.Event
 }
 
-// NewSprint creates a new sprint
-func NewSprint() flows.Sprint {
+// NewEmptySprint creates a new sprint
+func NewEmptySprint() flows.Sprint {
 	return &sprint{
 		modifiers: make([]flows.Modifier, 0),
 		events:    make([]flows.Event, 0),
 	}
 }
 
-// NewSprintWithValues creates a new sprint with the passed in events and modifiers
-func NewSprintWithValues(modifiers []flows.Modifier, events []flows.Event) flows.Sprint {
+// NewSprint creates a new sprint with the passed in modifiers and events
+func NewSprint(modifiers []flows.Modifier, events []flows.Event) flows.Sprint {
 	return &sprint{
 		modifiers: modifiers,
 		events:    events,

--- a/flows/engine/sprint.go
+++ b/flows/engine/sprint.go
@@ -17,6 +17,14 @@ func NewSprint() flows.Sprint {
 	}
 }
 
+// NewSprintWithValues creates a new sprint with the passed in events and modifiers
+func NewSprintWithValues(modifiers []flows.Modifier, events []flows.Event) flows.Sprint {
+	return &sprint{
+		modifiers: modifiers,
+		events:    events,
+	}
+}
+
 func (s *sprint) Modifiers() []flows.Modifier { return s.modifiers }
 func (s *sprint) Events() []flows.Event       { return s.events }
 


### PR DESCRIPTION
Surveyor need a way of creating a sprint from events and modifiers, this just adds a constructor for that so I don't need to create my own Sprint class.