### PR TITLE
🛂 Update modifier loading so missing assets are reported

### DIFF
--- a/flows/actions/modifiers/base.go
+++ b/flows/actions/modifiers/base.go
@@ -3,6 +3,7 @@ package modifiers
 import (
 	"encoding/json"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
@@ -10,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type readFunc func(flows.SessionAssets, json.RawMessage) (flows.Modifier, error)
+type readFunc func(flows.SessionAssets, json.RawMessage, assets.MissingCallback) (flows.Modifier, error)
 
 // RegisteredTypes is the registered modifier types
 var RegisteredTypes = map[string]readFunc{}
@@ -52,7 +53,7 @@ func (m *baseModifier) reevaluateDynamicGroups(env utils.Environment, assets flo
 //------------------------------------------------------------------------------------------
 
 // ReadModifier reads a modifier from the given JSON
-func ReadModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func ReadModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	typeName, err := utils.ReadTypeFromJSON(data)
 	if err != nil {
 		return nil, err
@@ -62,5 +63,5 @@ func ReadModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modif
 	if f == nil {
 		return nil, errors.Errorf("unknown type: '%s'", typeName)
 	}
-	return f(assets, data)
+	return f(assets, data, missing)
 }

--- a/flows/actions/modifiers/base.go
+++ b/flows/actions/modifiers/base.go
@@ -11,6 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrNoModifier is the error instance returned when a modifier is read but due to missing assets can't be returned
+var ErrNoModifier = errors.New("no modifier to return because of missing assets")
+
 type readFunc func(flows.SessionAssets, json.RawMessage, assets.MissingCallback) (flows.Modifier, error)
 
 // RegisteredTypes is the registered modifier types

--- a/flows/actions/modifiers/base_test.go
+++ b/flows/actions/modifiers/base_test.go
@@ -187,21 +187,21 @@ func TestReadModifier(t *testing.T) {
 	_, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "do_the_foo", "foo": "bar"}`), missing)
 	assert.EqualError(t, err, "unknown type: 'do_the_foo'")
 
-	// nil and a missing asset record if we load a channel modifier for a channel that no longer exists
+	// no-modifier error and a missing asset record if we load a channel modifier for a channel that no longer exists
 	mod, err := modifiers.ReadModifier(sessionAssets, []byte(`{"type": "channel", "channel": {"uuid": "8632b9f0-ac2f-40ad-808f-77781a444dc9", "name": "Nexmo"}}`), missing)
-	assert.NoError(t, err)
+	assert.Equal(t, modifiers.ErrNoModifier, err)
 	assert.Nil(t, mod)
 	assert.Equal(t, assets.NewChannelReference(assets.ChannelUUID("8632b9f0-ac2f-40ad-808f-77781a444dc9"), "Nexmo"), missingAssets[len(missingAssets)-1])
 
-	// nil and a missing asset record if we load a field modifier for a field that no longer exists
+	// no-modifier error and a missing asset record if we load a field modifier for a field that no longer exists
 	mod, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "field", "field": {"key": "gender", "name": "Gender"}, "value": {"text": "M"}}`), missing)
-	assert.NoError(t, err)
+	assert.Equal(t, modifiers.ErrNoModifier, err)
 	assert.Nil(t, mod)
 	assert.Equal(t, assets.NewFieldReference("gender", "Gender"), missingAssets[len(missingAssets)-1])
 
-	// nil if we load a groups modifier and none of its groups exist
+	// no-modifier error if we load a groups modifier and none of its groups exist
 	mod, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "groups", "modification": "add", "groups": [{"uuid": "8632b9f0-ac2f-40ad-808f-77781a444dc9", "name": "Testers"}]}`), missing)
-	assert.NoError(t, err)
+	assert.Equal(t, modifiers.ErrNoModifier, err)
 	assert.Nil(t, mod)
 	assert.Equal(t, assets.NewGroupReference(assets.GroupUUID("8632b9f0-ac2f-40ad-808f-77781a444dc9"), "Testers"), missingAssets[len(missingAssets)-1])
 

--- a/flows/actions/modifiers/base_test.go
+++ b/flows/actions/modifiers/base_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/assets/static"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/actions/modifiers"
+	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 
@@ -53,7 +55,7 @@ func testModifierType(t *testing.T, sessionAssets flows.SessionAssets, typeName 
 		testName := fmt.Sprintf("test '%s' for modifier type '%s'", tc.Description, typeName)
 
 		// read the modifier to be tested
-		modifier, err := modifiers.ReadModifier(sessionAssets, tc.Modifier)
+		modifier, err := modifiers.ReadModifier(sessionAssets, tc.Modifier, assets.PanicOnMissing)
 		require.NoError(t, err, "error loading modifier in %s", testName)
 		assert.Equal(t, typeName, modifier.Type())
 
@@ -171,11 +173,50 @@ func TestConstructors(t *testing.T) {
 }
 
 func TestReadModifier(t *testing.T) {
+	missingAssets := make([]assets.Reference, 0)
+	missing := func(a assets.Reference) { missingAssets = append(missingAssets, a) }
+
+	sessionAssets, err := engine.NewSessionAssets(static.NewEmptySource())
+	require.NoError(t, err)
+
 	// error if no type field
-	_, err := modifiers.ReadModifier(nil, []byte(`{"foo": "bar"}`))
+	_, err = modifiers.ReadModifier(sessionAssets, []byte(`{"foo": "bar"}`), missing)
 	assert.EqualError(t, err, "field 'type' is required")
 
 	// error if we don't recognize the type
-	_, err = modifiers.ReadModifier(nil, []byte(`{"type": "do_the_foo", "foo": "bar"}`))
+	_, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "do_the_foo", "foo": "bar"}`), missing)
 	assert.EqualError(t, err, "unknown type: 'do_the_foo'")
+
+	// nil and a missing asset record if we load a channel modifier for a channel that no longer exists
+	mod, err := modifiers.ReadModifier(sessionAssets, []byte(`{"type": "channel", "channel": {"uuid": "8632b9f0-ac2f-40ad-808f-77781a444dc9", "name": "Nexmo"}}`), missing)
+	assert.NoError(t, err)
+	assert.Nil(t, mod)
+	assert.Equal(t, assets.NewChannelReference(assets.ChannelUUID("8632b9f0-ac2f-40ad-808f-77781a444dc9"), "Nexmo"), missingAssets[len(missingAssets)-1])
+
+	// nil and a missing asset record if we load a field modifier for a field that no longer exists
+	mod, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "field", "field": {"key": "gender", "name": "Gender"}, "value": {"text": "M"}}`), missing)
+	assert.NoError(t, err)
+	assert.Nil(t, mod)
+	assert.Equal(t, assets.NewFieldReference("gender", "Gender"), missingAssets[len(missingAssets)-1])
+
+	// nil if we load a groups modifier and none of its groups exist
+	mod, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "groups", "modification": "add", "groups": [{"uuid": "8632b9f0-ac2f-40ad-808f-77781a444dc9", "name": "Testers"}]}`), missing)
+	assert.NoError(t, err)
+	assert.Nil(t, mod)
+	assert.Equal(t, assets.NewGroupReference(assets.GroupUUID("8632b9f0-ac2f-40ad-808f-77781a444dc9"), "Testers"), missingAssets[len(missingAssets)-1])
+
+	// but if at least one of its groups exists, we still get a modifier
+	source, _ := static.NewSource([]byte(`{
+		"groups": [
+			{"uuid": "4349cdd6-5385-46f3-8e55-5750dd4f35fb", "name": "Winners"}
+		]
+	}`))
+	sessionAssets, err = engine.NewSessionAssets(source)
+	require.NoError(t, err)
+
+	mod, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "groups", "modification": "add", "groups": [{"uuid": "cd1a2aa6-0d9d-4a8c-b32d-ca5de9c43bdb", "name": "Losers"}, {"uuid": "4349cdd6-5385-46f3-8e55-5750dd4f35fb", "name": "Winners"}]}`), missing)
+	assert.NoError(t, err)
+	assert.NotNil(t, mod)
+	assert.Equal(t, "groups", mod.Type())
+	assert.Equal(t, assets.NewGroupReference(assets.GroupUUID("cd1a2aa6-0d9d-4a8c-b32d-ca5de9c43bdb"), "Losers"), missingAssets[len(missingAssets)-1])
 }

--- a/flows/actions/modifiers/channel.go
+++ b/flows/actions/modifiers/channel.go
@@ -50,7 +50,7 @@ type channelModifierEnvelope struct {
 	Channel *assets.ChannelReference `json:"channel" validate:"omitempty,dive"`
 }
 
-func readChannelModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func readChannelModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	e := &channelModifierEnvelope{}
 	if err := utils.UnmarshalAndValidate(data, e); err != nil {
 		return nil, err
@@ -60,7 +60,8 @@ func readChannelModifier(assets flows.SessionAssets, data json.RawMessage) (flow
 	if e.Channel != nil {
 		var err error
 		if channel, err = assets.Channels().Get(e.Channel.UUID); err != nil {
-			return nil, err
+			missing(e.Channel)
+			return nil, nil // nothing left to modify without the channel
 		}
 	}
 	return NewChannelModifier(channel), nil

--- a/flows/actions/modifiers/channel.go
+++ b/flows/actions/modifiers/channel.go
@@ -61,7 +61,7 @@ func readChannelModifier(assets flows.SessionAssets, data json.RawMessage, missi
 		var err error
 		if channel, err = assets.Channels().Get(e.Channel.UUID); err != nil {
 			missing(e.Channel)
-			return nil, nil // nothing left to modify without the channel
+			return nil, ErrNoModifier // nothing left to modify without the channel
 		}
 	}
 	return NewChannelModifier(channel), nil

--- a/flows/actions/modifiers/field.go
+++ b/flows/actions/modifiers/field.go
@@ -67,7 +67,7 @@ func readFieldModifier(assets flows.SessionAssets, data json.RawMessage, missing
 		var err error
 		if field, err = assets.Fields().Get(e.Field.Key); err != nil {
 			missing(e.Field)
-			return nil, nil // nothing left to modify without the field
+			return nil, ErrNoModifier // nothing left to modify without the field
 		}
 	}
 	return NewFieldModifier(field, e.Value), nil

--- a/flows/actions/modifiers/field.go
+++ b/flows/actions/modifiers/field.go
@@ -56,7 +56,7 @@ type fieldModifierEnvelope struct {
 	Value *flows.Value           `json:"value"`
 }
 
-func readFieldModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func readFieldModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	e := &fieldModifierEnvelope{}
 	if err := utils.UnmarshalAndValidate(data, e); err != nil {
 		return nil, err
@@ -66,7 +66,8 @@ func readFieldModifier(assets flows.SessionAssets, data json.RawMessage) (flows.
 	if e.Field != nil {
 		var err error
 		if field, err = assets.Fields().Get(e.Field.Key); err != nil {
-			return nil, err
+			missing(e.Field)
+			return nil, nil // nothing left to modify without the field
 		}
 	}
 	return NewFieldModifier(field, e.Value), nil

--- a/flows/actions/modifiers/groups.go
+++ b/flows/actions/modifiers/groups.go
@@ -111,7 +111,7 @@ func readGroupsModifier(assets flows.SessionAssets, data json.RawMessage, missin
 		return NewGroupsModifier(groups, e.Modification), nil
 	}
 
-	return nil, nil // nothing left to modify if there are no groups
+	return nil, ErrNoModifier // nothing left to modify if there are no groups
 }
 
 func (m *GroupsModifier) MarshalJSON() ([]byte, error) {

--- a/flows/actions/modifiers/groups.go
+++ b/flows/actions/modifiers/groups.go
@@ -91,22 +91,27 @@ type groupsModifierEnvelope struct {
 	Modification GroupsModification       `json:"modification" validate:"eq=add|eq=remove"`
 }
 
-func readGroupsModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func readGroupsModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	e := &groupsModifierEnvelope{}
 	if err := utils.UnmarshalAndValidate(data, e); err != nil {
 		return nil, err
 	}
 
-	groups := make([]*flows.Group, len(e.Groups))
-	var err error
-	for g, groupRef := range e.Groups {
-		groups[g], err = assets.Groups().Get(groupRef.UUID)
+	groups := make([]*flows.Group, 0, len(e.Groups))
+	for _, groupRef := range e.Groups {
+		group, err := assets.Groups().Get(groupRef.UUID)
 		if err != nil {
-			return nil, err
+			missing(groupRef)
+		} else {
+			groups = append(groups, group)
 		}
 	}
 
-	return NewGroupsModifier(groups, e.Modification), nil
+	if len(groups) > 0 {
+		return NewGroupsModifier(groups, e.Modification), nil
+	}
+
+	return nil, nil // nothing left to modify if there are no groups
 }
 
 func (m *GroupsModifier) MarshalJSON() ([]byte, error) {

--- a/flows/actions/modifiers/language.go
+++ b/flows/actions/modifiers/language.go
@@ -3,6 +3,7 @@ package modifiers
 import (
 	"encoding/json"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
@@ -45,7 +46,7 @@ var _ flows.Modifier = (*LanguageModifier)(nil)
 // JSON Encoding / Decoding
 //------------------------------------------------------------------------------------------
 
-func readLanguageModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func readLanguageModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	m := &LanguageModifier{}
 	return m, utils.UnmarshalAndValidate(data, m)
 }

--- a/flows/actions/modifiers/name.go
+++ b/flows/actions/modifiers/name.go
@@ -2,6 +2,8 @@ package modifiers
 
 import (
 	"encoding/json"
+
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
@@ -44,7 +46,7 @@ var _ flows.Modifier = (*NameModifier)(nil)
 // JSON Encoding / Decoding
 //------------------------------------------------------------------------------------------
 
-func readNameModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func readNameModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	m := &NameModifier{}
 	return m, utils.UnmarshalAndValidate(data, m)
 }

--- a/flows/actions/modifiers/timezone.go
+++ b/flows/actions/modifiers/timezone.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
@@ -55,7 +56,7 @@ type timezoneModifierEnvelope struct {
 	Timezone string `json:"timezone"`
 }
 
-func readTimezoneModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func readTimezoneModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	e := &timezoneModifierEnvelope{}
 	if err := utils.UnmarshalAndValidate(data, e); err != nil {
 		return nil, err

--- a/flows/actions/modifiers/urn.go
+++ b/flows/actions/modifiers/urn.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/utils"
@@ -56,7 +57,7 @@ var _ flows.Modifier = (*URNModifier)(nil)
 // JSON Encoding / Decoding
 //------------------------------------------------------------------------------------------
 
-func readURNModifier(assets flows.SessionAssets, data json.RawMessage) (flows.Modifier, error) {
+func readURNModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
 	m := &URNModifier{}
 	return m, utils.UnmarshalAndValidate(data, m)
 }


### PR DESCRIPTION
Addresses #475. So now `ReadModifier` returns...

* a modifier and `nil` error if all assets exist
* a "partial" modifier and `nil` error if some assets exist (e.g. we still have some groups in a groups:add modifier) - with missing group assets reported via the callback
* a nil modifier and nil error if no assets exist and there is no partial modifier to return (with all missing assets reported via the callback)

The last one is the one I'm not sure about.. but I think it's consistent with saying "missing assets isn't actually an error case" 

