### PR TITLE
🧯 Fix calling length on a complex object that needs to be reduced to a primitive

### DIFF
--- a/docs/expressions.html
+++ b/docs/expressions.html
@@ -459,10 +459,11 @@
 <p>Returns the length of the passed in text or array.</p>
 <p>length will return an error if it is passed an item which doesn’t have length.</p>
 <div class="sourceCode" id="cb37"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb37-1" title="1">@(length(<span class="st">&quot;Hello&quot;</span>)) → <span class="dv">5</span></a>
-<a class="sourceLine" id="cb37-2" title="2">@(length(<span class="st">&quot;😀😃😄😁&quot;</span>)) → <span class="dv">4</span></a>
-<a class="sourceLine" id="cb37-3" title="3">@(length(array())) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb37-4" title="4">@(length(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>))) → <span class="dv">3</span></a>
-<a class="sourceLine" id="cb37-5" title="5">@(length(<span class="dv">1234</span>)) → ERROR</a></code></pre></div>
+<a class="sourceLine" id="cb37-2" title="2">@(length(contact.fields.gender)) → <span class="dv">4</span></a>
+<a class="sourceLine" id="cb37-3" title="3">@(length(<span class="st">&quot;😀😃😄😁&quot;</span>)) → <span class="dv">4</span></a>
+<a class="sourceLine" id="cb37-4" title="4">@(length(array())) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb37-5" title="5">@(length(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>))) → <span class="dv">3</span></a>
+<a class="sourceLine" id="cb37-6" title="6">@(length(<span class="dv">1234</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:lower"></a></p>
 <h2 id="lowertext">lower(text)</h2>
 <p>Converts <code>text</code> to lowercase.</p>

--- a/docs/functions.json
+++ b/docs/functions.json
@@ -599,6 +599,10 @@
                 "output": "5"
             },
             {
+                "template": "@(length(contact.fields.gender))",
+                "output": "4"
+            },
+            {
                 "template": "@(length(\"😀😃😄😁\"))",
                 "output": "4"
             },

--- a/docs/md/expressions.md
+++ b/docs/md/expressions.md
@@ -750,6 +750,7 @@ length will return an error if it is passed an item which doesn't have length.
 
 ```objectivec
 @(length("Hello")) → 5
+@(length(contact.fields.gender)) → 4
 @(length("😀😃😄😁")) → 4
 @(length(array())) → 0
 @(length(array("a", "b", "c"))) → 3

--- a/excellent/functions/functions.go
+++ b/excellent/functions/functions.go
@@ -1716,14 +1716,14 @@ func FormatURN(env utils.Environment, arg types.XText) types.XValue {
 func Length(env utils.Environment, value types.XValue) types.XValue {
 	// argument must be a value with length
 	lengthable, isLengthable := value.(types.XLengthable)
-	if isLengthable {
+	if isLengthable && !utils.IsNil(lengthable) {
 		return types.NewXNumberFromInt(lengthable.Length())
 	}
 
-	// or reducable to something with length
+	// or reduceable to something with length
 	value = types.Reduce(env, value)
 	lengthable, isLengthable = value.(types.XLengthable)
-	if isLengthable {
+	if isLengthable && !utils.IsNil(lengthable) {
 		return types.NewXNumberFromInt(lengthable.Length())
 	}
 

--- a/excellent/functions/functions.go
+++ b/excellent/functions/functions.go
@@ -1706,6 +1706,7 @@ func FormatURN(env utils.Environment, arg types.XText) types.XValue {
 // length will return an error if it is passed an item which doesn't have length.
 //
 //   @(length("Hello")) -> 5
+//   @(length(contact.fields.gender)) -> 4
 //   @(length("😀😃😄😁")) -> 4
 //   @(length(array())) -> 0
 //   @(length(array("a", "b", "c"))) -> 3
@@ -1715,6 +1716,13 @@ func FormatURN(env utils.Environment, arg types.XText) types.XValue {
 func Length(env utils.Environment, value types.XValue) types.XValue {
 	// argument must be a value with length
 	lengthable, isLengthable := value.(types.XLengthable)
+	if isLengthable {
+		return types.NewXNumberFromInt(lengthable.Length())
+	}
+
+	// or reducable to something with length
+	value = types.Reduce(env, value)
+	lengthable, isLengthable = value.(types.XLengthable)
 	if isLengthable {
 		return types.NewXNumberFromInt(lengthable.Length())
 	}

--- a/excellent/functions/functions_test.go
+++ b/excellent/functions/functions_test.go
@@ -275,6 +275,8 @@ func TestFunctions(t *testing.T) {
 		{"length", dmy, []types.XValue{xs("😁😁")}, xi(2)},
 		{"length", dmy, []types.XValue{types.NewXArray(xs("hello"))}, xi(1)},
 		{"length", dmy, []types.XValue{types.NewXArray()}, xi(0)},
+		{"length", dmy, []types.XValue{nil}, ERROR},
+		{"length", dmy, []types.XValue{types.XArray(nil)}, ERROR},
 		{"length", dmy, []types.XValue{xi(1234)}, ERROR},
 		{"length", dmy, []types.XValue{ERROR}, ERROR},
 		{"length", dmy, []types.XValue{}, ERROR},


### PR DESCRIPTION
e.g. `contact.fields.gender` resolves to a `FieldValue` object which has no intrinsic length - so it needs to be first reduced to a primitive (it's `.value`)