### PR TITLE
🗺️ Store a map of result keys to result names in a validated flow definition

### DIFF
--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -32,7 +32,7 @@ type flow struct {
 	// optional properties not used by engine itself
 	ui           flows.UI
 	dependencies *dependencies
-	resultNames  []string
+	results      resultsInfo
 
 	// internal state
 	nodeMap   map[flows.NodeUUID]flows.Node
@@ -123,7 +123,7 @@ func (f *flow) validate(sa flows.SessionAssets, recursive bool) error {
 
 	f.validated = true
 	f.dependencies = deps
-	f.resultNames = f.ExtractResultNames()
+	f.results = newResultsInfo(f.ExtractResultNames())
 
 	if recursive {
 		// go validate any flow dependencies
@@ -275,7 +275,7 @@ type validatedFlowEnvelope struct {
 	*flowEnvelope
 
 	Dependencies *dependencies `json:"_dependencies"`
-	ResultNames  []string      `json:"_result_names"`
+	Results      resultsInfo   `json:"_results"`
 }
 
 // IsSpecVersionSupported determines if we can read the given flow version
@@ -342,7 +342,7 @@ func (f *flow) MarshalJSON() ([]byte, error) {
 		return json.Marshal(&validatedFlowEnvelope{
 			flowEnvelope: e,
 			Dependencies: f.dependencies,
-			ResultNames:  f.resultNames,
+			Results:      f.results,
 		})
 	}
 

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -227,7 +227,11 @@ func TestNewFlow(t *testing.T) {
 			map[string]string{"uuid": "3f65d88a-95dc-4140-9451-943e94e06fea", "name": "Spam"},
 		},
 	}
-	flowAsMap[`_results`] = map[string][]string{"response_1": {"Response 1"}}
+	flowAsMap[`_results`] = map[string]interface{}{
+		"response_1": map[string]interface{}{
+			"names": []string{"Response 1"},
+		},
+	}
 
 	// now when we marshal to JSON, those should be included
 	newFlowDef, err := json.Marshal(flowAsMap)
@@ -293,9 +297,9 @@ func TestValidateFlow(t *testing.T) {
 
 	resultsJSON, _ := json.Marshal(flowAsMap.(map[string]interface{})["_results"])
 	test.AssertEqualJSON(t, []byte(`{
-		"name": [
-	        "Name"
-	    ]
+		"name": {
+	        "names": ["Name"]
+	    }
 	}`), resultsJSON, "results mismatch")
 }
 

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -227,7 +227,7 @@ func TestNewFlow(t *testing.T) {
 			map[string]string{"uuid": "3f65d88a-95dc-4140-9451-943e94e06fea", "name": "Spam"},
 		},
 	}
-	flowAsMap[`_result_names`] = []string{"Response 1"}
+	flowAsMap[`_results`] = map[string][]string{"response_1": {"Response 1"}}
 
 	// now when we marshal to JSON, those should be included
 	newFlowDef, err := json.Marshal(flowAsMap)
@@ -260,7 +260,7 @@ func TestValidateEmptyFlow(t *testing.T) {
 		"localization": {},
 		"nodes": [],
 		"_dependencies": {},
-		"_result_names": []
+		"_results": {}
 	}`), marshaled, "flow definition mismatch")
 }
 

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -264,6 +264,41 @@ func TestValidateEmptyFlow(t *testing.T) {
 	}`), marshaled, "flow definition mismatch")
 }
 
+func TestValidateFlow(t *testing.T) {
+	sa, err := test.LoadSessionAssets("../../test/testdata/flows/brochure.json")
+	require.NoError(t, err)
+
+	flow, err := sa.Flows().Get(assets.FlowUUID("25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0"))
+	require.NoError(t, err)
+
+	err = flow.Validate(sa)
+	assert.NoError(t, err)
+
+	marshaled, err := json.Marshal(flow)
+	require.NoError(t, err)
+
+	flowAsMap, err := utils.JSONDecodeGeneric(marshaled)
+	require.NoError(t, err)
+
+	dependenciesJSON, _ := json.Marshal(flowAsMap.(map[string]interface{})["_dependencies"])
+	test.AssertEqualJSON(t, []byte(`{
+		"groups": [
+			{
+				"name": "Registered Users",
+				"uuid": "7be2f40b-38a0-4b06-9e6d-522dca592cc8"
+			}
+
+		]
+	}`), dependenciesJSON, "dependencies mismatch")
+
+	resultsJSON, _ := json.Marshal(flowAsMap.(map[string]interface{})["_results"])
+	test.AssertEqualJSON(t, []byte(`{
+		"name": [
+	        "Name"
+	    ]
+	}`), resultsJSON, "results mismatch")
+}
+
 func TestReadFlow(t *testing.T) {
 	// try reading something without a flow header
 	_, err := definition.ReadFlow([]byte(`{"nodes":[]}`))

--- a/flows/definition/results_info.go
+++ b/flows/definition/results_info.go
@@ -4,18 +4,28 @@ import (
 	"github.com/nyaruka/goflow/utils"
 )
 
+type resultInfo struct {
+	Names []string `json:"names"`
+}
+
 // holds information about what results a flow can generate, as a map of result
 // keys to slices of result names, e.g.
 //
-//  { "age": ["Age"], "response_1": ["Response 1", "Response-1"] }
+//  { "age": {"names": ["Age"]}, "response_1": {"names": ["Response 1", "Response-1"]} }
 //
-type resultsInfo map[string][]string
+type resultsInfo map[string]*resultInfo
 
 func newResultsInfo(names []string) resultsInfo {
 	r := make(resultsInfo)
 	for _, name := range names {
 		key := utils.Snakify(name)
-		r[key] = append(r[key], name)
+		info, exists := r[key]
+		if !exists {
+			info = &resultInfo{}
+			r[key] = info
+		}
+
+		info.Names = append(info.Names, name)
 	}
 	return r
 }

--- a/flows/definition/results_info.go
+++ b/flows/definition/results_info.go
@@ -1,0 +1,21 @@
+package definition
+
+import (
+	"github.com/nyaruka/goflow/utils"
+)
+
+// holds information about what results a flow can generate, as a map of result
+// keys to slices of result names, e.g.
+//
+//  { "age": ["Age"], "response_1": ["Response 1", "Response-1"] }
+//
+type resultsInfo map[string][]string
+
+func newResultsInfo(names []string) resultsInfo {
+	r := make(resultsInfo)
+	for _, name := range names {
+		key := utils.Snakify(name)
+		r[key] = append(r[key], name)
+	}
+	return r
+}

--- a/flows/definition/results_info_test.go
+++ b/flows/definition/results_info_test.go
@@ -1,0 +1,13 @@
+package definition
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResultsInfo(t *testing.T) {
+	r := newResultsInfo([]string{"Age", "Response 1", "Response-1"})
+
+	assert.Equal(t, resultsInfo(map[string][]string{"age": {"Age"}, "response_1": {"Response 1", "Response-1"}}), r)
+}

--- a/flows/definition/results_info_test.go
+++ b/flows/definition/results_info_test.go
@@ -9,5 +9,8 @@ import (
 func TestResultsInfo(t *testing.T) {
 	r := newResultsInfo([]string{"Age", "Response 1", "Response-1"})
 
-	assert.Equal(t, resultsInfo(map[string][]string{"age": {"Age"}, "response_1": {"Response 1", "Response-1"}}), r)
+	assert.Equal(t, resultsInfo(map[string]*resultInfo{
+		"age":        {Names: []string{"Age"}},
+		"response_1": {Names: []string{"Response 1", "Response-1"}},
+	}), r)
 }

--- a/test/testdata/flows/brochure.json
+++ b/test/testdata/flows/brochure.json
@@ -2,7 +2,7 @@
     "flows": [
         {
             "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
-            "name": "Registration Flow",
+            "name": "Brochure",
             "spec_version": "12.0",
             "language": "eng",
             "type": "messaging",

--- a/test/testdata/flows/brochure_test.json
+++ b/test/testdata/flows/brochure_test.json
@@ -89,7 +89,7 @@
                         "exited_on": null,
                         "expires_on": "2018-07-06T12:30:01.123456789Z",
                         "flow": {
-                            "name": "Registration Flow",
+                            "name": "Brochure",
                             "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0"
                         },
                         "modified_on": "2018-07-06T12:30:10.123456789Z",
@@ -150,7 +150,7 @@
                         "timezone": "America/Los_Angeles"
                     },
                     "flow": {
-                        "name": "Registration",
+                        "name": "Brochure",
                         "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0"
                     },
                     "triggered_on": "2000-01-01T00:00:00Z",
@@ -358,7 +358,7 @@
                         "exited_on": "2018-07-06T12:30:27.123456789Z",
                         "expires_on": "2018-07-06T12:30:11.123456789Z",
                         "flow": {
-                            "name": "Registration Flow",
+                            "name": "Brochure",
                             "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0"
                         },
                         "modified_on": "2018-07-06T12:30:27.123456789Z",
@@ -436,7 +436,7 @@
                         "timezone": "America/Los_Angeles"
                     },
                     "flow": {
-                        "name": "Registration",
+                        "name": "Brochure",
                         "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0"
                     },
                     "triggered_on": "2000-01-01T00:00:00Z",
@@ -494,7 +494,7 @@
             "timezone": "America/Los_Angeles"
         },
         "flow": {
-            "name": "Registration",
+            "name": "Brochure",
             "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0"
         },
         "triggered_on": "2000-01-01T00:00:00.000000000-00:00",


### PR DESCRIPTION
Upgrades the list of result names returned from flow validation to... a dict of result keys to the result names that map to that key.

I took quick look at the UReport code to see what it needs and whether if this sort of thing was included on the flows.json API endpoint it would be sufficient - but it's using things like rule UUIDs... so I'm thinking UReport might need to continue fetching flow definitions.

@norkans7 @nicpottier 