### PR TITLE
🤷 Allow flow validation without assets

### DIFF
--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -40,6 +40,10 @@ var invalidFlows = []struct {
 		"flow_with_invalid_case_exit.json",
 		"validation failed for node[uuid=a58be63b-907d-4a1a-856b-0bb5579d7507]: validation failed for router: case exit 37d8813f-1402-4ad2-9cc2-e9054a96525b is not a valid exit",
 	},
+	{
+		"flow_with_missing_asset.json",
+		"missing dependencies: group[uuid=7be2f40b-38a0-4b06-9e6d-522dca592cc8,name=Registered]",
+	},
 }
 
 func TestFlowValidation(t *testing.T) {

--- a/flows/definition/testdata/flow_with_missing_asset.json
+++ b/flows/definition/testdata/flow_with_missing_asset.json
@@ -1,0 +1,88 @@
+{
+    "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+    "name": "Brochure",
+    "spec_version": "12.0",
+    "language": "eng",
+    "type": "messaging",
+    "nodes": [
+        {
+            "uuid": "32bc60ad-5c86-465e-a6b8-049c44ecce49",
+            "actions": [
+                {
+                    "type": "send_msg",
+                    "uuid": "9d9290a7-3713-4c22-8821-4af0a64c0821",
+                    "text": "Hi! What is your name?"
+                }
+            ],
+            "exits": [
+                {
+                    "uuid": "2d481ce6-efcf-4898-a825-f76208e32f2a",
+                    "destination_node_uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82"
+                }
+            ]
+        },
+        {
+            "uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82",
+            "wait": {
+                "type": "msg",
+                "timeout": 600
+            },
+            "router": {
+                "type": "switch",
+                "default_exit_uuid": "0680b01f-ba0b-48f4-a688-d2f963130126",
+                "result_name": "Name",
+                "operand": "@input",
+                "cases": [
+                    {
+                        "uuid": "5d6abc80-39e7-4620-9988-a2447bffe526",
+                        "type": "has_text",
+                        "exit_uuid": "37d8813f-1402-4ad2-9cc2-e9054a96525b"
+                    }
+                ]
+            },
+            "exits": [
+                {
+                    "uuid": "37d8813f-1402-4ad2-9cc2-e9054a96525b",
+                    "name": "Not Empty",
+                    "destination_node_uuid": "7acb54fd-0db0-40b9-970b-93f7bfb4277b"
+                },
+                {
+                    "uuid": "0680b01f-ba0b-48f4-a688-d2f963130126",
+                    "name": "Other",
+                    "destination_node_uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82"
+                }
+            ]
+        },
+        {
+            "uuid": "7acb54fd-0db0-40b9-970b-93f7bfb4277b",
+            "exits": [
+                {
+                    "uuid": "388bbce3-8079-4573-922f-8dea469d93f3",
+                    "destination_node_uuid": null
+                }
+            ],
+            "actions": [
+                {
+                    "uuid": "455ba297-f6d2-45e6-bf3e-c1ef028b55ae",
+                    "type": "set_contact_name",
+                    "name": "@input.text"
+                },
+                {
+                    "uuid": "b3fa763e-474b-49df-b4d6-15e86507668f",
+                    "type": "add_contact_groups",
+                    "groups": [
+                        {
+                            "uuid": "7be2f40b-38a0-4b06-9e6d-522dca592cc8",
+                            "name": "Registered"
+                        }
+                    ]
+                },
+                {
+                    "uuid": "605e3486-503d-481c-94f7-cd553f196a8a",
+                    "type": "send_msg",
+                    "text": "Great, you are @contact.name, thanks for joining!"
+                }
+            ]
+        }
+    ]
+}

--- a/test/assets.go
+++ b/test/assets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/goflow/utils"
 )
 
+// LoadSessionAssets loads a session assets instance from a static JSON file
 func LoadSessionAssets(path string) (flows.SessionAssets, error) {
 	assetsJSON, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/test/testdata/flows/brochure.json
+++ b/test/testdata/flows/brochure.json
@@ -75,7 +75,7 @@
                             "groups": [
                                 {
                                     "uuid": "7be2f40b-38a0-4b06-9e6d-522dca592cc8",
-                                    "name": "Registered Users"
+                                    "name": "Registered"
                                 }
                             ]
                         },


### PR DESCRIPTION
In RP we call `Flow.update` when we import a flow definition... so that happens a lot currently in our unit tests. That method should call `/mr/flow/validate` to validate the flow and get back dependencies and result names... but that can't work from tests because mailroom can't read the assets from the database cuz they only exist in the unit test transaction.

Am thinking we make it so `org_id` is optional on the mailroom /mr/flow/validate endpoint so `Flow.update` can validate a flow in a unit test... the only difference being we won't have validated that it's asset dependencies actually exist.

This seems preferable to always mocking the calls to `/mr/flow/validate` because we'll still get the correct dependencies and result names. We can test the specific case of an asset dependency not existing in a specific unit test.

This would make mailroom a dependency of our unit tests.. so maybe I stick `@skip_if_no_mailroom` on test classes like `FlowTest` and `FlowsTest`