### PR TITLE
🗜️ Merge result infos by key so caller doesn't have to know how to do that

### DIFF
--- a/flows/definition/results_info.go
+++ b/flows/definition/results_info.go
@@ -10,10 +10,19 @@ type resultInfo struct {
 	Key  string `json:"key"`
 }
 
+// creates a set of result infos with unique keys
 func resultInfosFromNames(names []string) []resultInfo {
-	r := make([]resultInfo, len(names))
-	for n, name := range names {
-		r[n] = resultInfo{name, utils.Snakify(name)}
+	keysSeen := make(map[string]bool)
+
+	r := make([]resultInfo, 0, len(names))
+
+	for _, name := range names {
+		key := utils.Snakify(name)
+
+		if _, seen := keysSeen[key]; !seen {
+			r = append(r, resultInfo{name, key})
+			keysSeen[key] = true
+		}
 	}
 	return r
 }

--- a/flows/definition/results_info_test.go
+++ b/flows/definition/results_info_test.go
@@ -1,0 +1,15 @@
+package definition
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResultInfosFromNames(t *testing.T) {
+	assert.Equal(t, []resultInfo{}, resultInfosFromNames(nil))
+	assert.Equal(t, []resultInfo{
+		{Name: "Response 1", Key: "response_1"},
+		{Name: "Favorite Beer", Key: "favorite_beer"},
+	}, resultInfosFromNames([]string{"Response 1", "Response-1", "Favorite Beer"}))
+}


### PR DESCRIPTION
Want to make it so caller doesn't need to know how to slug keys and then figure out which result names are actually unique results. 