### PR TITLE
Split length() into count() and text_length()

### DIFF
--- a/docs/expressions.html
+++ b/docs/expressions.html
@@ -42,7 +42,7 @@
 <p>Is an array of items.</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb1-1" title="1">@(array(<span class="dv">1</span>, <span class="st">&quot;x&quot;</span>, true)) → [<span class="dv">1</span>, x, true]</a>
 <a class="sourceLine" id="cb1-2" title="2">@(array(<span class="dv">1</span>, <span class="st">&quot;x&quot;</span>, true)[<span class="dv">1</span>]) → x</a>
-<a class="sourceLine" id="cb1-3" title="3">@(length(array(<span class="dv">1</span>, <span class="st">&quot;x&quot;</span>, true))) → <span class="dv">3</span></a>
+<a class="sourceLine" id="cb1-3" title="3">@(count(array(<span class="dv">1</span>, <span class="st">&quot;x&quot;</span>, true))) → <span class="dv">3</span></a>
 <a class="sourceLine" id="cb1-4" title="4">@(json(array(<span class="dv">1</span>, <span class="st">&quot;x&quot;</span>, true))) → [<span class="dv">1</span>,<span class="st">&quot;x&quot;</span>,true]</a></code></pre></div>
 <p><a name="type:boolean"></a></p>
 <h2 id="boolean">Boolean</h2>
@@ -69,7 +69,7 @@
 <div class="sourceCode" id="cb5"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb5-1" title="1">@(dict(<span class="st">&quot;foo&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;x&quot;</span>)) → {bar: x, foo: <span class="dv">1</span>}</a>
 <a class="sourceLine" id="cb5-2" title="2">@(dict(<span class="st">&quot;foo&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;x&quot;</span>).bar) → x</a>
 <a class="sourceLine" id="cb5-3" title="3">@(dict(<span class="st">&quot;foo&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;x&quot;</span>)[<span class="st">&quot;bar&quot;</span>]) → x</a>
-<a class="sourceLine" id="cb5-4" title="4">@(length(dict(<span class="st">&quot;foo&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;x&quot;</span>))) → <span class="dv">2</span></a>
+<a class="sourceLine" id="cb5-4" title="4">@(count(dict(<span class="st">&quot;foo&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;x&quot;</span>))) → <span class="dv">2</span></a>
 <a class="sourceLine" id="cb5-5" title="5">@(json(dict(<span class="st">&quot;foo&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;x&quot;</span>))) → {<span class="st">&quot;bar&quot;</span>:<span class="st">&quot;x&quot;</span>,<span class="st">&quot;foo&quot;</span>:<span class="dv">1</span>}</a></code></pre></div>
 <p><a name="type:function"></a></p>
 <h2 id="function">Function</h2>
@@ -88,7 +88,7 @@
 <h2 id="text">Text</h2>
 <p>Is a string of characters.</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb8-1" title="1">@(<span class="st">&quot;abc&quot;</span>) → abc</a>
-<a class="sourceLine" id="cb8-2" title="2">@(length(<span class="st">&quot;abc&quot;</span>)) → <span class="dv">3</span></a>
+<a class="sourceLine" id="cb8-2" title="2">@(text_length(<span class="st">&quot;abc&quot;</span>)) → <span class="dv">3</span></a>
 <a class="sourceLine" id="cb8-3" title="3">@(upper(<span class="st">&quot;abc&quot;</span>)) → ABC</a>
 <a class="sourceLine" id="cb8-4" title="4">@(json(<span class="st">&quot;abc&quot;</span>)) → <span class="st">&quot;abc&quot;</span></a></code></pre></div>
 <p><a name="type:time"></a></p>
@@ -191,8 +191,8 @@
 <p>Takes multiple <code>values</code> and returns them as an array.</p>
 <div class="sourceCode" id="cb25"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb25-1" title="1">@(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="dv">356</span>)[<span class="dv">1</span>]) → b</a>
 <a class="sourceLine" id="cb25-2" title="2">@(join(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>), <span class="st">&quot;|&quot;</span>)) → a|b|c</a>
-<a class="sourceLine" id="cb25-3" title="3">@(length(array())) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb25-4" title="4">@(length(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>))) → <span class="dv">2</span></a></code></pre></div>
+<a class="sourceLine" id="cb25-3" title="3">@(count(array())) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb25-4" title="4">@(count(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>))) → <span class="dv">2</span></a></code></pre></div>
 <p><a name="function:attachment_parts"></a></p>
 <h2 id="attachment_partsattachment">attachment_parts(attachment)</h2>
 <p>Parses an attachment into its different parts</p>
@@ -226,97 +226,105 @@
 <a class="sourceLine" id="cb30-4" title="4">@(code(<span class="st">&quot;15&quot;</span>)) → <span class="dv">49</span></a>
 <a class="sourceLine" id="cb30-5" title="5">@(code(<span class="dv">15</span>)) → <span class="dv">49</span></a>
 <a class="sourceLine" id="cb30-6" title="6">@(code(<span class="st">&quot;&quot;</span>)) → ERROR</a></code></pre></div>
+<p><a name="function:count"></a></p>
+<h2 id="countvalue">count(value)</h2>
+<p>Returns the number of items in the given array or dict.</p>
+<p>It will return an error if it is passed an item which isn’t countable.</p>
+<div class="sourceCode" id="cb31"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb31-1" title="1">@(count(contact.fields)) → <span class="dv">5</span></a>
+<a class="sourceLine" id="cb31-2" title="2">@(count(array())) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb31-3" title="3">@(count(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>))) → <span class="dv">3</span></a>
+<a class="sourceLine" id="cb31-4" title="4">@(count(<span class="dv">1234</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:date"></a></p>
 <h2 id="datevalue">date(value)</h2>
 <p>Tries to convert <code>value</code> to a date.</p>
 <p>If it is text then it will be parsed into a date using the default date format. An error is returned if the value can’t be converted.</p>
-<div class="sourceCode" id="cb31"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb31-1" title="1">@(date(<span class="st">&quot;1979-07-18&quot;</span>)) → <span class="dv">1979-07-18</span></a>
-<a class="sourceLine" id="cb31-2" title="2">@(date(<span class="st">&quot;1979-07-18T10:30:45.123456Z&quot;</span>)) → <span class="dv">1979-07-18</span></a>
-<a class="sourceLine" id="cb31-3" title="3">@(date(<span class="st">&quot;10/05/2010&quot;</span>)) → <span class="dv">2010-05-10</span></a>
-<a class="sourceLine" id="cb31-4" title="4">@(date(<span class="st">&quot;NOT DATE&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb32"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb32-1" title="1">@(date(<span class="st">&quot;1979-07-18&quot;</span>)) → <span class="dv">1979-07-18</span></a>
+<a class="sourceLine" id="cb32-2" title="2">@(date(<span class="st">&quot;1979-07-18T10:30:45.123456Z&quot;</span>)) → <span class="dv">1979-07-18</span></a>
+<a class="sourceLine" id="cb32-3" title="3">@(date(<span class="st">&quot;10/05/2010&quot;</span>)) → <span class="dv">2010-05-10</span></a>
+<a class="sourceLine" id="cb32-4" title="4">@(date(<span class="st">&quot;NOT DATE&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:date_from_parts"></a></p>
 <h2 id="date_from_partsyear-month-day">date_from_parts(year, month, day)</h2>
 <p>Creates a date from <code>year</code>, <code>month</code> and <code>day</code>.</p>
-<div class="sourceCode" id="cb32"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb32-1" title="1">@(date_from_parts(<span class="dv">2017</span>, <span class="dv">1</span>, <span class="dv">15</span>)) → <span class="dv">2017-01-15</span></a>
-<a class="sourceLine" id="cb32-2" title="2">@(date_from_parts(<span class="dv">2017</span>, <span class="dv">2</span>, <span class="dv">31</span>)) → <span class="dv">2017-03-03</span></a>
-<a class="sourceLine" id="cb32-3" title="3">@(date_from_parts(<span class="dv">2017</span>, <span class="dv">13</span>, <span class="dv">15</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb33-1" title="1">@(date_from_parts(<span class="dv">2017</span>, <span class="dv">1</span>, <span class="dv">15</span>)) → <span class="dv">2017-01-15</span></a>
+<a class="sourceLine" id="cb33-2" title="2">@(date_from_parts(<span class="dv">2017</span>, <span class="dv">2</span>, <span class="dv">31</span>)) → <span class="dv">2017-03-03</span></a>
+<a class="sourceLine" id="cb33-3" title="3">@(date_from_parts(<span class="dv">2017</span>, <span class="dv">13</span>, <span class="dv">15</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:datetime"></a></p>
 <h2 id="datetimevalue">datetime(value)</h2>
 <p>Tries to convert <code>value</code> to a datetime.</p>
 <p>If it is text then it will be parsed into a datetime using the default date and time formats. An error is returned if the value can’t be converted.</p>
-<div class="sourceCode" id="cb33"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb33-1" title="1">@(datetime(<span class="st">&quot;1979-07-18&quot;</span>)) → <span class="dv">1979-07</span>-18T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb33-2" title="2">@(datetime(<span class="st">&quot;1979-07-18T10:30:45.123456Z&quot;</span>)) → <span class="dv">1979-07</span>-18T10:<span class="dv">30</span>:<span class="fl">45.123456</span>Z</a>
-<a class="sourceLine" id="cb33-3" title="3">@(datetime(<span class="st">&quot;10/05/2010&quot;</span>)) → <span class="dv">2010-05</span>-10T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb33-4" title="4">@(datetime(<span class="st">&quot;NOT DATE&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb34"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb34-1" title="1">@(datetime(<span class="st">&quot;1979-07-18&quot;</span>)) → <span class="dv">1979-07</span>-18T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb34-2" title="2">@(datetime(<span class="st">&quot;1979-07-18T10:30:45.123456Z&quot;</span>)) → <span class="dv">1979-07</span>-18T10:<span class="dv">30</span>:<span class="fl">45.123456</span>Z</a>
+<a class="sourceLine" id="cb34-3" title="3">@(datetime(<span class="st">&quot;10/05/2010&quot;</span>)) → <span class="dv">2010-05</span>-10T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb34-4" title="4">@(datetime(<span class="st">&quot;NOT DATE&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:datetime_add"></a></p>
 <h2 id="datetime_adddate-offset-unit">datetime_add(date, offset, unit)</h2>
 <p>Calculates the date value arrived at by adding <code>offset</code> number of <code>unit</code> to the <code>date</code></p>
 <p>Valid durations are “Y” for years, “M” for months, “W” for weeks, “D” for days, “h” for hour, “m” for minutes, “s” for seconds</p>
-<div class="sourceCode" id="cb34"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb34-1" title="1">@(datetime_add(<span class="st">&quot;2017-01-15&quot;</span>, <span class="dv">5</span>, <span class="st">&quot;D&quot;</span>)) → <span class="dv">2017-01</span>-20T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb34-2" title="2">@(datetime_add(<span class="st">&quot;2017-01-15 10:45&quot;</span>, <span class="dv">30</span>, <span class="st">&quot;m&quot;</span>)) → <span class="dv">2017-01</span>-15T11:<span class="dv">15</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a></code></pre></div>
+<div class="sourceCode" id="cb35"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb35-1" title="1">@(datetime_add(<span class="st">&quot;2017-01-15&quot;</span>, <span class="dv">5</span>, <span class="st">&quot;D&quot;</span>)) → <span class="dv">2017-01</span>-20T00:<span class="dv">00</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb35-2" title="2">@(datetime_add(<span class="st">&quot;2017-01-15 10:45&quot;</span>, <span class="dv">30</span>, <span class="st">&quot;m&quot;</span>)) → <span class="dv">2017-01</span>-15T11:<span class="dv">15</span>:<span class="fl">00.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a></code></pre></div>
 <p><a name="function:datetime_diff"></a></p>
 <h2 id="datetime_diffdate1-date2-unit">datetime_diff(date1, date2, unit)</h2>
 <p>Returns the duration between <code>date1</code> and <code>date2</code> in the <code>unit</code> specified.</p>
 <p>Valid durations are “Y” for years, “M” for months, “W” for weeks, “D” for days, “h” for hour, “m” for minutes, “s” for seconds.</p>
-<div class="sourceCode" id="cb35"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb35-1" title="1">@(datetime_diff(<span class="st">&quot;2017-01-15&quot;</span>, <span class="st">&quot;2017-01-17&quot;</span>, <span class="st">&quot;D&quot;</span>)) → <span class="dv">2</span></a>
-<a class="sourceLine" id="cb35-2" title="2">@(datetime_diff(<span class="st">&quot;2017-01-15&quot;</span>, <span class="st">&quot;2017-05-15&quot;</span>, <span class="st">&quot;W&quot;</span>)) → <span class="dv">17</span></a>
-<a class="sourceLine" id="cb35-3" title="3">@(datetime_diff(<span class="st">&quot;2017-01-15&quot;</span>, <span class="st">&quot;2017-05-15&quot;</span>, <span class="st">&quot;M&quot;</span>)) → <span class="dv">4</span></a>
-<a class="sourceLine" id="cb35-4" title="4">@(datetime_diff(<span class="st">&quot;2017-01-17 10:50&quot;</span>, <span class="st">&quot;2017-01-17 12:30&quot;</span>, <span class="st">&quot;h&quot;</span>)) → <span class="dv">1</span></a>
-<a class="sourceLine" id="cb35-5" title="5">@(datetime_diff(<span class="st">&quot;2017-01-17&quot;</span>, <span class="st">&quot;2015-12-17&quot;</span>, <span class="st">&quot;Y&quot;</span>)) → <span class="dv">-2</span></a></code></pre></div>
+<div class="sourceCode" id="cb36"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb36-1" title="1">@(datetime_diff(<span class="st">&quot;2017-01-15&quot;</span>, <span class="st">&quot;2017-01-17&quot;</span>, <span class="st">&quot;D&quot;</span>)) → <span class="dv">2</span></a>
+<a class="sourceLine" id="cb36-2" title="2">@(datetime_diff(<span class="st">&quot;2017-01-15&quot;</span>, <span class="st">&quot;2017-05-15&quot;</span>, <span class="st">&quot;W&quot;</span>)) → <span class="dv">17</span></a>
+<a class="sourceLine" id="cb36-3" title="3">@(datetime_diff(<span class="st">&quot;2017-01-15&quot;</span>, <span class="st">&quot;2017-05-15&quot;</span>, <span class="st">&quot;M&quot;</span>)) → <span class="dv">4</span></a>
+<a class="sourceLine" id="cb36-4" title="4">@(datetime_diff(<span class="st">&quot;2017-01-17 10:50&quot;</span>, <span class="st">&quot;2017-01-17 12:30&quot;</span>, <span class="st">&quot;h&quot;</span>)) → <span class="dv">1</span></a>
+<a class="sourceLine" id="cb36-5" title="5">@(datetime_diff(<span class="st">&quot;2017-01-17&quot;</span>, <span class="st">&quot;2015-12-17&quot;</span>, <span class="st">&quot;Y&quot;</span>)) → <span class="dv">-2</span></a></code></pre></div>
 <p><a name="function:datetime_from_epoch"></a></p>
 <h2 id="datetime_from_epochseconds">datetime_from_epoch(seconds)</h2>
 <p>Converts the UNIX epoch time <code>seconds</code> into a new date.</p>
-<div class="sourceCode" id="cb36"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb36-1" title="1">@(datetime_from_epoch(<span class="dv">1497286619</span>)) → <span class="dv">2017-06</span>-12T11:<span class="dv">56</span>:<span class="fl">59.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb36-2" title="2">@(datetime_from_epoch(<span class="fl">1497286619.123456</span>)) → <span class="dv">2017-06</span>-12T11:<span class="dv">56</span>:<span class="fl">59.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a></code></pre></div>
+<div class="sourceCode" id="cb37"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb37-1" title="1">@(datetime_from_epoch(<span class="dv">1497286619</span>)) → <span class="dv">2017-06</span>-12T11:<span class="dv">56</span>:<span class="fl">59.000000</span><span class="dv">-05</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb37-2" title="2">@(datetime_from_epoch(<span class="fl">1497286619.123456</span>)) → <span class="dv">2017-06</span>-12T11:<span class="dv">56</span>:<span class="fl">59.123456</span><span class="dv">-05</span>:<span class="dv">00</span></a></code></pre></div>
 <p><a name="function:default"></a></p>
 <h2 id="defaultvalue-default">default(value, default)</h2>
 <p>Returns <code>value</code> if is not empty or an error, otherwise it returns <code>default</code>.</p>
-<div class="sourceCode" id="cb37"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb37-1" title="1">@(<span class="kw">default</span>(undeclared.var, <span class="st">&quot;default_value&quot;</span>)) → default_value</a>
-<a class="sourceLine" id="cb37-2" title="2">@(<span class="kw">default</span>(<span class="st">&quot;10&quot;</span>, <span class="st">&quot;20&quot;</span>)) → <span class="dv">10</span></a>
-<a class="sourceLine" id="cb37-3" title="3">@(<span class="kw">default</span>(<span class="st">&quot;&quot;</span>, <span class="st">&quot;value&quot;</span>)) → value</a>
-<a class="sourceLine" id="cb37-4" title="4">@(<span class="kw">default</span>(array(<span class="dv">1</span>, <span class="dv">2</span>), <span class="st">&quot;value&quot;</span>)) → [<span class="dv">1</span>, <span class="dv">2</span>]</a>
-<a class="sourceLine" id="cb37-5" title="5">@(<span class="kw">default</span>(array(), <span class="st">&quot;value&quot;</span>)) → value</a>
-<a class="sourceLine" id="cb37-6" title="6">@(<span class="kw">default</span>(datetime(<span class="st">&quot;invalid-date&quot;</span>), <span class="st">&quot;today&quot;</span>)) → today</a>
-<a class="sourceLine" id="cb37-7" title="7">@(<span class="kw">default</span>(format_urn(<span class="st">&quot;invalid-urn&quot;</span>), <span class="st">&quot;ok&quot;</span>)) → ok</a></code></pre></div>
+<div class="sourceCode" id="cb38"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb38-1" title="1">@(<span class="kw">default</span>(undeclared.var, <span class="st">&quot;default_value&quot;</span>)) → default_value</a>
+<a class="sourceLine" id="cb38-2" title="2">@(<span class="kw">default</span>(<span class="st">&quot;10&quot;</span>, <span class="st">&quot;20&quot;</span>)) → <span class="dv">10</span></a>
+<a class="sourceLine" id="cb38-3" title="3">@(<span class="kw">default</span>(<span class="st">&quot;&quot;</span>, <span class="st">&quot;value&quot;</span>)) → value</a>
+<a class="sourceLine" id="cb38-4" title="4">@(<span class="kw">default</span>(array(<span class="dv">1</span>, <span class="dv">2</span>), <span class="st">&quot;value&quot;</span>)) → [<span class="dv">1</span>, <span class="dv">2</span>]</a>
+<a class="sourceLine" id="cb38-5" title="5">@(<span class="kw">default</span>(array(), <span class="st">&quot;value&quot;</span>)) → value</a>
+<a class="sourceLine" id="cb38-6" title="6">@(<span class="kw">default</span>(datetime(<span class="st">&quot;invalid-date&quot;</span>), <span class="st">&quot;today&quot;</span>)) → today</a>
+<a class="sourceLine" id="cb38-7" title="7">@(<span class="kw">default</span>(format_urn(<span class="st">&quot;invalid-urn&quot;</span>), <span class="st">&quot;ok&quot;</span>)) → ok</a></code></pre></div>
 <p><a name="function:dict"></a></p>
 <h2 id="dictpairs">dict(pairs…)</h2>
 <p>Takes key value pairs and returns them as an dict.</p>
-<div class="sourceCode" id="cb38"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb38-1" title="1">@(dict()) → {}</a>
-<a class="sourceLine" id="cb38-2" title="2">@(dict(<span class="st">&quot;a&quot;</span>, <span class="dv">123</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;hello&quot;</span>)) → {a: <span class="dv">123</span>, b: hello}</a>
-<a class="sourceLine" id="cb38-3" title="3">@(dict(<span class="st">&quot;a&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb39"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb39-1" title="1">@(dict()) → {}</a>
+<a class="sourceLine" id="cb39-2" title="2">@(dict(<span class="st">&quot;a&quot;</span>, <span class="dv">123</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;hello&quot;</span>)) → {a: <span class="dv">123</span>, b: hello}</a>
+<a class="sourceLine" id="cb39-3" title="3">@(dict(<span class="st">&quot;a&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:epoch"></a></p>
 <h2 id="epochdate">epoch(date)</h2>
 <p>Converts <code>date</code> to a UNIX epoch time.</p>
 <p>The returned number can contain fractional seconds.</p>
-<div class="sourceCode" id="cb39"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb39-1" title="1">@(epoch(<span class="st">&quot;2017-06-12T16:56:59.000000Z&quot;</span>)) → <span class="dv">1497286619</span></a>
-<a class="sourceLine" id="cb39-2" title="2">@(epoch(<span class="st">&quot;2017-06-12T18:56:59.000000+02:00&quot;</span>)) → <span class="dv">1497286619</span></a>
-<a class="sourceLine" id="cb39-3" title="3">@(epoch(<span class="st">&quot;2017-06-12T16:56:59.123456Z&quot;</span>)) → <span class="fl">1497286619.123456</span></a>
-<a class="sourceLine" id="cb39-4" title="4">@(round_down(epoch(<span class="st">&quot;2017-06-12T16:56:59.123456Z&quot;</span>))) → <span class="dv">1497286619</span></a></code></pre></div>
+<div class="sourceCode" id="cb40"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb40-1" title="1">@(epoch(<span class="st">&quot;2017-06-12T16:56:59.000000Z&quot;</span>)) → <span class="dv">1497286619</span></a>
+<a class="sourceLine" id="cb40-2" title="2">@(epoch(<span class="st">&quot;2017-06-12T18:56:59.000000+02:00&quot;</span>)) → <span class="dv">1497286619</span></a>
+<a class="sourceLine" id="cb40-3" title="3">@(epoch(<span class="st">&quot;2017-06-12T16:56:59.123456Z&quot;</span>)) → <span class="fl">1497286619.123456</span></a>
+<a class="sourceLine" id="cb40-4" title="4">@(round_down(epoch(<span class="st">&quot;2017-06-12T16:56:59.123456Z&quot;</span>))) → <span class="dv">1497286619</span></a></code></pre></div>
 <p><a name="function:extract"></a></p>
 <h2 id="extractdict-properties">extract(dict, properties…)</h2>
 <p>Takes a dict and extracts the named property.</p>
-<div class="sourceCode" id="cb40"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb40-1" title="1">@(extract(contact, <span class="st">&quot;name&quot;</span>)) → Ryan Lewis</a>
-<a class="sourceLine" id="cb40-2" title="2">@(extract(contact.groups[<span class="dv">0</span>], <span class="st">&quot;name&quot;</span>)) → Testers</a></code></pre></div>
+<div class="sourceCode" id="cb41"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb41-1" title="1">@(extract(contact, <span class="st">&quot;name&quot;</span>)) → Ryan Lewis</a>
+<a class="sourceLine" id="cb41-2" title="2">@(extract(contact.groups[<span class="dv">0</span>], <span class="st">&quot;name&quot;</span>)) → Testers</a></code></pre></div>
 <p><a name="function:extract_dict"></a></p>
 <h2 id="extract_dictdict-properties">extract_dict(dict, properties…)</h2>
 <p>Takes a dict and returns a new dict by extracting only the named properties.</p>
-<div class="sourceCode" id="cb41"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb41-1" title="1">@(extract_dict(contact.groups[<span class="dv">0</span>], <span class="st">&quot;name&quot;</span>)) → {name: Testers}</a></code></pre></div>
+<div class="sourceCode" id="cb42"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb42-1" title="1">@(extract_dict(contact.groups[<span class="dv">0</span>], <span class="st">&quot;name&quot;</span>)) → {name: Testers}</a></code></pre></div>
 <p><a name="function:field"></a></p>
 <h2 id="fieldtext-index-delimiter">field(text, index, delimiter)</h2>
 <p>Splits <code>text</code> using the given <code>delimiter</code> and returns the field at <code>index</code>.</p>
 <p>The index starts at zero. When splitting with a space, the delimiter is considered to be all whitespace.</p>
-<div class="sourceCode" id="cb42"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb42-1" title="1">@(field(<span class="st">&quot;a,b,c&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;,&quot;</span>)) → b</a>
-<a class="sourceLine" id="cb42-2" title="2">@(field(<span class="st">&quot;a,,b,c&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;,&quot;</span>)) →</a>
-<a class="sourceLine" id="cb42-3" title="3">@(field(<span class="st">&quot;a   b c&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) → b</a>
-<a class="sourceLine" id="cb42-4" title="4">@(field(<span class="st">&quot;a      b   c   d&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;    &quot;</span>)) →</a>
-<a class="sourceLine" id="cb42-5" title="5">@(field(<span class="st">&quot;a</span><span class="sc">\t\t</span><span class="st">b</span><span class="sc">\t</span><span class="st">c</span><span class="sc">\t</span><span class="st">d&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) →</a>
-<a class="sourceLine" id="cb42-6" title="6">@(field(<span class="st">&quot;a,b,c&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;,&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb43"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb43-1" title="1">@(field(<span class="st">&quot;a,b,c&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;,&quot;</span>)) → b</a>
+<a class="sourceLine" id="cb43-2" title="2">@(field(<span class="st">&quot;a,,b,c&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;,&quot;</span>)) →</a>
+<a class="sourceLine" id="cb43-3" title="3">@(field(<span class="st">&quot;a   b c&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) → b</a>
+<a class="sourceLine" id="cb43-4" title="4">@(field(<span class="st">&quot;a      b   c   d&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;    &quot;</span>)) →</a>
+<a class="sourceLine" id="cb43-5" title="5">@(field(<span class="st">&quot;a</span><span class="sc">\t\t</span><span class="st">b</span><span class="sc">\t</span><span class="st">c</span><span class="sc">\t</span><span class="st">d&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) →</a>
+<a class="sourceLine" id="cb43-6" title="6">@(field(<span class="st">&quot;a,b,c&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;,&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:foreach"></a></p>
 <h2 id="foreacharray-func-args">foreach(array, func, [args…])</h2>
 <p>Takes an array of objects and returns a new array by applying the given function to each item.</p>
 <p>If the given function takes more than one argument, you can pass additional arguments after the function.</p>
-<div class="sourceCode" id="cb43"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb43-1" title="1">@(foreach(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>), upper)) → [A, B, C]</a>
-<a class="sourceLine" id="cb43-2" title="2">@(foreach(array(<span class="st">&quot;the man&quot;</span>, <span class="st">&quot;fox&quot;</span>, <span class="st">&quot;jumped up&quot;</span>), word, <span class="dv">0</span>)) → [the, fox, jumped]</a></code></pre></div>
+<div class="sourceCode" id="cb44"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb44-1" title="1">@(foreach(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>), upper)) → [A, B, C]</a>
+<a class="sourceLine" id="cb44-2" title="2">@(foreach(array(<span class="st">&quot;the man&quot;</span>, <span class="st">&quot;fox&quot;</span>, <span class="st">&quot;jumped up&quot;</span>), word, <span class="dv">0</span>)) → [the, fox, jumped]</a></code></pre></div>
 <p><a name="function:format_date"></a></p>
 <h2 id="format_datedate-format">format_date(date, [,format])</h2>
 <p>Formats <code>date</code> as text according to the given <code>format</code>. If <code>format</code> is not specified then the environment’s default format is used.</p>
@@ -329,12 +337,12 @@
 <li><code>D</code> - day of month, 1-31</li>
 <li><code>DD</code> - day of month, zero padded 0-31</li>
 </ul>
-<div class="sourceCode" id="cb44"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb44-1" title="1">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>)) → <span class="dv">18-07-1979</span></a>
-<a class="sourceLine" id="cb44-2" title="2">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → <span class="dv">1979-07-18</span></a>
-<a class="sourceLine" id="cb44-3" title="3">@(format_date(<span class="st">&quot;2010-05-10T19:50:00.000000Z&quot;</span>, <span class="st">&quot;YYYY M DD&quot;</span>)) → <span class="dv">2010</span> <span class="dv">5</span> <span class="dv">10</span></a>
-<a class="sourceLine" id="cb44-4" title="4">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY&quot;</span>)) → <span class="dv">1979</span></a>
-<a class="sourceLine" id="cb44-5" title="5">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;M&quot;</span>)) → <span class="dv">7</span></a>
-<a class="sourceLine" id="cb44-6" title="6">@(format_date(<span class="st">&quot;NOT DATE&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb45"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb45-1" title="1">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>)) → <span class="dv">18-07-1979</span></a>
+<a class="sourceLine" id="cb45-2" title="2">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → <span class="dv">1979-07-18</span></a>
+<a class="sourceLine" id="cb45-3" title="3">@(format_date(<span class="st">&quot;2010-05-10T19:50:00.000000Z&quot;</span>, <span class="st">&quot;YYYY M DD&quot;</span>)) → <span class="dv">2010</span> <span class="dv">5</span> <span class="dv">10</span></a>
+<a class="sourceLine" id="cb45-4" title="4">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY&quot;</span>)) → <span class="dv">1979</span></a>
+<a class="sourceLine" id="cb45-5" title="5">@(format_date(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;M&quot;</span>)) → <span class="dv">7</span></a>
+<a class="sourceLine" id="cb45-6" title="6">@(format_date(<span class="st">&quot;NOT DATE&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:format_datetime"></a></p>
 <h2 id="format_datetimedate-format-timezone">format_datetime(date [,format [,timezone]])</h2>
 <p>Formats <code>date</code> as text according to the given <code>format</code>. If <code>format</code> is not specified then the environment’s default format is used.</p>
@@ -362,32 +370,32 @@
 <li><code>ZZZ</code> - hour and minute offset from UTC</li>
 </ul>
 <p>Timezone should be a location name as specified in the IANA Time Zone database, such as “America/Guayaquil” or “America/Los_Angeles”. If not specified, the current timezone will be used. An error will be returned if the timezone is not recognized.</p>
-<div class="sourceCode" id="cb45"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb45-1" title="1">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>)) → <span class="dv">18-07-1979</span> <span class="dv">10</span>:<span class="dv">00</span></a>
-<a class="sourceLine" id="cb45-2" title="2">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → <span class="dv">1979-07-18</span></a>
-<a class="sourceLine" id="cb45-3" title="3">@(format_datetime(<span class="st">&quot;2010-05-10T19:50:00.000000Z&quot;</span>, <span class="st">&quot;YYYY M DD tt:mm&quot;</span>)) → <span class="dv">2010</span> <span class="dv">5</span> <span class="dv">10</span> <span class="dv">14</span>:<span class="dv">50</span></a>
-<a class="sourceLine" id="cb45-4" title="4">@(format_datetime(<span class="st">&quot;2010-05-10T19:50:00.000000Z&quot;</span>, <span class="st">&quot;YYYY-MM-DD tt:mm AA&quot;</span>, <span class="st">&quot;America/Los_Angeles&quot;</span>)) → <span class="dv">2010-05-10</span> <span class="dv">12</span>:<span class="dv">50</span> PM</a>
-<a class="sourceLine" id="cb45-5" title="5">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY&quot;</span>)) → <span class="dv">1979</span></a>
-<a class="sourceLine" id="cb45-6" title="6">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;M&quot;</span>)) → <span class="dv">7</span></a>
-<a class="sourceLine" id="cb45-7" title="7">@(format_datetime(<span class="st">&quot;NOT DATE&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb46"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb46-1" title="1">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>)) → <span class="dv">18-07-1979</span> <span class="dv">10</span>:<span class="dv">00</span></a>
+<a class="sourceLine" id="cb46-2" title="2">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → <span class="dv">1979-07-18</span></a>
+<a class="sourceLine" id="cb46-3" title="3">@(format_datetime(<span class="st">&quot;2010-05-10T19:50:00.000000Z&quot;</span>, <span class="st">&quot;YYYY M DD tt:mm&quot;</span>)) → <span class="dv">2010</span> <span class="dv">5</span> <span class="dv">10</span> <span class="dv">14</span>:<span class="dv">50</span></a>
+<a class="sourceLine" id="cb46-4" title="4">@(format_datetime(<span class="st">&quot;2010-05-10T19:50:00.000000Z&quot;</span>, <span class="st">&quot;YYYY-MM-DD tt:mm AA&quot;</span>, <span class="st">&quot;America/Los_Angeles&quot;</span>)) → <span class="dv">2010-05-10</span> <span class="dv">12</span>:<span class="dv">50</span> PM</a>
+<a class="sourceLine" id="cb46-5" title="5">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;YYYY&quot;</span>)) → <span class="dv">1979</span></a>
+<a class="sourceLine" id="cb46-6" title="6">@(format_datetime(<span class="st">&quot;1979-07-18T15:00:00.000000Z&quot;</span>, <span class="st">&quot;M&quot;</span>)) → <span class="dv">7</span></a>
+<a class="sourceLine" id="cb46-7" title="7">@(format_datetime(<span class="st">&quot;NOT DATE&quot;</span>, <span class="st">&quot;YYYY-MM-DD&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:format_input"></a></p>
 <h2 id="format_inputurn">format_input(urn)</h2>
 <p>Formats <code>input</code> to be the text followed by the URLs of any attachment, separated by newlines.</p>
-<div class="sourceCode" id="cb46"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb46-1" title="1">@(format_input(input)) → Hi there\nhttp:<span class="co">//s3.amazon.com/bucket/test.jpg\nhttp://s3.amazon.com/bucket/test.mp3</span></a>
-<a class="sourceLine" id="cb46-2" title="2">@(format_input(<span class="st">&quot;NOT INPUT&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb47"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb47-1" title="1">@(format_input(input)) → Hi there\nhttp:<span class="co">//s3.amazon.com/bucket/test.jpg\nhttp://s3.amazon.com/bucket/test.mp3</span></a>
+<a class="sourceLine" id="cb47-2" title="2">@(format_input(<span class="st">&quot;NOT INPUT&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:format_location"></a></p>
 <h2 id="format_locationlocation">format_location(location)</h2>
 <p>Formats the given <code>location</code> as its name.</p>
-<div class="sourceCode" id="cb47"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb47-1" title="1">@(format_location(<span class="st">&quot;Rwanda&quot;</span>)) → Rwanda</a>
-<a class="sourceLine" id="cb47-2" title="2">@(format_location(<span class="st">&quot;Rwanda &gt; Kigali&quot;</span>)) → Kigali</a></code></pre></div>
+<div class="sourceCode" id="cb48"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb48-1" title="1">@(format_location(<span class="st">&quot;Rwanda&quot;</span>)) → Rwanda</a>
+<a class="sourceLine" id="cb48-2" title="2">@(format_location(<span class="st">&quot;Rwanda &gt; Kigali&quot;</span>)) → Kigali</a></code></pre></div>
 <p><a name="function:format_number"></a></p>
 <h2 id="format_numbernumber-places-humanize">format_number(number, places [, humanize])</h2>
 <p>Formats <code>number</code> to the given number of decimal <code>places</code>.</p>
 <p>An optional third argument <code>humanize</code> can be false to disable the use of thousand separators.</p>
-<div class="sourceCode" id="cb48"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb48-1" title="1">@(format_number(<span class="dv">31337</span>)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
-<a class="sourceLine" id="cb48-2" title="2">@(format_number(<span class="dv">31337</span>, <span class="dv">2</span>)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
-<a class="sourceLine" id="cb48-3" title="3">@(format_number(<span class="dv">31337</span>, <span class="dv">2</span>, true)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
-<a class="sourceLine" id="cb48-4" title="4">@(format_number(<span class="dv">31337</span>, <span class="dv">0</span>, false)) → <span class="dv">31337</span></a>
-<a class="sourceLine" id="cb48-5" title="5">@(format_number(<span class="st">&quot;foo&quot;</span>, <span class="dv">2</span>, false)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb49"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb49-1" title="1">@(format_number(<span class="dv">31337</span>)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
+<a class="sourceLine" id="cb49-2" title="2">@(format_number(<span class="dv">31337</span>, <span class="dv">2</span>)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
+<a class="sourceLine" id="cb49-3" title="3">@(format_number(<span class="dv">31337</span>, <span class="dv">2</span>, true)) → <span class="dv">31</span>,<span class="fl">337.00</span></a>
+<a class="sourceLine" id="cb49-4" title="4">@(format_number(<span class="dv">31337</span>, <span class="dv">0</span>, false)) → <span class="dv">31337</span></a>
+<a class="sourceLine" id="cb49-5" title="5">@(format_number(<span class="st">&quot;foo&quot;</span>, <span class="dv">2</span>, false)) → ERROR</a></code></pre></div>
 <p><a name="function:format_time"></a></p>
 <h2 id="format_timetime-format">format_time(time [,format])</h2>
 <p>Formats <code>time</code> as text according to the given <code>format</code>. If <code>format</code> is not specified then the environment’s default format is used.</p>
@@ -406,60 +414,50 @@
 <li><code>aa</code> - am or pm</li>
 <li><code>AA</code> - AM or PM</li>
 </ul>
-<div class="sourceCode" id="cb49"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb49-1" title="1">@(format_time(<span class="st">&quot;14:50:30.000000&quot;</span>)) → <span class="dv">14</span>:<span class="dv">50</span></a>
-<a class="sourceLine" id="cb49-2" title="2">@(format_time(<span class="st">&quot;14:50:30.000000&quot;</span>, <span class="st">&quot;h:mm aa&quot;</span>)) → <span class="dv">2</span>:<span class="dv">50</span> pm</a>
-<a class="sourceLine" id="cb49-3" title="3">@(format_time(<span class="st">&quot;15:00:27.000000&quot;</span>, <span class="st">&quot;s&quot;</span>)) → <span class="dv">27</span></a>
-<a class="sourceLine" id="cb49-4" title="4">@(format_time(<span class="st">&quot;NOT TIME&quot;</span>, <span class="st">&quot;hh:mm&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb50"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb50-1" title="1">@(format_time(<span class="st">&quot;14:50:30.000000&quot;</span>)) → <span class="dv">14</span>:<span class="dv">50</span></a>
+<a class="sourceLine" id="cb50-2" title="2">@(format_time(<span class="st">&quot;14:50:30.000000&quot;</span>, <span class="st">&quot;h:mm aa&quot;</span>)) → <span class="dv">2</span>:<span class="dv">50</span> pm</a>
+<a class="sourceLine" id="cb50-3" title="3">@(format_time(<span class="st">&quot;15:00:27.000000&quot;</span>, <span class="st">&quot;s&quot;</span>)) → <span class="dv">27</span></a>
+<a class="sourceLine" id="cb50-4" title="4">@(format_time(<span class="st">&quot;NOT TIME&quot;</span>, <span class="st">&quot;hh:mm&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:format_urn"></a></p>
 <h2 id="format_urnurn">format_urn(urn)</h2>
 <p>Formats <code>urn</code> into human friendly text.</p>
-<div class="sourceCode" id="cb50"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb50-1" title="1">@(format_urn(<span class="st">&quot;tel:+250781234567&quot;</span>)) → <span class="dv">0781</span> <span class="dv">234</span> <span class="dv">567</span></a>
-<a class="sourceLine" id="cb50-2" title="2">@(format_urn(<span class="st">&quot;twitter:134252511151#billy_bob&quot;</span>)) → billy_bob</a>
-<a class="sourceLine" id="cb50-3" title="3">@(format_urn(contact.urn)) → (<span class="dv">206</span>) <span class="dv">555-1212</span></a>
-<a class="sourceLine" id="cb50-4" title="4">@(format_urn(urns.tel)) → (<span class="dv">206</span>) <span class="dv">555-1212</span></a>
-<a class="sourceLine" id="cb50-5" title="5">@(format_urn(urns.mailto)) → foo@bar.com</a>
-<a class="sourceLine" id="cb50-6" title="6">@(format_urn(<span class="st">&quot;NOT URN&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb51"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb51-1" title="1">@(format_urn(<span class="st">&quot;tel:+250781234567&quot;</span>)) → <span class="dv">0781</span> <span class="dv">234</span> <span class="dv">567</span></a>
+<a class="sourceLine" id="cb51-2" title="2">@(format_urn(<span class="st">&quot;twitter:134252511151#billy_bob&quot;</span>)) → billy_bob</a>
+<a class="sourceLine" id="cb51-3" title="3">@(format_urn(contact.urn)) → (<span class="dv">206</span>) <span class="dv">555-1212</span></a>
+<a class="sourceLine" id="cb51-4" title="4">@(format_urn(urns.tel)) → (<span class="dv">206</span>) <span class="dv">555-1212</span></a>
+<a class="sourceLine" id="cb51-5" title="5">@(format_urn(urns.mailto)) → foo@bar.com</a>
+<a class="sourceLine" id="cb51-6" title="6">@(format_urn(<span class="st">&quot;NOT URN&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:if"></a></p>
 <h2 id="iftest-value1-value2">if(test, value1, value2)</h2>
 <p>Returns <code>value1</code> if <code>test</code> is truthy or <code>value2</code> if not.</p>
 <p>If the first argument is an error that error is returned.</p>
-<div class="sourceCode" id="cb51"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb51-1" title="1">@(<span class="kw">if</span>(<span class="dv">1</span> = <span class="dv">1</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;bar&quot;</span>)) → foo</a>
-<a class="sourceLine" id="cb51-2" title="2">@(<span class="kw">if</span>(<span class="st">&quot;foo&quot;</span> &gt; <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;bar&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb52"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb52-1" title="1">@(<span class="kw">if</span>(<span class="dv">1</span> = <span class="dv">1</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;bar&quot;</span>)) → foo</a>
+<a class="sourceLine" id="cb52-2" title="2">@(<span class="kw">if</span>(<span class="st">&quot;foo&quot;</span> &gt; <span class="st">&quot;bar&quot;</span>, <span class="st">&quot;foo&quot;</span>, <span class="st">&quot;bar&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:is_error"></a></p>
 <h2 id="is_errorvalue">is_error(value)</h2>
 <p>Returns whether <code>value</code> is an error</p>
-<div class="sourceCode" id="cb52"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb52-1" title="1">@(is_error(datetime(<span class="st">&quot;foo&quot;</span>))) → true</a>
-<a class="sourceLine" id="cb52-2" title="2">@(is_error(run.not.existing)) → true</a>
-<a class="sourceLine" id="cb52-3" title="3">@(is_error(<span class="st">&quot;hello&quot;</span>)) → false</a></code></pre></div>
+<div class="sourceCode" id="cb53"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb53-1" title="1">@(is_error(datetime(<span class="st">&quot;foo&quot;</span>))) → true</a>
+<a class="sourceLine" id="cb53-2" title="2">@(is_error(run.not.existing)) → true</a>
+<a class="sourceLine" id="cb53-3" title="3">@(is_error(<span class="st">&quot;hello&quot;</span>)) → false</a></code></pre></div>
 <p><a name="function:join"></a></p>
 <h2 id="joinarray-separator">join(array, separator)</h2>
 <p>Joins the given <code>array</code> of strings with <code>separator</code> to make text.</p>
-<div class="sourceCode" id="cb53"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb53-1" title="1">@(join(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>), <span class="st">&quot;|&quot;</span>)) → a|b|c</a>
-<a class="sourceLine" id="cb53-2" title="2">@(join(split(<span class="st">&quot;a.b.c&quot;</span>, <span class="st">&quot;.&quot;</span>), <span class="st">&quot; &quot;</span>)) → a b c</a></code></pre></div>
+<div class="sourceCode" id="cb54"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb54-1" title="1">@(join(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>), <span class="st">&quot;|&quot;</span>)) → a|b|c</a>
+<a class="sourceLine" id="cb54-2" title="2">@(join(split(<span class="st">&quot;a.b.c&quot;</span>, <span class="st">&quot;.&quot;</span>), <span class="st">&quot; &quot;</span>)) → a b c</a></code></pre></div>
 <p><a name="function:json"></a></p>
 <h2 id="jsonvalue">json(value)</h2>
 <p>Returns the JSON representation of <code>value</code>.</p>
-<div class="sourceCode" id="cb54"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb54-1" title="1">@(json(<span class="st">&quot;string&quot;</span>)) → <span class="st">&quot;string&quot;</span></a>
-<a class="sourceLine" id="cb54-2" title="2">@(json(<span class="dv">10</span>)) → <span class="dv">10</span></a>
-<a class="sourceLine" id="cb54-3" title="3">@(json(null)) → null</a>
-<a class="sourceLine" id="cb54-4" title="4">@(json(contact.uuid)) → <span class="st">&quot;5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f&quot;</span></a></code></pre></div>
+<div class="sourceCode" id="cb55"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb55-1" title="1">@(json(<span class="st">&quot;string&quot;</span>)) → <span class="st">&quot;string&quot;</span></a>
+<a class="sourceLine" id="cb55-2" title="2">@(json(<span class="dv">10</span>)) → <span class="dv">10</span></a>
+<a class="sourceLine" id="cb55-3" title="3">@(json(null)) → null</a>
+<a class="sourceLine" id="cb55-4" title="4">@(json(contact.uuid)) → <span class="st">&quot;5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f&quot;</span></a></code></pre></div>
 <p><a name="function:left"></a></p>
 <h2 id="lefttext-count">left(text, count)</h2>
 <p>Returns the <code>count</code> left-most characters in <code>text</code></p>
-<div class="sourceCode" id="cb55"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb55-1" title="1">@(left(<span class="st">&quot;hello&quot;</span>, <span class="dv">2</span>)) → he</a>
-<a class="sourceLine" id="cb55-2" title="2">@(left(<span class="st">&quot;hello&quot;</span>, <span class="dv">7</span>)) → hello</a>
-<a class="sourceLine" id="cb55-3" title="3">@(left(<span class="st">&quot;😀😃😄😁&quot;</span>, <span class="dv">2</span>)) → 😀😃</a>
-<a class="sourceLine" id="cb55-4" title="4">@(left(<span class="st">&quot;hello&quot;</span>, <span class="dv">-1</span>)) → ERROR</a></code></pre></div>
-<p><a name="function:length"></a></p>
-<h2 id="lengthvalue">length(value)</h2>
-<p>Returns the length of the passed in text or array.</p>
-<p>length will return an error if it is passed an item which doesn’t have length.</p>
-<div class="sourceCode" id="cb56"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb56-1" title="1">@(length(<span class="st">&quot;Hello&quot;</span>)) → <span class="dv">5</span></a>
-<a class="sourceLine" id="cb56-2" title="2">@(length(contact.fields.gender)) → <span class="dv">4</span></a>
-<a class="sourceLine" id="cb56-3" title="3">@(length(<span class="st">&quot;😀😃😄😁&quot;</span>)) → <span class="dv">4</span></a>
-<a class="sourceLine" id="cb56-4" title="4">@(length(array())) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb56-5" title="5">@(length(array(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;b&quot;</span>, <span class="st">&quot;c&quot;</span>))) → <span class="dv">3</span></a>
-<a class="sourceLine" id="cb56-6" title="6">@(length(<span class="dv">1234</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb56"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb56-1" title="1">@(left(<span class="st">&quot;hello&quot;</span>, <span class="dv">2</span>)) → he</a>
+<a class="sourceLine" id="cb56-2" title="2">@(left(<span class="st">&quot;hello&quot;</span>, <span class="dv">7</span>)) → hello</a>
+<a class="sourceLine" id="cb56-3" title="3">@(left(<span class="st">&quot;😀😃😄😁&quot;</span>, <span class="dv">2</span>)) → 😀😃</a>
+<a class="sourceLine" id="cb56-4" title="4">@(left(<span class="st">&quot;hello&quot;</span>, <span class="dv">-1</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:lower"></a></p>
 <h2 id="lowertext">lower(text)</h2>
 <p>Converts <code>text</code> to lowercase.</p>
@@ -684,102 +682,107 @@
 <div class="sourceCode" id="cb83"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb83-1" title="1">@(text_compare(<span class="st">&quot;abc&quot;</span>, <span class="st">&quot;abc&quot;</span>)) → <span class="dv">0</span></a>
 <a class="sourceLine" id="cb83-2" title="2">@(text_compare(<span class="st">&quot;abc&quot;</span>, <span class="st">&quot;def&quot;</span>)) → <span class="dv">-1</span></a>
 <a class="sourceLine" id="cb83-3" title="3">@(text_compare(<span class="st">&quot;zzz&quot;</span>, <span class="st">&quot;aaa&quot;</span>)) → <span class="dv">1</span></a></code></pre></div>
+<p><a name="function:text_length"></a></p>
+<h2 id="text_lengthvalue">text_length(value)</h2>
+<p>Returns the length (number of characters) of <code>value</code> when converted to text.</p>
+<div class="sourceCode" id="cb84"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb84-1" title="1">@(text_length(<span class="st">&quot;abc&quot;</span>)) → <span class="dv">3</span></a>
+<a class="sourceLine" id="cb84-2" title="2">@(text_length(array(<span class="dv">2</span>, <span class="dv">3</span>))) → <span class="dv">6</span></a></code></pre></div>
 <p><a name="function:time"></a></p>
 <h2 id="timevalue">time(value)</h2>
 <p>Tries to convert <code>value</code> to a time.</p>
 <p>If it is text then it will be parsed into a time using the default time format. An error is returned if the value can’t be converted.</p>
-<div class="sourceCode" id="cb84"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb84-1" title="1">@(time(<span class="st">&quot;10:30&quot;</span>)) → <span class="dv">10</span>:<span class="dv">30</span>:<span class="fl">00.000000</span></a>
-<a class="sourceLine" id="cb84-2" title="2">@(time(<span class="st">&quot;10:30:45 PM&quot;</span>)) → <span class="dv">22</span>:<span class="dv">30</span>:<span class="fl">45.000000</span></a>
-<a class="sourceLine" id="cb84-3" title="3">@(time(datetime(<span class="st">&quot;1979-07-18T10:30:45.123456Z&quot;</span>))) → <span class="dv">10</span>:<span class="dv">30</span>:<span class="fl">45.123456</span></a>
-<a class="sourceLine" id="cb84-4" title="4">@(time(<span class="st">&quot;what?&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb85"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb85-1" title="1">@(time(<span class="st">&quot;10:30&quot;</span>)) → <span class="dv">10</span>:<span class="dv">30</span>:<span class="fl">00.000000</span></a>
+<a class="sourceLine" id="cb85-2" title="2">@(time(<span class="st">&quot;10:30:45 PM&quot;</span>)) → <span class="dv">22</span>:<span class="dv">30</span>:<span class="fl">45.000000</span></a>
+<a class="sourceLine" id="cb85-3" title="3">@(time(datetime(<span class="st">&quot;1979-07-18T10:30:45.123456Z&quot;</span>))) → <span class="dv">10</span>:<span class="dv">30</span>:<span class="fl">45.123456</span></a>
+<a class="sourceLine" id="cb85-4" title="4">@(time(<span class="st">&quot;what?&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:time_from_parts"></a></p>
 <h2 id="time_from_partshour-minute-second">time_from_parts(hour, minute, second)</h2>
 <p>Creates a time from <code>hour</code>, <code>minute</code> and <code>second</code></p>
-<div class="sourceCode" id="cb85"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb85-1" title="1">@(time_from_parts(<span class="dv">14</span>, <span class="dv">40</span>, <span class="dv">15</span>)) → <span class="dv">14</span>:<span class="dv">40</span>:<span class="fl">15.000000</span></a>
-<a class="sourceLine" id="cb85-2" title="2">@(time_from_parts(<span class="dv">8</span>, <span class="dv">10</span>, <span class="dv">0</span>)) → <span class="dv">08</span>:<span class="dv">10</span>:<span class="fl">00.000000</span></a>
-<a class="sourceLine" id="cb85-3" title="3">@(time_from_parts(<span class="dv">25</span>, <span class="dv">0</span>, <span class="dv">0</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb86"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb86-1" title="1">@(time_from_parts(<span class="dv">14</span>, <span class="dv">40</span>, <span class="dv">15</span>)) → <span class="dv">14</span>:<span class="dv">40</span>:<span class="fl">15.000000</span></a>
+<a class="sourceLine" id="cb86-2" title="2">@(time_from_parts(<span class="dv">8</span>, <span class="dv">10</span>, <span class="dv">0</span>)) → <span class="dv">08</span>:<span class="dv">10</span>:<span class="fl">00.000000</span></a>
+<a class="sourceLine" id="cb86-3" title="3">@(time_from_parts(<span class="dv">25</span>, <span class="dv">0</span>, <span class="dv">0</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:title"></a></p>
 <h2 id="titletext">title(text)</h2>
 <p>Capitalizes each word in <code>text</code>.</p>
-<div class="sourceCode" id="cb86"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb86-1" title="1">@(title(<span class="st">&quot;foo&quot;</span>)) → Foo</a>
-<a class="sourceLine" id="cb86-2" title="2">@(title(<span class="st">&quot;ryan lewis&quot;</span>)) → Ryan Lewis</a>
-<a class="sourceLine" id="cb86-3" title="3">@(title(<span class="st">&quot;RYAN LEWIS&quot;</span>)) → Ryan Lewis</a>
-<a class="sourceLine" id="cb86-4" title="4">@(title(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
+<div class="sourceCode" id="cb87"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb87-1" title="1">@(title(<span class="st">&quot;foo&quot;</span>)) → Foo</a>
+<a class="sourceLine" id="cb87-2" title="2">@(title(<span class="st">&quot;ryan lewis&quot;</span>)) → Ryan Lewis</a>
+<a class="sourceLine" id="cb87-3" title="3">@(title(<span class="st">&quot;RYAN LEWIS&quot;</span>)) → Ryan Lewis</a>
+<a class="sourceLine" id="cb87-4" title="4">@(title(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
 <p><a name="function:today"></a></p>
 <h2 id="today">today()</h2>
 <p>Returns the current date in the environment timezone.</p>
-<div class="sourceCode" id="cb87"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb87-1" title="1">@(today()) → <span class="dv">2018-04-11</span></a></code></pre></div>
+<div class="sourceCode" id="cb88"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb88-1" title="1">@(today()) → <span class="dv">2018-04-11</span></a></code></pre></div>
 <p><a name="function:tz"></a></p>
 <h2 id="tzdate">tz(date)</h2>
 <p>Returns the name of the timezone of <code>date</code>.</p>
 <p>If no timezone information is present in the date, then the current timezone will be returned.</p>
-<div class="sourceCode" id="cb88"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb88-1" title="1">@(tz(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → UTC</a>
-<a class="sourceLine" id="cb88-2" title="2">@(tz(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → America/Guayaquil</a>
-<a class="sourceLine" id="cb88-3" title="3">@(tz(<span class="st">&quot;2017-01-15&quot;</span>)) → America/Guayaquil</a>
-<a class="sourceLine" id="cb88-4" title="4">@(tz(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb89"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb89-1" title="1">@(tz(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → UTC</a>
+<a class="sourceLine" id="cb89-2" title="2">@(tz(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → America/Guayaquil</a>
+<a class="sourceLine" id="cb89-3" title="3">@(tz(<span class="st">&quot;2017-01-15&quot;</span>)) → America/Guayaquil</a>
+<a class="sourceLine" id="cb89-4" title="4">@(tz(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:tz_offset"></a></p>
 <h2 id="tz_offsetdate">tz_offset(date)</h2>
 <p>Returns the offset of the timezone of <code>date</code>.</p>
 <p>The offset is returned in the format <code>[+/-]HH:MM</code>. If no timezone information is present in the date, then the current timezone offset will be returned.</p>
-<div class="sourceCode" id="cb89"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb89-1" title="1">@(tz_offset(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → +<span class="dv">0000</span></a>
-<a class="sourceLine" id="cb89-2" title="2">@(tz_offset(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → <span class="dv">-0500</span></a>
-<a class="sourceLine" id="cb89-3" title="3">@(tz_offset(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">-0500</span></a>
-<a class="sourceLine" id="cb89-4" title="4">@(tz_offset(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb90"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb90-1" title="1">@(tz_offset(<span class="st">&quot;2017-01-15T02:15:18.123456Z&quot;</span>)) → +<span class="dv">0000</span></a>
+<a class="sourceLine" id="cb90-2" title="2">@(tz_offset(<span class="st">&quot;2017-01-15 02:15:18PM&quot;</span>)) → <span class="dv">-0500</span></a>
+<a class="sourceLine" id="cb90-3" title="3">@(tz_offset(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">-0500</span></a>
+<a class="sourceLine" id="cb90-4" title="4">@(tz_offset(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:upper"></a></p>
 <h2 id="uppertext">upper(text)</h2>
 <p>Converts <code>text</code> to lowercase.</p>
-<div class="sourceCode" id="cb90"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb90-1" title="1">@(upper(<span class="st">&quot;Asdf&quot;</span>)) → ASDF</a>
-<a class="sourceLine" id="cb90-2" title="2">@(upper(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
+<div class="sourceCode" id="cb91"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb91-1" title="1">@(upper(<span class="st">&quot;Asdf&quot;</span>)) → ASDF</a>
+<a class="sourceLine" id="cb91-2" title="2">@(upper(<span class="dv">123</span>)) → <span class="dv">123</span></a></code></pre></div>
 <p><a name="function:url_encode"></a></p>
 <h2 id="url_encodetext">url_encode(text)</h2>
 <p>Encodes <code>text</code> for use as a URL parameter.</p>
-<div class="sourceCode" id="cb91"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb91-1" title="1">@(url_encode(<span class="st">&quot;two &amp; words&quot;</span>)) → two%<span class="dv">20</span>%<span class="dv">26</span>%20words</a>
-<a class="sourceLine" id="cb91-2" title="2">@(url_encode(<span class="dv">10</span>)) → <span class="dv">10</span></a></code></pre></div>
+<div class="sourceCode" id="cb92"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb92-1" title="1">@(url_encode(<span class="st">&quot;two &amp; words&quot;</span>)) → two%<span class="dv">20</span>%<span class="dv">26</span>%20words</a>
+<a class="sourceLine" id="cb92-2" title="2">@(url_encode(<span class="dv">10</span>)) → <span class="dv">10</span></a></code></pre></div>
 <p><a name="function:urn_parts"></a></p>
 <h2 id="urn_partsurn">urn_parts(urn)</h2>
 <p>Parses a URN into its different parts</p>
-<div class="sourceCode" id="cb92"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb92-1" title="1">@(urn_parts(<span class="st">&quot;tel:+593979012345&quot;</span>)) → {display: , path: +<span class="dv">593979012345</span>, scheme: tel}</a>
-<a class="sourceLine" id="cb92-2" title="2">@(urn_parts(<span class="st">&quot;twitterid:3263621177#bobby&quot;</span>)) → {display: bobby, path: <span class="dv">3263621177</span>, scheme: twitterid}</a></code></pre></div>
+<div class="sourceCode" id="cb93"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb93-1" title="1">@(urn_parts(<span class="st">&quot;tel:+593979012345&quot;</span>)) → {display: , path: +<span class="dv">593979012345</span>, scheme: tel}</a>
+<a class="sourceLine" id="cb93-2" title="2">@(urn_parts(<span class="st">&quot;twitterid:3263621177#bobby&quot;</span>)) → {display: bobby, path: <span class="dv">3263621177</span>, scheme: twitterid}</a></code></pre></div>
 <p><a name="function:weekday"></a></p>
 <h2 id="weekdaydate">weekday(date)</h2>
 <p>Returns the day of the week for <code>date</code>.</p>
 <p>The week is considered to start on Sunday so a Sunday returns 0, a Monday returns 1 etc.</p>
-<div class="sourceCode" id="cb93"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb93-1" title="1">@(weekday(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb93-2" title="2">@(weekday(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
+<div class="sourceCode" id="cb94"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb94-1" title="1">@(weekday(<span class="st">&quot;2017-01-15&quot;</span>)) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb94-2" title="2">@(weekday(<span class="st">&quot;foo&quot;</span>)) → ERROR</a></code></pre></div>
 <p><a name="function:word"></a></p>
 <h2 id="wordtext-index-delimiters">word(text, index [,delimiters])</h2>
 <p>Returns the word at <code>index</code> in <code>text</code>.</p>
 <p>Indexes start at zero. There is an optional final parameter <code>delimiters</code> which is string of characters used to split the text into words.</p>
-<div class="sourceCode" id="cb94"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb94-1" title="1">@(word(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
-<a class="sourceLine" id="cb94-2" title="2">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
-<a class="sourceLine" id="cb94-3" title="3">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">1</span>)) → cat</a>
-<a class="sourceLine" id="cb94-4" title="4">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">2</span>)) → dog</a>
-<a class="sourceLine" id="cb94-5" title="5">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-1</span>)) → dog</a>
-<a class="sourceLine" id="cb94-6" title="6">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-2</span>)) → cat</a>
-<a class="sourceLine" id="cb94-7" title="7">@(word(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;.*=|&quot;</span>)) → cat,dog</a>
-<a class="sourceLine" id="cb94-8" title="8">@(word(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
+<div class="sourceCode" id="cb95"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb95-1" title="1">@(word(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
+<a class="sourceLine" id="cb95-2" title="2">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">0</span>)) → bee</a>
+<a class="sourceLine" id="cb95-3" title="3">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">1</span>)) → cat</a>
+<a class="sourceLine" id="cb95-4" title="4">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">2</span>)) → dog</a>
+<a class="sourceLine" id="cb95-5" title="5">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-1</span>)) → dog</a>
+<a class="sourceLine" id="cb95-6" title="6">@(word(<span class="st">&quot;bee.cat,dog&quot;</span>, <span class="dv">-2</span>)) → cat</a>
+<a class="sourceLine" id="cb95-7" title="7">@(word(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="st">&quot;.*=|&quot;</span>)) → cat,dog</a>
+<a class="sourceLine" id="cb95-8" title="8">@(word(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
 <p><a name="function:word_count"></a></p>
 <h2 id="word_counttext-delimiters">word_count(text [,delimiters])</h2>
 <p>Returns the number of words in <code>text</code>.</p>
 <p>There is an optional final parameter <code>delimiters</code> which is string of characters used to split the text into words.</p>
-<div class="sourceCode" id="cb95"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb95-1" title="1">@(word_count(<span class="st">&quot;foo bar&quot;</span>)) → <span class="dv">2</span></a>
-<a class="sourceLine" id="cb95-2" title="2">@(word_count(<span class="dv">10</span>)) → <span class="dv">1</span></a>
-<a class="sourceLine" id="cb95-3" title="3">@(word_count(<span class="st">&quot;&quot;</span>)) → <span class="dv">0</span></a>
-<a class="sourceLine" id="cb95-4" title="4">@(word_count(<span class="st">&quot;😀😃😄😁&quot;</span>)) → <span class="dv">4</span></a>
-<a class="sourceLine" id="cb95-5" title="5">@(word_count(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="st">&quot;.*=|&quot;</span>)) → <span class="dv">2</span></a>
-<a class="sourceLine" id="cb95-6" title="6">@(word_count(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="st">&quot; &quot;</span>)) → <span class="dv">2</span></a></code></pre></div>
+<div class="sourceCode" id="cb96"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb96-1" title="1">@(word_count(<span class="st">&quot;foo bar&quot;</span>)) → <span class="dv">2</span></a>
+<a class="sourceLine" id="cb96-2" title="2">@(word_count(<span class="dv">10</span>)) → <span class="dv">1</span></a>
+<a class="sourceLine" id="cb96-3" title="3">@(word_count(<span class="st">&quot;&quot;</span>)) → <span class="dv">0</span></a>
+<a class="sourceLine" id="cb96-4" title="4">@(word_count(<span class="st">&quot;😀😃😄😁&quot;</span>)) → <span class="dv">4</span></a>
+<a class="sourceLine" id="cb96-5" title="5">@(word_count(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="st">&quot;.*=|&quot;</span>)) → <span class="dv">2</span></a>
+<a class="sourceLine" id="cb96-6" title="6">@(word_count(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="st">&quot; &quot;</span>)) → <span class="dv">2</span></a></code></pre></div>
 <p><a name="function:word_slice"></a></p>
 <h2 id="word_slicetext-start-end-delimiters">word_slice(text, start, end [,delimiters])</h2>
 <p>Extracts a sub-sequence of words from <code>text</code>.</p>
 <p>The returned words are those from <code>start</code> up to but not-including <code>end</code>. Indexes start at zero and a negative end value means that all words after the start should be returned. There is an optional final parameter <code>delimiters</code> which is string of characters used to split the text into words.</p>
-<div class="sourceCode" id="cb96"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb96-1" title="1">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">1</span>)) → bee</a>
-<a class="sourceLine" id="cb96-2" title="2">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">2</span>)) → bee cat</a>
-<a class="sourceLine" id="cb96-3" title="3">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>)) → cat dog</a>
-<a class="sourceLine" id="cb96-4" title="4">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>)) → cat dog</a>
-<a class="sourceLine" id="cb96-5" title="5">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">2</span>, <span class="dv">3</span>)) → dog</a>
-<a class="sourceLine" id="cb96-6" title="6">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">3</span>, <span class="dv">10</span>)) →</a>
-<a class="sourceLine" id="cb96-7" title="7">@(word_slice(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>, <span class="st">&quot;.*=|,&quot;</span>)) → cat dog</a>
-<a class="sourceLine" id="cb96-8" title="8">@(word_slice(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="dv">2</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
+<div class="sourceCode" id="cb97"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><a class="sourceLine" id="cb97-1" title="1">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">1</span>)) → bee</a>
+<a class="sourceLine" id="cb97-2" title="2">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">0</span>, <span class="dv">2</span>)) → bee cat</a>
+<a class="sourceLine" id="cb97-3" title="3">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>)) → cat dog</a>
+<a class="sourceLine" id="cb97-4" title="4">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">1</span>)) → cat dog</a>
+<a class="sourceLine" id="cb97-5" title="5">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">2</span>, <span class="dv">3</span>)) → dog</a>
+<a class="sourceLine" id="cb97-6" title="6">@(word_slice(<span class="st">&quot;bee cat dog&quot;</span>, <span class="dv">3</span>, <span class="dv">10</span>)) →</a>
+<a class="sourceLine" id="cb97-7" title="7">@(word_slice(<span class="st">&quot;bee.*cat,dog&quot;</span>, <span class="dv">1</span>, <span class="dv">-1</span>, <span class="st">&quot;.*=|,&quot;</span>)) → cat dog</a>
+<a class="sourceLine" id="cb97-8" title="8">@(word_slice(<span class="st">&quot;O&#39;Grady O&#39;Flaggerty&quot;</span>, <span class="dv">1</span>, <span class="dv">2</span>, <span class="st">&quot; &quot;</span>)) → O&#39;Flaggerty</a></code></pre></div>
 </div>
 
     </body>

--- a/docs/functions.json
+++ b/docs/functions.json
@@ -47,11 +47,11 @@
                 "output": "a|b|c"
             },
             {
-                "template": "@(length(array()))",
+                "template": "@(count(array()))",
                 "output": "0"
             },
             {
-                "template": "@(length(array(\"a\", \"b\")))",
+                "template": "@(count(array(\"a\", \"b\")))",
                 "output": "2"
             }
         ]
@@ -147,6 +147,29 @@
             },
             {
                 "template": "@(code(\"\"))",
+                "output": "ERROR"
+            }
+        ]
+    },
+    {
+        "signature": "count(value)",
+        "summary": "Returns the number of items in the given array or dict.",
+        "detail": "It will return an error if it is passed an item which isn't countable.",
+        "examples": [
+            {
+                "template": "@(count(contact.fields))",
+                "output": "5"
+            },
+            {
+                "template": "@(count(array()))",
+                "output": "0"
+            },
+            {
+                "template": "@(count(array(\"a\", \"b\", \"c\")))",
+                "output": "3"
+            },
+            {
+                "template": "@(count(1234))",
                 "output": "ERROR"
             }
         ]
@@ -690,37 +713,6 @@
             },
             {
                 "template": "@(left(\"hello\", -1))",
-                "output": "ERROR"
-            }
-        ]
-    },
-    {
-        "signature": "length(value)",
-        "summary": "Returns the length of the passed in text or array.",
-        "detail": "length will return an error if it is passed an item which doesn't have length.",
-        "examples": [
-            {
-                "template": "@(length(\"Hello\"))",
-                "output": "5"
-            },
-            {
-                "template": "@(length(contact.fields.gender))",
-                "output": "4"
-            },
-            {
-                "template": "@(length(\"😀😃😄😁\"))",
-                "output": "4"
-            },
-            {
-                "template": "@(length(array()))",
-                "output": "0"
-            },
-            {
-                "template": "@(length(array(\"a\", \"b\", \"c\")))",
-                "output": "3"
-            },
-            {
-                "template": "@(length(1234))",
                 "output": "ERROR"
             }
         ]
@@ -1271,6 +1263,21 @@
             {
                 "template": "@(text_compare(\"zzz\", \"aaa\"))",
                 "output": "1"
+            }
+        ]
+    },
+    {
+        "signature": "text_length(value)",
+        "summary": "Returns the length (number of characters) of `value` when converted to text.",
+        "detail": "",
+        "examples": [
+            {
+                "template": "@(text_length(\"abc\"))",
+                "output": "3"
+            },
+            {
+                "template": "@(text_length(array(2, 3)))",
+                "output": "6"
             }
         ]
     },

--- a/docs/md/expressions.md
+++ b/docs/md/expressions.md
@@ -41,7 +41,7 @@ Is an array of items.
 ```objectivec
 @(array(1, "x", true)) → [1, x, true]
 @(array(1, "x", true)[1]) → x
-@(length(array(1, "x", true))) → 3
+@(count(array(1, "x", true))) → 3
 @(json(array(1, "x", true))) → [1,"x",true]
 ```
 
@@ -96,7 +96,7 @@ Is a dictionary of keys and values.
 @(dict("foo", 1, "bar", "x")) → {bar: x, foo: 1}
 @(dict("foo", 1, "bar", "x").bar) → x
 @(dict("foo", 1, "bar", "x")["bar"]) → x
-@(length(dict("foo", 1, "bar", "x"))) → 2
+@(count(dict("foo", 1, "bar", "x"))) → 2
 @(json(dict("foo", 1, "bar", "x"))) → {"bar":"x","foo":1}
 ```
 
@@ -136,7 +136,7 @@ Is a string of characters.
 
 ```objectivec
 @("abc") → abc
-@(length("abc")) → 3
+@(text_length("abc")) → 3
 @(upper("abc")) → ABC
 @(json("abc")) → "abc"
 ```
@@ -367,8 +367,8 @@ Takes multiple `values` and returns them as an array.
 ```objectivec
 @(array("a", "b", 356)[1]) → b
 @(join(array("a", "b", "c"), "|")) → a|b|c
-@(length(array())) → 0
-@(length(array("a", "b"))) → 2
+@(count(array())) → 0
+@(count(array("a", "b"))) → 2
 ```
 
 <a name="function:attachment_parts"></a>
@@ -440,6 +440,22 @@ It is the inverse of [char](expressions.html#function:char).
 @(code("15")) → 49
 @(code(15)) → 49
 @(code("")) → ERROR
+```
+
+<a name="function:count"></a>
+
+## count(value)
+
+Returns the number of items in the given array or dict.
+
+It will return an error if it is passed an item which isn't countable.
+
+
+```objectivec
+@(count(contact.fields)) → 5
+@(count(array())) → 0
+@(count(array("a", "b", "c"))) → 3
+@(count(1234)) → ERROR
 ```
 
 <a name="function:date"></a>
@@ -861,24 +877,6 @@ Returns the `count` left-most characters in `text`
 @(left("hello", 7)) → hello
 @(left("😀😃😄😁", 2)) → 😀😃
 @(left("hello", -1)) → ERROR
-```
-
-<a name="function:length"></a>
-
-## length(value)
-
-Returns the length of the passed in text or array.
-
-length will return an error if it is passed an item which doesn't have length.
-
-
-```objectivec
-@(length("Hello")) → 5
-@(length(contact.fields.gender)) → 4
-@(length("😀😃😄😁")) → 4
-@(length(array())) → 0
-@(length(array("a", "b", "c"))) → 3
-@(length(1234)) → ERROR
 ```
 
 <a name="function:lower"></a>
@@ -1318,6 +1316,18 @@ and 1 if `text1` comes after `text2`.
 @(text_compare("abc", "abc")) → 0
 @(text_compare("abc", "def")) → -1
 @(text_compare("zzz", "aaa")) → 1
+```
+
+<a name="function:text_length"></a>
+
+## text_length(value)
+
+Returns the length (number of characters) of `value` when converted to text.
+
+
+```objectivec
+@(text_length("abc")) → 3
+@(text_length(array(2, 3))) → 6
 ```
 
 <a name="function:time"></a>

--- a/excellent/evaluator.go
+++ b/excellent/evaluator.go
@@ -175,11 +175,11 @@ func (v *visitor) VisitArrayLookup(ctx *gen.ArrayLookupContext) interface{} {
 			return xerr
 		}
 
-		if index >= asArray.Length() || index < -asArray.Length() {
-			return types.NewXErrorf("index %d out of range for %d items", index, asArray.Length())
+		if index >= asArray.Count() || index < -asArray.Count() {
+			return types.NewXErrorf("index %d out of range for %d items", index, asArray.Count())
 		}
 		if index < 0 {
-			index += asArray.Length()
+			index += asArray.Count()
 		}
 		return asArray.Get(index)
 	}

--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -327,7 +327,7 @@ var errorTests = []struct {
 
 	// function call errors
 	{`@(FOO())`, `error evaluating @(FOO()): FOO is not a function`},
-	{`@(length(1))`, `error evaluating @(length(1)): error calling LENGTH: value doesn't have length`},
+	{`@(count(1))`, `error evaluating @(count(1)): error calling COUNT: value isn't countable`},
 	{`@(word_count())`, `error evaluating @(word_count()): error calling WORD_COUNT: need 1 to 2 argument(s), got 0`},
 	{`@(word_count("a", "b", "c"))`, `error evaluating @(word_count("a", "b", "c")): error calling WORD_COUNT: need 1 to 2 argument(s), got 3`},
 }

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -93,6 +93,19 @@ func TestFunctions(t *testing.T) {
 		{"code", dmy, []types.XValue{ERROR}, ERROR},
 		{"code", dmy, []types.XValue{}, ERROR},
 
+		{
+			"count",
+			dmy,
+			[]types.XValue{types.NewXDict(map[string]types.XValue{"a": xs("hello"), "b": xi(3)})},
+			xi(2),
+		},
+		{"count", dmy, []types.XValue{xa(xs("hello"), xi(3))}, xi(2)},
+		{"count", dmy, []types.XValue{xa()}, xi(0)},
+		{"count", dmy, []types.XValue{nil}, xi(0)},
+		{"count", dmy, []types.XValue{xi(1234)}, ERROR},
+		{"count", dmy, []types.XValue{ERROR}, ERROR},
+		{"count", dmy, []types.XValue{}, ERROR},
+
 		{"clean", dmy, []types.XValue{xs("hello")}, xs("hello")},
 		{"clean", dmy, []types.XValue{xs("😃 Hello \nwo\tr\rld")}, xs("😃 Hello world")},
 		{"clean", dmy, []types.XValue{xs("")}, xs("")},
@@ -356,16 +369,6 @@ func TestFunctions(t *testing.T) {
 		{"legacy_add", dmy, []types.XValue{xs("10"), xs("xxx")}, ERROR},
 		{"legacy_add", dmy, []types.XValue{}, ERROR},
 
-		{"length", dmy, []types.XValue{xs("hello")}, xi(5)},
-		{"length", dmy, []types.XValue{xs("")}, xi(0)},
-		{"length", dmy, []types.XValue{xs("😁😁")}, xi(2)},
-		{"length", dmy, []types.XValue{xa(xs("hello"))}, xi(1)},
-		{"length", dmy, []types.XValue{xa()}, xi(0)},
-		{"length", dmy, []types.XValue{nil}, xi(0)},
-		{"length", dmy, []types.XValue{xi(1234)}, ERROR},
-		{"length", dmy, []types.XValue{ERROR}, ERROR},
-		{"length", dmy, []types.XValue{}, ERROR},
-
 		{"lower", dmy, []types.XValue{xs("HEllo")}, xs("hello")},
 		{"lower", dmy, []types.XValue{xs("  HELLO  WORLD")}, xs("  hello  world")},
 		{"lower", dmy, []types.XValue{xs("")}, xs("")},
@@ -529,6 +532,16 @@ func TestFunctions(t *testing.T) {
 		{"text_compare", dmy, []types.XValue{xs("def"), xs("abc")}, xi(1)},
 		{"text_compare", dmy, []types.XValue{xs("abc"), types.NewXErrorf("error")}, ERROR},
 		{"text_compare", dmy, []types.XValue{}, ERROR},
+
+		{"text_length", dmy, []types.XValue{xs("hello")}, xi(5)},
+		{"text_length", dmy, []types.XValue{xs("")}, xi(0)},
+		{"text_length", dmy, []types.XValue{xs("😁😁")}, xi(2)},
+		{"text_length", dmy, []types.XValue{xa(xs("hello"))}, xi(7)}, // [hello]
+		{"text_length", dmy, []types.XValue{xa()}, xi(2)},            // []
+		{"text_length", dmy, []types.XValue{nil}, xi(0)},
+		{"text_length", dmy, []types.XValue{xi(1234)}, xi(4)},
+		{"text_length", dmy, []types.XValue{ERROR}, ERROR},
+		{"text_length", dmy, []types.XValue{}, ERROR},
 
 		{"time", dmy, []types.XValue{xs("10:30")}, xt(utils.NewTimeOfDay(10, 30, 0, 0))},
 		{"time", dmy, []types.XValue{ERROR}, ERROR},

--- a/excellent/types/array.go
+++ b/excellent/types/array.go
@@ -11,7 +11,7 @@ import (
 //
 //   @(array(1, "x", true)) -> [1, x, true]
 //   @(array(1, "x", true)[1]) -> x
-//   @(length(array(1, "x", true))) -> 3
+//   @(count(array(1, "x", true))) -> 3
 //   @(json(array(1, "x", true))) -> [1,"x",true]
 //
 // @type array
@@ -42,7 +42,7 @@ func (x *XArray) Describe() string { return "array" }
 
 // ToXText converts this type to text
 func (x *XArray) ToXText(env utils.Environment) XText {
-	parts := make([]string, x.Length())
+	parts := make([]string, x.Count())
 	for i, v := range x.values() {
 		vAsText, xerr := ToXText(env, v)
 		if xerr != nil {
@@ -55,7 +55,7 @@ func (x *XArray) ToXText(env utils.Environment) XText {
 
 // ToXBoolean converts this type to a bool
 func (x *XArray) ToXBoolean() XBoolean {
-	return NewXBoolean(len(x.values()) > 0)
+	return NewXBoolean(x.Count() > 0)
 }
 
 // Get is called when this object is indexed
@@ -63,14 +63,14 @@ func (x *XArray) Get(index int) XValue {
 	return x.values()[index]
 }
 
-// Length is called when the length of this object is requested in an expression
-func (x *XArray) Length() int {
+// Count is called when the length of this object is requested in an expression
+func (x *XArray) Count() int {
 	return len(x.values())
 }
 
 // MarshalJSON converts this type to internal JSON
 func (x *XArray) MarshalJSON() ([]byte, error) {
-	marshaled := make([]json.RawMessage, len(x.values()))
+	marshaled := make([]json.RawMessage, x.Count())
 	for i, v := range x.values() {
 		asJSON, err := ToXJSON(v)
 		if err == nil {
@@ -82,7 +82,7 @@ func (x *XArray) MarshalJSON() ([]byte, error) {
 
 // String returns the native string representation of this type
 func (x *XArray) String() string {
-	parts := make([]string, x.Length())
+	parts := make([]string, x.Count())
 	for i, v := range x.values() {
 		parts[i] = String(v)
 	}
@@ -91,7 +91,7 @@ func (x *XArray) String() string {
 
 // Equals determines equality for this type
 func (x *XArray) Equals(other *XArray) bool {
-	if x.Length() != other.Length() {
+	if x.Count() != other.Count() {
 		return false
 	}
 

--- a/excellent/types/array_test.go
+++ b/excellent/types/array_test.go
@@ -13,7 +13,7 @@ func TestXArray(t *testing.T) {
 	env := utils.NewEnvironmentBuilder().Build()
 
 	arr1 := types.NewXArray(types.NewXText("abc"), types.NewXNumberFromInt(123), types.XBooleanFalse)
-	assert.Equal(t, 3, arr1.Length())
+	assert.Equal(t, 3, arr1.Count())
 	assert.Equal(t, types.NewXText("abc"), arr1.Get(0))
 	assert.Equal(t, types.NewXNumberFromInt(123), arr1.Get(1))
 
@@ -45,7 +45,7 @@ func TestXLazyArray(t *testing.T) {
 
 	assert.False(t, initialized)
 
-	assert.Equal(t, 3, arr1.Length())
+	assert.Equal(t, 3, arr1.Count())
 	assert.Equal(t, types.NewXText("abc"), arr1.Get(0))
 	assert.Equal(t, types.NewXNumberFromInt(123), arr1.Get(1))
 	assert.Equal(t, types.NewXText(`[abc, 123, false]`), arr1.ToXText(env))

--- a/excellent/types/base.go
+++ b/excellent/types/base.go
@@ -23,9 +23,9 @@ type XValue interface {
 	ToXBoolean() XBoolean
 }
 
-// XLengthable is the interface for types which have a length
-type XLengthable interface {
-	Length() int
+// XCountable is the interface for types which can be counted
+type XCountable interface {
+	Count() int
 }
 
 // Equals checks for equality between the two give values. This is only used for testing as x = y
@@ -77,9 +77,15 @@ func IsEmpty(x XValue) bool {
 		return true
 	}
 
-	// anything with length of zero is empty
-	asLengthable, isLengthable := x.(XLengthable)
-	if isLengthable && asLengthable.Length() == 0 {
+	// empty string is empty
+	text, isText := x.(XText)
+	if isText && text.Length() == 0 {
+		return true
+	}
+
+	// anything with count of zero is empty
+	countable, isCountable := x.(XCountable)
+	if isCountable && countable != nil && countable.Count() == 0 {
 		return true
 	}
 

--- a/excellent/types/dict.go
+++ b/excellent/types/dict.go
@@ -14,13 +14,13 @@ import (
 //   @(dict("foo", 1, "bar", "x")) -> {bar: x, foo: 1}
 //   @(dict("foo", 1, "bar", "x").bar) -> x
 //   @(dict("foo", 1, "bar", "x")["bar"]) -> x
-//   @(length(dict("foo", 1, "bar", "x"))) -> 2
+//   @(count(dict("foo", 1, "bar", "x"))) -> 2
 //   @(json(dict("foo", 1, "bar", "x"))) -> {"bar":"x","foo":1}
 //
 // @type dict
 type XDict struct {
 	XValue
-	XLengthable
+	XCountable
 
 	data   map[string]XValue
 	source func() map[string]XValue
@@ -45,7 +45,7 @@ func (x *XDict) Describe() string { return "dict" }
 
 // ToXText converts this type to text
 func (x *XDict) ToXText(env utils.Environment) XText {
-	pairs := make([]string, 0, x.Length())
+	pairs := make([]string, 0, x.Count())
 	for _, k := range x.keys(true) {
 		vAsText, xerr := ToXText(env, x.values()[k])
 		if xerr != nil {
@@ -59,12 +59,12 @@ func (x *XDict) ToXText(env utils.Environment) XText {
 
 // ToXBoolean converts this type to a bool
 func (x *XDict) ToXBoolean() XBoolean {
-	return NewXBoolean(len(x.values()) > 0)
+	return NewXBoolean(x.Count() > 0)
 }
 
 // MarshalJSON converts this type to internal JSON
 func (x *XDict) MarshalJSON() ([]byte, error) {
-	marshaled := make(map[string]json.RawMessage, len(x.values()))
+	marshaled := make(map[string]json.RawMessage, x.Count())
 	for k, v := range x.values() {
 		asJSON, err := ToXJSON(v)
 		if err == nil {
@@ -74,8 +74,8 @@ func (x *XDict) MarshalJSON() ([]byte, error) {
 	return json.Marshal(marshaled)
 }
 
-// Length is called when the length of this object is requested in an expression
-func (x *XDict) Length() int {
+// Count is called when the length of this object is requested in an expression
+func (x *XDict) Count() int {
 	return len(x.values())
 }
 
@@ -98,7 +98,7 @@ func (x *XDict) Keys() []string {
 
 // String returns the native string representation of this type for debugging
 func (x *XDict) String() string {
-	pairs := make([]string, 0, x.Length())
+	pairs := make([]string, 0, x.Count())
 	for _, k := range x.keys(true) {
 		pairs = append(pairs, fmt.Sprintf("%s: %s", k, String(x.values()[k])))
 	}
@@ -128,7 +128,7 @@ func (x *XDict) Equals(other *XDict) bool {
 }
 
 func (x *XDict) keys(sorted bool) []string {
-	keys := make([]string, 0, len(x.values()))
+	keys := make([]string, 0, x.Count())
 	for key := range x.values() {
 		keys = append(keys, key)
 	}

--- a/excellent/types/dict_test.go
+++ b/excellent/types/dict_test.go
@@ -18,7 +18,7 @@ func TestXDict(t *testing.T) {
 		"zed": types.XBooleanFalse,
 		"xxx": nil,
 	})
-	assert.Equal(t, 4, dict.Length())
+	assert.Equal(t, 4, dict.Count())
 	assert.ElementsMatch(t, []string{"foo", "bar", "zed", "xxx"}, dict.Keys())
 
 	val, exists := dict.Get("foo")
@@ -56,7 +56,7 @@ func TestXLazyDict(t *testing.T) {
 
 	dict := types.NewXLazyDict(func() map[string]types.XValue {
 		initialized = true
-		
+
 		return map[string]types.XValue{
 			"foo": types.NewXText("abc"),
 			"bar": types.NewXNumberFromInt(123),
@@ -66,7 +66,7 @@ func TestXLazyDict(t *testing.T) {
 
 	assert.False(t, initialized)
 
-	assert.Equal(t, 3, dict.Length())
+	assert.Equal(t, 3, dict.Count())
 	assert.ElementsMatch(t, []string{"foo", "bar", "zed"}, dict.Keys())
 	assert.Equal(t, types.NewXText("{bar: 123, foo: abc, zed: false}"), dict.ToXText(env))
 	assert.Equal(t, "dict", dict.Describe())

--- a/excellent/types/text.go
+++ b/excellent/types/text.go
@@ -12,7 +12,7 @@ import (
 // XText is a string of characters.
 //
 //   @("abc") -> abc
-//   @(length("abc")) -> 3
+//   @(text_length("abc")) -> 3
 //   @(upper("abc")) -> ABC
 //   @(json("abc")) -> "abc"
 //
@@ -78,7 +78,6 @@ func (x *XText) UnmarshalJSON(data []byte) error {
 // XTextEmpty is the empty text value
 var XTextEmpty = NewXText("")
 var _ XValue = XTextEmpty
-var _ XLengthable = XTextEmpty
 
 // ToXText converts the given value to a string
 func ToXText(env utils.Environment, x XValue) (XText, XError) {

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -61,7 +61,7 @@ var templateTests = []struct {
 	// contact groups
 	{`@(foreach(contact.groups, extract, "name"))`, `[Testers, Males]`, ""},
 	{`@(join(foreach(contact.groups, extract, "name"), "|"))`, `Testers|Males`, ""},
-	{`@(length(contact.groups))`, "2", ""},
+	{`@(count(contact.groups))`, "2", ""},
 
 	// contact fields
 	{"@contact.fields", "{activation_token: AACC55, age: 23, gender: Male, join_date: 2017-12-02T00:00:00.000000-02:00, not_set: }", ""},
@@ -71,7 +71,7 @@ var templateTests = []struct {
 	{"@contact.fields.favorite_icecream", "", "error evaluating @contact.fields.favorite_icecream: dict has no property 'favorite_icecream'"},
 	{"@(is_error(contact.fields.favorite_icecream))", "true", ""},
 	{"@(has_error(contact.fields.favorite_icecream))", "{match: dict has no property 'favorite_icecream'}", ""},
-	{"@(length(contact.fields))", "5", ""},
+	{"@(count(contact.fields))", "5", ""},
 
 	// simplifed field access
 	{"@fields", "{activation_token: AACC55, age: 23, gender: Male, join_date: 2017-12-02T00:00:00.000000-02:00, not_set: }", ""},
@@ -81,7 +81,7 @@ var templateTests = []struct {
 	{"@fields.favorite_icecream", "", "error evaluating @fields.favorite_icecream: dict has no property 'favorite_icecream'"},
 	{"@(is_error(fields.favorite_icecream))", "true", ""},
 	{"@(has_error(fields.favorite_icecream))", "{match: dict has no property 'favorite_icecream'}", ""},
-	{"@(length(fields))", "5", ""},
+	{"@(count(fields))", "5", ""},
 
 	{"@input", "{attachments: [image/jpeg:http://s3.amazon.com/bucket/test.jpg, audio/mp3:http://s3.amazon.com/bucket/test.mp3], channel: {address: +12345671111, name: My Android Phone, uuid: 57f1078f-88aa-46f4-a59a-948a5739c03d}, created_on: 2017-12-31T11:35:10.035757-02:00, text: Hi there, type: msg, urn: tel:+12065551212, uuid: 9bf91c2b-ce58-4cef-aacc-281e03f69ab5}", ""},
 	{"@input.text", "Hi there", ""},
@@ -96,7 +96,7 @@ var templateTests = []struct {
 	{"@results.favorite_color.category_localized", "Red", ""},
 	{"@(is_error(results.favorite_icecream))", "true", ""},
 	{"@(has_error(results.favorite_icecream))", "{match: dict has no property 'favorite_icecream'}", ""},
-	{"@(length(results))", "3", ""},
+	{"@(count(results))", "3", ""},
 
 	{"@run.results.favorite_color", `{categories: [Red], categories_localized: [Red], created_on: 2018-09-13T13:36:30.123456Z, extra: , input: , name: Favorite Color, node_uuid: f5bb9b7a-7b5e-45c3-8f0e-61b4e95edf03, values: [red]}`, ""},
 	{"@run.results.favorite_color.values", "[red]", ""},
@@ -106,13 +106,13 @@ var templateTests = []struct {
 	{"@run.results.favorite_icecream", "", "error evaluating @run.results.favorite_icecream: dict has no property 'favorite_icecream'"},
 	{"@(is_error(run.results.favorite_icecream))", "true", ""},
 	{"@(has_error(run.results.favorite_icecream))", "{match: dict has no property 'favorite_icecream'}", ""},
-	{"@(length(run.results))", "3", ""},
+	{"@(count(run.results))", "3", ""},
 
 	{"@run.status", "completed", ""},
 
 	{"@trigger.params", `{address: {state: WA}, source: website}`, ""},
 	{"@trigger.params.source", "website", ""},
-	{"@(length(trigger.params.address))", "1", ""},
+	{"@(count(trigger.params.address))", "1", ""},
 
 	// migrated split by expressions
 	{`@(if(is_error(results.favorite_color.value), "@flow.favorite_color", results.favorite_color.value))`, `red`, ""},

--- a/flows/routers/cases/tests.go
+++ b/flows/routers/cases/tests.go
@@ -162,7 +162,7 @@ func HasGroup(env utils.Environment, arg1 types.XValue, arg2 types.XValue) types
 		return xerr
 	}
 
-	for i := 0; i < array.Length(); i++ {
+	for i := 0; i < array.Count(); i++ {
 		group, xerr := types.ToXDict(env, array.Get(i))
 		if xerr != nil {
 			return xerr

--- a/flows/runs/legacy.go
+++ b/flows/runs/legacy.go
@@ -89,8 +89,8 @@ func (e *legacyExtra) addValues(values types.XValue) {
 }
 
 func arrayToDict(array *types.XArray) *types.XDict {
-	m := make(map[string]types.XValue, array.Length())
-	for i := 0; i < array.Length(); i++ {
+	m := make(map[string]types.XValue, array.Count())
+	for i := 0; i < array.Count(); i++ {
 		m[strconv.Itoa(i)] = array.Get(i)
 	}
 	return types.NewXDict(m)

--- a/legacy/expressions/functions.go
+++ b/legacy/expressions/functions.go
@@ -124,7 +124,7 @@ var callMigrators = map[string]callMigrator{
 	"if":                asIs(),
 	"int":               asRename(`round_down`),
 	"left":              asIs(),
-	"len":               asRename(`length`),
+	"len":               asRename(`text_length`),
 	"lower":             asIs(),
 	"max":               asIs(),
 	"min":               asIs(),

--- a/legacy/expressions/functions_test.go
+++ b/legacy/expressions/functions_test.go
@@ -47,7 +47,7 @@ func TestMigrateFunctionCall(t *testing.T) {
 		{old: `@(IF(contact.gender = "M", "Sir", "Madam"))`, new: `@(if(fields.gender = "M", "Sir", "Madam"))`, val: `Madam`},
 		{old: `@(INT(contact.age))`, new: `@(round_down(fields.age))`, val: `23`},
 		{old: `@(LEFT(contact.name, 4))`, new: `@(left(contact.name, 4))`, val: `Ryan`},
-		{old: `@(LEN(contact.first_name))`, new: `@(length(contact.first_name))`, val: `4`},
+		{old: `@(LEN(contact.first_name))`, new: `@(text_length(contact.first_name))`, val: `4`},
 		{old: `@(LOWER(contact.first_name))`, new: `@(lower(contact.first_name))`, val: `ryan`},
 		{old: `@(MAX(child.age, 10))`, new: `@(max(child.results.age.values[0], 10))`, val: `23`},
 		{old: `@(MIN(child.age, 10))`, new: `@(min(child.results.age.values[0], 10))`, val: `10`},


### PR DESCRIPTION
This still feels like a step backwards in terms of simplicity but here we are. Especially since we tried to make `text(x) == x` work as a general principle and it didn't really work. 

`length(urns) == 12343` and `length(dict()) == 2` would be pretty unintuitive so for now am calling the length-converted-to-text method `text_length` (we already have `text_compare`), and the one that works on arrays and dicts, `count`.

We can have a final discussion about function names in a different issue, but I think it's important to make those decisions looking at all the names together.

Addresses #575 