### PR TITLE
🧹 Simpler template enumeration and rewriting

### DIFF
--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -85,6 +85,6 @@ func (a *AddContactURNAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *AddContactURNAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *AddContactURNAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Path)
 }

--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -85,8 +85,8 @@ func (a *AddContactURNAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *AddContactURNAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Path)
+func (a *AddContactURNAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Path)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -88,8 +88,3 @@ func (a *AddContactURNAction) Inspect(inspect func(flows.Inspectable)) {
 func (a *AddContactURNAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 	include.String(&a.Path)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *AddContactURNAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Path = rewrite(a.Path)
-}

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -60,7 +60,7 @@ func (a *BaseAction) Validate() error { return nil }
 func (a *BaseAction) LocalizationUUID() utils.UUID { return utils.UUID(a.UUID_) }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *BaseAction) EnumerateTemplates(localization flows.Localization, include func(string)) {}
+func (a *BaseAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {}
 
 // RewriteTemplates rewrites all templates on this object and its children
 func (a *BaseAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {}

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -60,7 +60,7 @@ func (a *BaseAction) Validate() error { return nil }
 func (a *BaseAction) LocalizationUUID() utils.UUID { return utils.UUID(a.UUID_) }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *BaseAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {}
+func (a *BaseAction) EnumerateTemplates(include flows.TemplateIncluder) {}
 
 // EnumerateDependencies enumerates all dependencies on this object and its children
 func (a *BaseAction) EnumerateDependencies(localization flows.Localization, include func(assets.Reference)) {

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -62,9 +62,6 @@ func (a *BaseAction) LocalizationUUID() utils.UUID { return utils.UUID(a.UUID_) 
 // EnumerateTemplates enumerates all expressions on this object and its children
 func (a *BaseAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {}
 
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *BaseAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {}
-
 // EnumerateDependencies enumerates all dependencies on this object and its children
 func (a *BaseAction) EnumerateDependencies(localization flows.Localization, include func(assets.Reference)) {
 }

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -136,7 +136,7 @@ func (a *CallWebhookAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *CallWebhookAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *CallWebhookAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.URL)
 	include.String(&a.Body)
 	include.Map(a.Headers)

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -142,15 +142,6 @@ func (a *CallWebhookAction) EnumerateTemplates(localization flows.Localization, 
 	include.Map(a.Headers)
 }
 
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *CallWebhookAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.URL = rewrite(a.URL)
-	a.Body = rewrite(a.Body)
-	for k, v := range a.Headers {
-		a.Headers[k] = rewrite(v)
-	}
-}
-
 // EnumerateResults enumerates all potential results on this object
 func (a *CallWebhookAction) EnumerateResults(include func(*flows.ResultSpec)) {
 	if a.ResultName != "" {

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -136,12 +136,10 @@ func (a *CallWebhookAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *CallWebhookAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.URL)
-	include(a.Body)
-	for _, v := range a.Headers {
-		include(v)
-	}
+func (a *CallWebhookAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.URL)
+	include.String(&a.Body)
+	include.Map(a.Headers)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/play_audio.go
+++ b/flows/actions/play_audio.go
@@ -75,7 +75,7 @@ func (a *PlayAudioAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *PlayAudioAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *PlayAudioAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.AudioURL)
-	flows.EnumerateTemplateTranslations(localization, a, "audio_url", include)
+	include.Translations(a, "audio_url")
 }

--- a/flows/actions/play_audio.go
+++ b/flows/actions/play_audio.go
@@ -75,8 +75,8 @@ func (a *PlayAudioAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *PlayAudioAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.AudioURL)
+func (a *PlayAudioAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.AudioURL)
 	flows.EnumerateTemplateTranslations(localization, a, "audio_url", include)
 }
 

--- a/flows/actions/play_audio.go
+++ b/flows/actions/play_audio.go
@@ -79,9 +79,3 @@ func (a *PlayAudioAction) EnumerateTemplates(localization flows.Localization, in
 	include.String(&a.AudioURL)
 	flows.EnumerateTemplateTranslations(localization, a, "audio_url", include)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *PlayAudioAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.AudioURL = rewrite(a.AudioURL)
-	flows.RewriteTemplateTranslations(localization, a, "audio_url", rewrite)
-}

--- a/flows/actions/say_msg.go
+++ b/flows/actions/say_msg.go
@@ -86,7 +86,7 @@ func (a *SayMsgAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SayMsgAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SayMsgAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Text)
-	flows.EnumerateTemplateTranslations(localization, a, "text", include)
+	include.Translations(a, "text")
 }

--- a/flows/actions/say_msg.go
+++ b/flows/actions/say_msg.go
@@ -86,8 +86,8 @@ func (a *SayMsgAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SayMsgAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Text)
+func (a *SayMsgAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Text)
 	flows.EnumerateTemplateTranslations(localization, a, "text", include)
 }
 

--- a/flows/actions/say_msg.go
+++ b/flows/actions/say_msg.go
@@ -90,9 +90,3 @@ func (a *SayMsgAction) EnumerateTemplates(localization flows.Localization, inclu
 	include.String(&a.Text)
 	flows.EnumerateTemplateTranslations(localization, a, "text", include)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SayMsgAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Text = rewrite(a.Text)
-	flows.RewriteTemplateTranslations(localization, a, "text", rewrite)
-}

--- a/flows/actions/send_broadcast.go
+++ b/flows/actions/send_broadcast.go
@@ -94,14 +94,16 @@ func (a *SendBroadcastAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SendBroadcastAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Text)
-	flows.EnumerateTemplateArray(a.Attachments, include)
-	flows.EnumerateTemplateArray(a.QuickReplies, include)
+func (a *SendBroadcastAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Text)
+	include.Slice(a.Attachments)
+	include.Slice(a.QuickReplies)
+	include.Slice(a.LegacyVars)
+
 	flows.EnumerateTemplateTranslations(localization, a, "text", include)
 	flows.EnumerateTemplateTranslations(localization, a, "attachments", include)
 	flows.EnumerateTemplateTranslations(localization, a, "quick_replies", include)
-	flows.EnumerateTemplateArray(a.LegacyVars, include)
+
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/send_broadcast.go
+++ b/flows/actions/send_broadcast.go
@@ -106,13 +106,3 @@ func (a *SendBroadcastAction) EnumerateTemplates(localization flows.Localization
 
 }
 
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SendBroadcastAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Text = rewrite(a.Text)
-	flows.RewriteTemplateArray(a.Attachments, rewrite)
-	flows.RewriteTemplateArray(a.QuickReplies, rewrite)
-	flows.RewriteTemplateTranslations(localization, a, "text", rewrite)
-	flows.RewriteTemplateTranslations(localization, a, "attachments", rewrite)
-	flows.RewriteTemplateTranslations(localization, a, "quick_replies", rewrite)
-	flows.RewriteTemplateArray(a.LegacyVars, rewrite)
-}

--- a/flows/actions/send_broadcast.go
+++ b/flows/actions/send_broadcast.go
@@ -94,15 +94,12 @@ func (a *SendBroadcastAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SendBroadcastAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SendBroadcastAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Text)
 	include.Slice(a.Attachments)
 	include.Slice(a.QuickReplies)
+	include.Translations(a, "text")
+	include.Translations(a, "attachments")
+	include.Translations(a, "quick_replies")
 	include.Slice(a.LegacyVars)
-
-	flows.EnumerateTemplateTranslations(localization, a, "text", include)
-	flows.EnumerateTemplateTranslations(localization, a, "attachments", include)
-	flows.EnumerateTemplateTranslations(localization, a, "quick_replies", include)
-
 }
-

--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -106,10 +106,10 @@ func (a *SendEmailAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SendEmailAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Subject)
-	include(a.Body)
-	flows.EnumerateTemplateArray(a.Addresses, include)
+func (a *SendEmailAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Subject)
+	include.String(&a.Body)
+	include.Slice(a.Addresses)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -111,10 +111,3 @@ func (a *SendEmailAction) EnumerateTemplates(localization flows.Localization, in
 	include.String(&a.Body)
 	include.Slice(a.Addresses)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SendEmailAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Subject = rewrite(a.Subject)
-	a.Body = rewrite(a.Body)
-	flows.RewriteTemplateArray(a.Addresses, rewrite)
-}

--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -106,7 +106,7 @@ func (a *SendEmailAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SendEmailAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SendEmailAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Subject)
 	include.String(&a.Body)
 	include.Slice(a.Addresses)

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -141,17 +141,3 @@ func (a *SendMsgAction) EnumerateTemplates(localization flows.Localization, incl
 	flows.EnumerateTemplateTranslations(localization, a, "attachments", include)
 	flows.EnumerateTemplateTranslations(localization, a, "quick_replies", include)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SendMsgAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Text = rewrite(a.Text)
-	flows.RewriteTemplateArray(a.Attachments, rewrite)
-	flows.RewriteTemplateArray(a.QuickReplies, rewrite)
-	if a.Templating != nil {
-		flows.RewriteTemplateArray(a.Templating.Variables, rewrite)
-	}
-
-	flows.RewriteTemplateTranslations(localization, a, "text", rewrite)
-	flows.RewriteTemplateTranslations(localization, a, "attachments", rewrite)
-	flows.RewriteTemplateTranslations(localization, a, "quick_replies", rewrite)
-}

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -129,7 +129,7 @@ func (a *SendMsgAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SendMsgAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SendMsgAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Text)
 	include.Slice(a.Attachments)
 	include.Slice(a.QuickReplies)
@@ -137,7 +137,7 @@ func (a *SendMsgAction) EnumerateTemplates(localization flows.Localization, incl
 		include.Slice(a.Templating.Variables)
 	}
 
-	flows.EnumerateTemplateTranslations(localization, a, "text", include)
-	flows.EnumerateTemplateTranslations(localization, a, "attachments", include)
-	flows.EnumerateTemplateTranslations(localization, a, "quick_replies", include)
+	include.Translations(a, "text")
+	include.Translations(a, "attachments")
+	include.Translations(a, "quick_replies")
 }

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -129,12 +129,12 @@ func (a *SendMsgAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SendMsgAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Text)
-	flows.EnumerateTemplateArray(a.Attachments, include)
-	flows.EnumerateTemplateArray(a.QuickReplies, include)
+func (a *SendMsgAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Text)
+	include.Slice(a.Attachments)
+	include.Slice(a.QuickReplies)
 	if a.Templating != nil {
-		flows.EnumerateTemplateArray(a.Templating.Variables, include)
+		include.Slice(a.Templating.Variables)
 	}
 
 	flows.EnumerateTemplateTranslations(localization, a, "text", include)

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -82,8 +82,3 @@ func (a *SetContactFieldAction) Inspect(inspect func(flows.Inspectable)) {
 func (a *SetContactFieldAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 	include.String(&a.Value)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SetContactFieldAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Value = rewrite(a.Value)
-}

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -79,8 +79,8 @@ func (a *SetContactFieldAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactFieldAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Value)
+func (a *SetContactFieldAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Value)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -79,6 +79,6 @@ func (a *SetContactFieldAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactFieldAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SetContactFieldAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Value)
 }

--- a/flows/actions/set_contact_language.go
+++ b/flows/actions/set_contact_language.go
@@ -78,6 +78,6 @@ func (a *SetContactLanguageAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactLanguageAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SetContactLanguageAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Language)
 }

--- a/flows/actions/set_contact_language.go
+++ b/flows/actions/set_contact_language.go
@@ -81,8 +81,3 @@ func (a *SetContactLanguageAction) Inspect(inspect func(flows.Inspectable)) {
 func (a *SetContactLanguageAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 	include.String(&a.Language)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SetContactLanguageAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Language = rewrite(a.Language)
-}

--- a/flows/actions/set_contact_language.go
+++ b/flows/actions/set_contact_language.go
@@ -78,8 +78,8 @@ func (a *SetContactLanguageAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactLanguageAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Language)
+func (a *SetContactLanguageAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Language)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/set_contact_name.go
+++ b/flows/actions/set_contact_name.go
@@ -70,8 +70,3 @@ func (a *SetContactNameAction) Inspect(inspect func(flows.Inspectable)) {
 func (a *SetContactNameAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 	include.String(&a.Name)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SetContactNameAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Name = rewrite(a.Name)
-}

--- a/flows/actions/set_contact_name.go
+++ b/flows/actions/set_contact_name.go
@@ -67,8 +67,8 @@ func (a *SetContactNameAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactNameAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Name)
+func (a *SetContactNameAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Name)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/set_contact_name.go
+++ b/flows/actions/set_contact_name.go
@@ -67,6 +67,6 @@ func (a *SetContactNameAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactNameAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SetContactNameAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Name)
 }

--- a/flows/actions/set_contact_timezone.go
+++ b/flows/actions/set_contact_timezone.go
@@ -81,8 +81,3 @@ func (a *SetContactTimezoneAction) Inspect(inspect func(flows.Inspectable)) {
 func (a *SetContactTimezoneAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 	include.String(&a.Timezone)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SetContactTimezoneAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Timezone = rewrite(a.Timezone)
-}

--- a/flows/actions/set_contact_timezone.go
+++ b/flows/actions/set_contact_timezone.go
@@ -78,6 +78,6 @@ func (a *SetContactTimezoneAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactTimezoneAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SetContactTimezoneAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Timezone)
 }

--- a/flows/actions/set_contact_timezone.go
+++ b/flows/actions/set_contact_timezone.go
@@ -78,8 +78,8 @@ func (a *SetContactTimezoneAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetContactTimezoneAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Timezone)
+func (a *SetContactTimezoneAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Timezone)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/set_run_result.go
+++ b/flows/actions/set_run_result.go
@@ -74,7 +74,7 @@ func (a *SetRunResultAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetRunResultAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *SetRunResultAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&a.Value)
 }
 

--- a/flows/actions/set_run_result.go
+++ b/flows/actions/set_run_result.go
@@ -78,11 +78,6 @@ func (a *SetRunResultAction) EnumerateTemplates(localization flows.Localization,
 	include.String(&a.Value)
 }
 
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *SetRunResultAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	a.Value = rewrite(a.Value)
-}
-
 // EnumerateResults enumerates all potential results on this object
 func (a *SetRunResultAction) EnumerateResults(include func(*flows.ResultSpec)) {
 	if a.Category != "" {

--- a/flows/actions/set_run_result.go
+++ b/flows/actions/set_run_result.go
@@ -74,8 +74,8 @@ func (a *SetRunResultAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *SetRunResultAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(a.Value)
+func (a *SetRunResultAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&a.Value)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/start_session.go
+++ b/flows/actions/start_session.go
@@ -83,8 +83,8 @@ func (a *StartSessionAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *StartSessionAction) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	flows.EnumerateTemplateArray(a.LegacyVars, include)
+func (a *StartSessionAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.Slice(a.LegacyVars)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/actions/start_session.go
+++ b/flows/actions/start_session.go
@@ -86,8 +86,3 @@ func (a *StartSessionAction) Inspect(inspect func(flows.Inspectable)) {
 func (a *StartSessionAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 	include.Slice(a.LegacyVars)
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (a *StartSessionAction) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	flows.RewriteTemplateArray(a.LegacyVars, rewrite)
-}

--- a/flows/actions/start_session.go
+++ b/flows/actions/start_session.go
@@ -83,6 +83,6 @@ func (a *StartSessionAction) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (a *StartSessionAction) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (a *StartSessionAction) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.Slice(a.LegacyVars)
 }

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -184,7 +184,7 @@ func (f *flow) inspect(inspect func(flows.Inspectable)) {
 // ExtractTemplates extracts all non-empty templates
 func (f *flow) ExtractTemplates() []string {
 	templates := make([]string, 0)
-	include := flows.NewTemplateIncluder(func(template string) {
+	include := flows.NewTemplateEnumerator(func(template string) {
 		if template != "" {
 			templates = append(templates, template)
 		}
@@ -199,7 +199,7 @@ func (f *flow) ExtractTemplates() []string {
 // RewriteTemplates rewrites all templates
 func (f *flow) RewriteTemplates(rewrite func(string) string) {
 	f.inspect(func(item flows.Inspectable) {
-		item.RewriteTemplates(f.Localization(), rewrite)
+		item.EnumerateTemplates(f.Localization(), flows.NewTemplateRewriter(rewrite))
 	})
 }
 
@@ -217,7 +217,7 @@ func (f *flow) ExtractDependencies() []assets.Reference {
 		}
 	}
 
-	include := flows.NewTemplateIncluder(func(template string) {
+	include := flows.NewTemplateEnumerator(func(template string) {
 		fieldRefs := flows.ExtractFieldReferences(template)
 		for _, f := range fieldRefs {
 			addDependency(f)

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -184,14 +184,14 @@ func (f *flow) inspect(inspect func(flows.Inspectable)) {
 // ExtractTemplates extracts all non-empty templates
 func (f *flow) ExtractTemplates() []string {
 	templates := make([]string, 0)
-	include := flows.NewTemplateEnumerator(func(template string) {
+	include := flows.NewTemplateEnumerator(f.Localization(), func(template string) {
 		if template != "" {
 			templates = append(templates, template)
 		}
 	})
 
 	f.inspect(func(item flows.Inspectable) {
-		item.EnumerateTemplates(f.Localization(), include)
+		item.EnumerateTemplates(include)
 	})
 	return templates
 }
@@ -199,7 +199,7 @@ func (f *flow) ExtractTemplates() []string {
 // RewriteTemplates rewrites all templates
 func (f *flow) RewriteTemplates(rewrite func(string) string) {
 	f.inspect(func(item flows.Inspectable) {
-		item.EnumerateTemplates(f.Localization(), flows.NewTemplateRewriter(rewrite))
+		item.EnumerateTemplates(flows.NewTemplateRewriter(f.Localization(), rewrite))
 	})
 }
 
@@ -217,7 +217,7 @@ func (f *flow) ExtractDependencies() []assets.Reference {
 		}
 	}
 
-	include := flows.NewTemplateEnumerator(func(template string) {
+	include := flows.NewTemplateEnumerator(f.Localization(), func(template string) {
 		fieldRefs := flows.ExtractFieldReferences(template)
 		for _, f := range fieldRefs {
 			addDependency(f)
@@ -225,7 +225,7 @@ func (f *flow) ExtractDependencies() []assets.Reference {
 	})
 
 	f.inspect(func(item flows.Inspectable) {
-		item.EnumerateTemplates(f.Localization(), include)
+		item.EnumerateTemplates(include)
 		item.EnumerateDependencies(f.Localization(), func(r assets.Reference) {
 			addDependency(r)
 		})

--- a/flows/definition/node.go
+++ b/flows/definition/node.go
@@ -105,7 +105,7 @@ func (n *node) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object
-func (n *node) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {}
+func (n *node) EnumerateTemplates(include flows.TemplateIncluder) {}
 
 // EnumerateDependencies enumerates all dependencies on this object
 func (n *node) EnumerateDependencies(localization flows.Localization, include func(assets.Reference)) {

--- a/flows/definition/node.go
+++ b/flows/definition/node.go
@@ -105,7 +105,7 @@ func (n *node) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object
-func (n *node) EnumerateTemplates(localization flows.Localization, include func(string)) {}
+func (n *node) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {}
 
 // RewriteTemplates rewrites all templates on this object
 func (n *node) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {}

--- a/flows/definition/node.go
+++ b/flows/definition/node.go
@@ -107,9 +107,6 @@ func (n *node) Inspect(inspect func(flows.Inspectable)) {
 // EnumerateTemplates enumerates all expressions on this object
 func (n *node) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {}
 
-// RewriteTemplates rewrites all templates on this object
-func (n *node) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {}
-
 // EnumerateDependencies enumerates all dependencies on this object
 func (n *node) EnumerateDependencies(localization flows.Localization, include func(assets.Reference)) {
 }

--- a/flows/expressions.go
+++ b/flows/expressions.go
@@ -85,37 +85,10 @@ func isFieldRefPath(path []string) (bool, string) {
 	return false, ""
 }
 
-// EnumerateTemplateArray enumerates each template in the array
-func EnumerateTemplateArray(templates []string, include func(string)) {
-	for _, template := range templates {
-		include(template)
-	}
-}
-
-// RewriteTemplateArray rewrites each template in the array
-func RewriteTemplateArray(templates []string, rewrite func(string) string) {
-	for t := range templates {
-		templates[t] = rewrite(templates[t])
-	}
-}
-
 func EnumerateTemplateTranslations(localization Localization, localizable Localizable, key string, include TemplateIncluder) {
 	for _, lang := range localization.Languages() {
 		translations := localization.GetTranslations(lang)
 		include.Slice(translations.GetTextArray(localizable.LocalizationUUID(), key))
-	}
-}
-
-func RewriteTemplateTranslations(localization Localization, localizable Localizable, key string, rewrite func(string) string) {
-	for _, lang := range localization.Languages() {
-		translations := localization.GetTranslations(lang)
-
-		templates := translations.GetTextArray(localizable.LocalizationUUID(), key)
-		rewritten := make([]string, len(templates))
-		for t := range templates {
-			rewritten[t] = rewrite(templates[t])
-		}
-		translations.SetTextArray(localizable.LocalizationUUID(), key, rewritten)
 	}
 }
 
@@ -144,18 +117,6 @@ func (r inspectableReference) EnumerateTemplates(localization Localization, incl
 			include.String(&typed.NameMatch)
 		case *assets.LabelReference:
 			include.String(&typed.NameMatch)
-		}
-	}
-}
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (r inspectableReference) RewriteTemplates(localization Localization, rewrite func(string) string) {
-	if r.ref != nil && r.ref.Variable() {
-		switch typed := r.ref.(type) {
-		case *assets.GroupReference:
-			typed.NameMatch = rewrite(typed.NameMatch)
-		case *assets.LabelReference:
-			typed.NameMatch = rewrite(typed.NameMatch)
 		}
 	}
 }

--- a/flows/expressions.go
+++ b/flows/expressions.go
@@ -99,12 +99,10 @@ func RewriteTemplateArray(templates []string, rewrite func(string) string) {
 	}
 }
 
-func EnumerateTemplateTranslations(localization Localization, localizable Localizable, key string, include func(string)) {
+func EnumerateTemplateTranslations(localization Localization, localizable Localizable, key string, include TemplateIncluder) {
 	for _, lang := range localization.Languages() {
 		translations := localization.GetTranslations(lang)
-		for _, tpl := range translations.GetTextArray(localizable.LocalizationUUID(), key) {
-			include(tpl)
-		}
+		include.Slice(translations.GetTextArray(localizable.LocalizationUUID(), key))
 	}
 }
 
@@ -139,13 +137,13 @@ func (r inspectableReference) Inspect(inspect func(Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (r inspectableReference) EnumerateTemplates(localization Localization, include func(string)) {
+func (r inspectableReference) EnumerateTemplates(localization Localization, include TemplateIncluder) {
 	if r.ref != nil && r.ref.Variable() {
 		switch typed := r.ref.(type) {
 		case *assets.GroupReference:
-			include(typed.NameMatch)
+			include.String(&typed.NameMatch)
 		case *assets.LabelReference:
-			include(typed.NameMatch)
+			include.String(&typed.NameMatch)
 		}
 	}
 }

--- a/flows/routers/base.go
+++ b/flows/routers/base.go
@@ -59,7 +59,8 @@ func (r *BaseRouter) AllowTimeout() bool {
 func (r *BaseRouter) ResultName() string { return r.resultName }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (r *BaseRouter) EnumerateTemplates(localization flows.Localization, include func(string)) {}
+func (r *BaseRouter) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+}
 
 // RewriteTemplates rewrites all templates on this object and its children
 func (r *BaseRouter) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {}

--- a/flows/routers/base.go
+++ b/flows/routers/base.go
@@ -59,8 +59,9 @@ func (r *BaseRouter) AllowTimeout() bool {
 func (r *BaseRouter) ResultName() string { return r.resultName }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (r *BaseRouter) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (r *BaseRouter) EnumerateTemplates(include flows.TemplateIncluder) {
 }
+
 // EnumerateDependencies enumerates all dependencies on this object
 func (r *BaseRouter) EnumerateDependencies(localization flows.Localization, include func(assets.Reference)) {
 }

--- a/flows/routers/base.go
+++ b/flows/routers/base.go
@@ -61,10 +61,6 @@ func (r *BaseRouter) ResultName() string { return r.resultName }
 // EnumerateTemplates enumerates all expressions on this object and its children
 func (r *BaseRouter) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 }
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (r *BaseRouter) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {}
-
 // EnumerateDependencies enumerates all dependencies on this object
 func (r *BaseRouter) EnumerateDependencies(localization flows.Localization, include func(assets.Reference)) {
 }

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -48,10 +48,8 @@ func (c *Case) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (c *Case) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	for _, arg := range c.Arguments {
-		include(arg)
-	}
+func (c *Case) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.Slice(c.Arguments)
 
 	flows.EnumerateTemplateTranslations(localization, c, "arguments", include)
 }
@@ -231,8 +229,8 @@ func (r *SwitchRouter) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (r *SwitchRouter) EnumerateTemplates(localization flows.Localization, include func(string)) {
-	include(r.operand)
+func (r *SwitchRouter) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+	include.String(&r.operand)
 }
 
 // RewriteTemplates rewrites all templates on this object and its children

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -48,10 +48,9 @@ func (c *Case) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (c *Case) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (c *Case) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.Slice(c.Arguments)
-
-	flows.EnumerateTemplateTranslations(localization, c, "arguments", include)
+	include.Translations(c, "arguments")
 }
 
 // EnumerateDependencies enumerates all dependencies on this object and its children
@@ -220,7 +219,7 @@ func (r *SwitchRouter) Inspect(inspect func(flows.Inspectable)) {
 }
 
 // EnumerateTemplates enumerates all expressions on this object and its children
-func (r *SwitchRouter) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
+func (r *SwitchRouter) EnumerateTemplates(include flows.TemplateIncluder) {
 	include.String(&r.operand)
 }
 

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -54,15 +54,6 @@ func (c *Case) EnumerateTemplates(localization flows.Localization, include flows
 	flows.EnumerateTemplateTranslations(localization, c, "arguments", include)
 }
 
-// RewriteTemplates rewrites all templates on this object and its children
-func (c *Case) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	for a := range c.Arguments {
-		c.Arguments[a] = rewrite(c.Arguments[a])
-	}
-
-	flows.RewriteTemplateTranslations(localization, c, "arguments", rewrite)
-}
-
 // EnumerateDependencies enumerates all dependencies on this object and its children
 func (c *Case) EnumerateDependencies(localization flows.Localization, include func(assets.Reference)) {
 	// currently only the HAS_GROUP router test can produce a dependency
@@ -231,11 +222,6 @@ func (r *SwitchRouter) Inspect(inspect func(flows.Inspectable)) {
 // EnumerateTemplates enumerates all expressions on this object and its children
 func (r *SwitchRouter) EnumerateTemplates(localization flows.Localization, include flows.TemplateIncluder) {
 	include.String(&r.operand)
-}
-
-// RewriteTemplates rewrites all templates on this object and its children
-func (r *SwitchRouter) RewriteTemplates(localization flows.Localization, rewrite func(string) string) {
-	r.operand = rewrite(r.operand)
 }
 
 // EnumerateDependencies enumerates all dependencies on this object and its children


### PR DESCRIPTION
Addresses #548 by adding a `TemplateIncluder` that can both enumerate and rewrite Excellent templates so those don't have to be separate things.