### PR TITLE
🧮 Match number like .5 and 1OO (o's) as 1)

### DIFF
--- a/flows/routers/cases/tests.go
+++ b/flows/routers/cases/tests.go
@@ -836,8 +836,10 @@ func hasOnlyPhraseTest(origHays []string, hays []string, pins []string) types.XV
 
 // ParseDecimalFuzzy parses a decimal from a string
 func ParseDecimalFuzzy(val string, format *utils.NumberFormat) (decimal.Decimal, error) {
+	cleaned := strings.TrimSpace(val)
+
 	// remove digit grouping symbol
-	cleaned := strings.Replace(val, format.DigitGroupingSymbol, "", -1)
+	cleaned = strings.Replace(cleaned, format.DigitGroupingSymbol, "", -1)
 
 	// replace non-period decimal symbols
 	cleaned = strings.Replace(cleaned, format.DecimalSymbol, ".", -1)
@@ -849,7 +851,7 @@ type decimalTest func(value decimal.Decimal, test1 decimal.Decimal, test2 decima
 
 func testNumber(env utils.Environment, str types.XText, testNum1 types.XNumber, testNum2 types.XNumber, testFunc decimalTest) types.XValue {
 	// create a number finding regex based on current environment
-	pattern := regexp.MustCompile(fmt.Sprintf(`[-+]?[\pNlO\%s]+(\%s[\pNlO]+)?`, env.NumberFormat().DigitGroupingSymbol, env.NumberFormat().DecimalSymbol))
+	pattern := regexp.MustCompile(fmt.Sprintf(`[-+]?([\pN\%[1]s]+(\%[2]s[\pN]+)?|(\W|^)\%[2]s[\pN]+)`, env.NumberFormat().DigitGroupingSymbol, env.NumberFormat().DecimalSymbol))
 
 	// look for number like things in the input and use the first one that we can actually parse
 	for _, value := range pattern.FindAllString(str.Native(), -1) {

--- a/flows/routers/cases/tests_test.go
+++ b/flows/routers/cases/tests_test.go
@@ -116,8 +116,10 @@ var testTests = []struct {
 	{"has_number", []types.XValue{xs("O número é 500")}, result(xn("500"))},
 	{"has_number", []types.XValue{xs("another is -12.51")}, result(xn("-12.51"))},
 	{"has_number", []types.XValue{xs("hi.51")}, result(xn("51"))},
+	{"has_number", []types.XValue{xs("hi .51")}, result(xn("0.51"))},
+	{"has_number", []types.XValue{xs(".51")}, result(xn("0.51"))},
 	{"has_number", []types.XValue{xs("nothing here")}, falseResult},
-	{"has_number", []types.XValue{xs("1OO l00")}, falseResult}, // no longer do substitutions
+	{"has_number", []types.XValue{xs("lOO")}, falseResult}, // no longer do substitutions
 	{"has_number", []types.XValue{xs("one"), xs("two"), xs("three")}, ERROR},
 	{"has_number", []types.XValue{}, ERROR},
 
@@ -326,6 +328,8 @@ func TestParseDecimalFuzzy(t *testing.T) {
 		{"1234", decimal.RequireFromString("1234"), utils.DefaultNumberFormat},
 		{"1,234.567", decimal.RequireFromString("1234.567"), utils.DefaultNumberFormat},
 		{"1.234,567", decimal.RequireFromString("1234.567"), &utils.NumberFormat{DecimalSymbol: ",", DigitGroupingSymbol: "."}},
+		{".1234", decimal.RequireFromString("0.1234"), utils.DefaultNumberFormat},
+		{" .1234", decimal.RequireFromString("0.1234"), utils.DefaultNumberFormat},
 		{"100.00", decimal.RequireFromString("100.00"), utils.DefaultNumberFormat},
 	}
 


### PR DESCRIPTION
Fixes #657 