### PR TITLE
🔥 omit empty variables in templates

### DIFF
--- a/flows/actions/testdata/_assets.json
+++ b/flows/actions/testdata/_assets.json
@@ -194,6 +194,20 @@
                     "content": "Hi {{1}}, who's an excellent {{2}}?"
                 }
             ]
+        },
+        {
+            "name": "wakeup",
+            "uuid": "2edc8dfd-aef0-41cf-a900-8a71bdb00900",
+            "translations": [
+                {
+                    "channel": {
+                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
+                        "name": "My Android Phone"
+                    },
+                    "language": "eng",
+                    "content": "Hi there, it's time to get up!"
+                }
+            ]
         }
     ]
 }

--- a/flows/actions/testdata/send_msg.json
+++ b/flows/actions/testdata/send_msg.json
@@ -316,5 +316,52 @@
             ],
             "results": []
         }
+    },
+    {
+        "description": "Msg with template but no variables",
+        "action": {
+            "type": "send_msg",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "text": "Hi there, it's time to get up!",
+            "templating": {
+                "template": {
+                    "name": "wakeup",
+                    "uuid": "2edc8dfd-aef0-41cf-a900-8a71bdb00900"
+                },
+                "variables": []
+            }
+        },
+        "events": [
+            {
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "msg": {
+                    "urn": "tel:+12065551212?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=123",
+                    "channel": {
+                        "name": "My Android Phone",
+                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                    },
+                    "text": "Hi there, it's time to get up!",
+                    "uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
+                    "templating": {
+                        "template": {
+                            "name": "wakeup",
+                            "uuid": "2edc8dfd-aef0-41cf-a900-8a71bdb00900"
+                        },
+                        "language": "eng"
+                    }
+                },
+                "step_uuid": "e7187099-7d38-4f60-955c-325957214c42",
+                "type": "msg_created"
+            }
+        ],
+        "inspection": {
+            "templates": [
+                "Hi there, it's time to get up!"
+            ],
+            "dependencies": [
+                "template[uuid=2edc8dfd-aef0-41cf-a900-8a71bdb00900,name=wakeup]"
+            ],
+            "results": []
+        }
     }
 ]

--- a/flows/msg.go
+++ b/flows/msg.go
@@ -96,7 +96,7 @@ func (m *MsgOut) Templating() *MsgTemplating { return m.Templating_ }
 type MsgTemplating struct {
 	Template_  *assets.TemplateReference `json:"template"`
 	Language_  utils.Language            `json:"language"`
-	Variables_ []string                  `json:"variables"`
+	Variables_ []string                  `json:"variables,omitempty"`
 }
 
 // Template returns the template this msg template is for


### PR DESCRIPTION
Lua is bananas and considers arrays and dictionaries the same when encoding to JSON. Sadly when it sees something empty it turns it into `{}` instead of `[]` which obviously munges our decoding on the Courier side. Work around by omitting empty variables instead.

This is a hot fix.  