### PR TITLE
 🔥 Make URLJoin honor absolute urls

### DIFF
--- a/legacy/utils.go
+++ b/legacy/utils.go
@@ -93,6 +93,12 @@ func (e *TypedEnvelope) UnmarshalJSON(b []byte) error {
 
 // URLJoin joins two URL parts with /
 func URLJoin(base, relative string) string {
+
+	// noop if we are already absolute
+	if strings.HasPrefix(relative, "http://") || strings.HasPrefix(relative, "https://") {
+		return relative
+	}
+
 	if strings.HasSuffix(base, "/") {
 		base = base[:len(base)-1]
 	}

--- a/legacy/utils_test.go
+++ b/legacy/utils_test.go
@@ -87,4 +87,6 @@ func TestURLJoin(t *testing.T) {
 	assert.Equal(t, "http://myfiles.com/test.jpg", legacy.URLJoin("http://myfiles.com/", "test.jpg"))
 	assert.Equal(t, "http://myfiles.com/test.jpg", legacy.URLJoin("http://myfiles.com", "/test.jpg"))
 	assert.Equal(t, "http://myfiles.com/test.jpg", legacy.URLJoin("http://myfiles.com/", "/test.jpg"))
+	assert.Equal(t, "http://myfiles.com/test.jpg", legacy.URLJoin("http://myfiles.com/", "http://myfiles.com/test.jpg"))
+	assert.Equal(t, "https://myfiles.com/test.jpg", legacy.URLJoin("https://myfiles.com/", "https://myfiles.com/test.jpg"))
 }


### PR DESCRIPTION
Fixes: #667

Customer reported issue. All new attachments aren't being honored since we shipped updated endpoints in RP.