### PR TITLE
💡 Don't create unstarted sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ contact := flows.NewContact(assets, ...)
 env := utils.NewEnvironmentBuilder().Build()
 trigger := triggers.NewManualTrigger(env, contact, flow.Reference(), nil, nil, time.Now())
 eng := engine.NewBuilder().WithDefaultUserAgent("goflow-flowrunner").Build()
-session := eng.NewSession(assets)
-session.Start(trigger)
+session, sprint, err := eng.NewSession(assets, trigger)
 ```
 
 ## Sessions

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -120,10 +120,9 @@ func RunFlow(assetsPath string, flowUUID assets.FlowUUID, initialMsg string, con
 	fmt.Fprintf(out, "Starting flow '%s'....\n---------------------------------------\n", flow.Name())
 
 	eng := engine.NewBuilder().WithDefaultUserAgent("goflow-flowrunner").Build()
-	session := eng.NewSession(sa)
 
 	// start our session
-	sprint, err := session.Start(repro.Trigger)
+	session, sprint, err := eng.NewSession(sa, repro.Trigger)
 	if err != nil {
 		return nil, err
 	}

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -17,14 +17,19 @@ type engine struct {
 }
 
 // NewSession creates a new session
-func (e *engine) NewSession(sa flows.SessionAssets) flows.Session {
-	return &session{
+func (e *engine) NewSession(sa flows.SessionAssets, trigger flows.Trigger) (flows.Session, flows.Sprint, error) {
+	s := &session{
 		engine:     e,
-		env:        utils.NewEnvironmentBuilder().Build(),
 		assets:     sa,
+		env:        utils.NewEnvironmentBuilder().Build(),
+		trigger:    trigger,
 		status:     flows.SessionStatusActive,
 		runsByUUID: make(map[flows.RunUUID]flows.FlowRun),
 	}
+
+	sprint, err := s.start(trigger)
+
+	return s, sprint, err
 }
 
 // ReadSession reads an existing session

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -112,10 +112,9 @@ func (s *session) Engine() flows.Engine { return s.engine }
 //------------------------------------------------------------------------------------------
 
 // Start initializes this session with the given trigger and runs the flow to the first wait
-func (s *session) Start(trigger flows.Trigger) (flows.Sprint, error) {
+func (s *session) start(trigger flows.Trigger) (flows.Sprint, error) {
 	sprint := NewEmptySprint()
-	s.trigger = trigger
-
+	
 	if err := s.prepareForSprint(); err != nil {
 		return sprint, err
 	}

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -613,18 +613,20 @@ func TestWaitTimeout(t *testing.T) {
 	sessionAssets, err := ioutil.ReadFile("testdata/timeout_test.json")
 	require.NoError(t, err)
 
-	// create our engine session
-	session, err := test.CreateSession(json.RawMessage(sessionAssets), "")
+	// create our session assets
+	sa, err := test.CreateSessionAssets(json.RawMessage(sessionAssets), "")
 	require.NoError(t, err)
 
-	flow, err := session.Assets().Flows().Get(assets.FlowUUID("76f0a02f-3b75-4b86-9064-e9195e1b3a02"))
+	flow, err := sa.Flows().Get(assets.FlowUUID("76f0a02f-3b75-4b86-9064-e9195e1b3a02"))
 	require.NoError(t, err)
 
-	contact := flows.NewEmptyContact(session.Assets(), "Joe", "eng", nil)
+	contact := flows.NewEmptyContact(sa, "Joe", "eng", nil)
 	contact.AddURN(flows.NewContactURN(urns.URN("tel:+18005555777"), nil))
 	trigger := triggers.NewManualTrigger(nil, flow.Reference(), contact, nil)
 
-	sprint, err := session.Start(trigger)
+	// create session
+	eng := engine.NewBuilder().WithDefaultUserAgent("goflow-testing").Build()
+	session, sprint, err := eng.NewSession(sa, trigger)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(session.Runs()[0].Path()))

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -356,7 +356,7 @@ type Step interface {
 }
 
 type Engine interface {
-	NewSession(SessionAssets) Session
+	NewSession(SessionAssets, Trigger) (Session, Sprint, error)
 	ReadSession(SessionAssets, json.RawMessage, assets.MissingCallback) (Session, error)
 
 	HTTPClient() *utils.HTTPClient
@@ -394,7 +394,6 @@ type Session interface {
 	PushFlow(Flow, FlowRun, bool)
 	Wait() ActivatedWait
 
-	Start(Trigger) (Sprint, error)
 	Resume(Resume) (Sprint, error)
 	Runs() []FlowRun
 	GetRun(RunUUID) (FlowRun, error)

--- a/flows/runs/run_test.go
+++ b/flows/runs/run_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/excellent/types"
+	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/flows/triggers"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
@@ -174,13 +175,14 @@ func TestRunContext(t *testing.T) {
 
 func TestMissingRelatedRunContext(t *testing.T) {
 	// create a run with no parent or child
-	session, err := test.CreateSession([]byte(sessionAssets), "")
+	sa, err := test.CreateSessionAssets([]byte(sessionAssets), "")
 	require.NoError(t, err)
 
-	trigger, err := triggers.ReadTrigger(session.Assets(), []byte(sessionTrigger), assets.IgnoreMissing)
+	trigger, err := triggers.ReadTrigger(sa, []byte(sessionTrigger), assets.IgnoreMissing)
 	require.NoError(t, err)
 
-	_, err = session.Start(trigger)
+	eng := engine.NewBuilder().WithDefaultUserAgent("goflow-testing").Build()
+	session, _, err := eng.NewSession(sa, trigger)
 	require.NoError(t, err)
 
 	run := session.Runs()[0]

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -261,15 +261,6 @@ func (s *Session) Assets() *SessionAssets {
 	return &SessionAssets{target: s.target.Assets()}
 }
 
-// Start starts this session using the given trigger
-func (s *Session) Start(trigger *Trigger) (*Sprint, error) {
-	sprint, err := s.target.Start(trigger.target)
-	if err != nil {
-		return nil, err
-	}
-	return &Sprint{target: sprint}, nil
-}
-
 // Resume resumes this session
 func (s *Session) Resume(resume *Resume) (*Sprint, error) {
 	sprint, err := s.target.Resume(resume.target)
@@ -331,8 +322,13 @@ func NewEngine(httpUserAgent string) *Engine {
 }
 
 // NewSession creates a new session
-func (e *Engine) NewSession(sa *SessionAssets) *Session {
-	return &Session{target: e.target.NewSession(sa.target)}
+func (e *Engine) NewSession(sa *SessionAssets, trigger *Trigger) (*Session, *Sprint, error) {
+	session, sprint, err := e.target.NewSession(sa.target, trigger.target)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &Session{target: session}, &Sprint{target: sprint}, nil
 }
 
 // ReadSession reads an existing session from JSON

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -322,13 +322,16 @@ func NewEngine(httpUserAgent string) *Engine {
 }
 
 // NewSession creates a new session
-func (e *Engine) NewSession(sa *SessionAssets, trigger *Trigger) (*Session, *Sprint, error) {
+func (e *Engine) NewSession(sa *SessionAssets, trigger *Trigger) (*SessionAndSprint, error) {
 	session, sprint, err := e.target.NewSession(sa.target, trigger.target)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return &Session{target: session}, &Sprint{target: sprint}, nil
+	return &SessionAndSprint{
+		session: &Session{target: session},
+		sprint:  &Sprint{target: sprint},
+	}, nil
 }
 
 // ReadSession reads an existing session from JSON
@@ -338,4 +341,18 @@ func (e *Engine) ReadSession(a *SessionAssets, data string) (*Session, error) {
 		return nil, err
 	}
 	return &Session{target: s}, nil
+}
+
+// SessionAndSprint holds a session and a sprint.. because a Java method can't return two values
+type SessionAndSprint struct {
+	session *Session
+	sprint  *Sprint
+}
+
+func (ss *SessionAndSprint) Session() *Session {
+	return ss.session
+}
+
+func (ss *SessionAndSprint) Sprint() *Sprint {
+	return ss.sprint
 }

--- a/mobile/bindings_test.go
+++ b/mobile/bindings_test.go
@@ -52,7 +52,8 @@ func TestMobileBindings(t *testing.T) {
 	trigger := mobile.NewManualTrigger(environment, contact, mobile.NewFlowReference("7c3db26f-e12a-48af-9673-e2feefdf8516", "Two Questions"))
 
 	eng := mobile.NewEngine("mobile-test")
-	session, sprint, err := eng.NewSession(sa, trigger)
+	sprint, err := eng.NewSession(sa, trigger)
+	session := sprint.Session()
 	require.NoError(t, err)
 	assert.Equal(t, sa, session.Assets())
 	assert.Equal(t, "waiting", session.Status())

--- a/mobile/bindings_test.go
+++ b/mobile/bindings_test.go
@@ -52,8 +52,9 @@ func TestMobileBindings(t *testing.T) {
 	trigger := mobile.NewManualTrigger(environment, contact, mobile.NewFlowReference("7c3db26f-e12a-48af-9673-e2feefdf8516", "Two Questions"))
 
 	eng := mobile.NewEngine("mobile-test")
-	sprint, err := eng.NewSession(sa, trigger)
-	session := sprint.Session()
+	ss, err := eng.NewSession(sa, trigger)
+	session := ss.Session()
+	sprint := ss.Sprint()
 	require.NoError(t, err)
 	assert.Equal(t, sa, session.Assets())
 	assert.Equal(t, "waiting", session.Status())

--- a/mobile/bindings_test.go
+++ b/mobile/bindings_test.go
@@ -52,12 +52,9 @@ func TestMobileBindings(t *testing.T) {
 	trigger := mobile.NewManualTrigger(environment, contact, mobile.NewFlowReference("7c3db26f-e12a-48af-9673-e2feefdf8516", "Two Questions"))
 
 	eng := mobile.NewEngine("mobile-test")
-	session := eng.NewSession(sa)
-	assert.Equal(t, sa, session.Assets())
-
-	sprint, err := session.Start(trigger)
+	session, sprint, err := eng.NewSession(sa, trigger)
 	require.NoError(t, err)
-
+	assert.Equal(t, sa, session.Assets())
 	assert.Equal(t, "waiting", session.Status())
 
 	events := sprint.Events()

--- a/test/runner_test.go
+++ b/test/runner_test.go
@@ -166,9 +166,7 @@ func runFlow(assetsPath string, rawTrigger json.RawMessage, rawResumes []json.Ra
 	}
 
 	eng := engine.NewBuilder().WithDefaultUserAgent("goflow-testing").Build()
-	session := eng.NewSession(sa)
-
-	sprint, err := session.Start(trigger)
+	session, sprint, err := eng.NewSession(sa, trigger)
 	if err != nil {
 		return runResult{}, err
 	}


### PR DESCRIPTION
I've never liked how sessions exist in a weird state between being created and being started. They have a different environment, they could be serialized but not unserialized.. so this PR changes `NewSession` to do the creating and the starting.
