### PR TITLE
🤷 Make recursion optional (again) during flow validation

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -90,7 +90,7 @@ func RunFlow(assetsPath string, flowUUID assets.FlowUUID, initialMsg string, con
 		return nil, err
 	}
 
-	if err := flow.Validate(sa, nil); err != nil {
+	if err := flow.ValidateRecursive(sa, nil); err != nil {
 		return nil, err
 	}
 

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -567,10 +567,6 @@ func TestConstructors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		// test validating the action
-		err := tc.action.Validate()
-		assert.NoError(t, err)
-
 		// test marshaling the action
 		actualJSON, err := json.Marshal(tc.action)
 		assert.NoError(t, err)

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -103,7 +103,7 @@ func TestBrokenFlows(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 
-			err = flow.Validate(sa, nil)
+			err = flow.ValidateRecursive(sa, nil)
 			assert.EqualError(t, err, tc.validationError, "validation error mismatch for %s", tc.path)
 		}
 	}

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -155,6 +155,7 @@ type Flow interface {
 
 	Inspect() *FlowInfo
 	Validate(SessionAssets, func(assets.Reference)) error
+	ValidateRecursive(SessionAssets, func(assets.Reference)) error
 
 	ExtractTemplates() []string
 	RewriteTemplates(func(string) string)


### PR DESCRIPTION
Have identified the following interactions between mailroom and goflow, and some need to validate a definition without caring about other definitions

* save old flow: 
  - no asset validation
  - inspect
* save new flow: 
  - hard-validate assets, non-recursive
  - inspect
* import new flow step 1:
  - no asset validation
  - inspect
* import new flow step 2:
  - clone
  - hard-validate assets, non-recursive
* run flow: 
  - soft-validate assets, recursive