### PR TITLE
🚀 Ignore invalid destinations when migrating legacy flows

### DIFF
--- a/cmd/flowmigrate/main.go
+++ b/cmd/flowmigrate/main.go
@@ -46,7 +46,7 @@ func Migrate(reader io.Reader, includeUI bool, baseMediaURL string) ([]byte, err
 		return nil, err
 	}
 
-	migrated, err := flow.Migrate(includeUI, baseMediaURL)
+	migrated, err := flow.Migrate(baseMediaURL)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/flowmigrate/main_test.go
+++ b/cmd/flowmigrate/main_test.go
@@ -35,6 +35,10 @@ func TestMigrate(t *testing.T) {
 		"revision": 1,
 		"expire_after_minutes": 0,
 		"localization": {},
-		"nodes": []
+		"nodes": [],
+		"_ui": {
+			"nodes": {},
+			"stickies": {}
+		}
 	}`), migrated, "Migrated flow mismatch")
 }

--- a/legacy/compat.go
+++ b/legacy/compat.go
@@ -25,7 +25,7 @@ func MigrateLegacyDefinition(data json.RawMessage, baseMediaURL string) (json.Ra
 		return nil, errors.Wrap(err, "unable to read legacy flow")
 	}
 
-	flow, err := legacyFlow.Migrate(true, baseMediaURL)
+	flow, err := legacyFlow.Migrate(baseMediaURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to migrate legacy flow")
 	}

--- a/legacy/definition.go
+++ b/legacy/definition.go
@@ -558,14 +558,14 @@ func migrateAction(baseLanguage utils.Language, a Action, localization flows.Loc
 }
 
 // migrates the given legacy rulset to a node with a router
-func migrateRuleSet(lang utils.Language, r RuleSet, localization flows.Localization) (flows.Node, UINodeType, NodeUIConfig, error) {
+func migrateRuleSet(lang utils.Language, r RuleSet, validDests map[flows.NodeUUID]bool, localization flows.Localization) (flows.Node, UINodeType, NodeUIConfig, error) {
 	var newActions []flows.Action
 	var router flows.Router
 	var wait flows.Wait
 	var uiType UINodeType
 	uiConfig := make(NodeUIConfig)
 
-	cases, categories, defaultCategory, timeoutCategory, exits, err := migrateRules(lang, r, localization, uiConfig)
+	cases, categories, defaultCategory, timeoutCategory, exits, err := migrateRules(lang, r, validDests, localization, uiConfig)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -791,7 +791,7 @@ type categoryAndExit struct {
 }
 
 // migrates a set of legacy rules to sets of categories, cases and exits
-func migrateRules(baseLanguage utils.Language, r RuleSet, localization flows.Localization, uiConfig NodeUIConfig) ([]*routers.Case, []*routers.Category, flows.CategoryUUID, flows.CategoryUUID, []flows.Exit, error) {
+func migrateRules(baseLanguage utils.Language, r RuleSet, validDests map[flows.NodeUUID]bool, localization flows.Localization, uiConfig NodeUIConfig) ([]*routers.Case, []*routers.Category, flows.CategoryUUID, flows.CategoryUUID, []flows.Exit, error) {
 	cases := make([]*routers.Case, 0, len(r.Rules))
 	categories := make([]*routers.Category, 0, len(r.Rules))
 	exits := make([]flows.Exit, 0, len(r.Rules))
@@ -811,8 +811,14 @@ func migrateRules(baseLanguage utils.Language, r RuleSet, localization flows.Loc
 			converted = convertedByCategoryName[baseName]
 		}
 		if converted == nil {
+			// only set exit destination if it's valid
+			var destinationUUID flows.NodeUUID
+			if validDests[rule.Destination] {
+				destinationUUID = rule.Destination
+			}
+
 			// rule UUIDs in legacy flows determine path data, so their UUIDs become the exit UUIDs
-			exit := definition.NewExit(rule.UUID, rule.Destination)
+			exit := definition.NewExit(rule.UUID, destinationUUID)
 			exits = append(exits, exit)
 
 			category := routers.NewCategory(flows.CategoryUUID(utils.NewUUID()), baseName, exit.UUID())
@@ -1004,7 +1010,7 @@ func migrateRule(baseLanguage utils.Language, r Rule, category *routers.Category
 }
 
 // migrates the given legacy actionset to a node with a set of migrated actions and a single exit
-func migrateActionSet(lang utils.Language, a ActionSet, localization flows.Localization, baseMediaURL string) (flows.Node, error) {
+func migrateActionSet(lang utils.Language, a ActionSet, validDests map[flows.NodeUUID]bool, localization flows.Localization, baseMediaURL string) (flows.Node, error) {
 	actions := make([]flows.Action, len(a.Actions))
 
 	// migrate each action
@@ -1016,7 +1022,13 @@ func migrateActionSet(lang utils.Language, a ActionSet, localization flows.Local
 		actions[i] = action
 	}
 
-	exit := definition.NewExit(a.ExitUUID, a.Destination)
+	// only set exit destination if it's valid
+	var destinationUUID flows.NodeUUID
+	if validDests[a.Destination] {
+		destinationUUID = a.Destination
+	}
+
+	exit := definition.NewExit(a.ExitUUID, destinationUUID)
 
 	return definition.NewNode(a.UUID, actions, nil, []flows.Exit{exit}), nil
 }
@@ -1041,8 +1053,17 @@ func migrateNodes(f *Flow, baseMediaURL string) ([]flows.Node, map[flows.NodeUUI
 	nodes := make([]flows.Node, numNodes)
 	nodeUIs := make(map[flows.NodeUUID]*NodeUI, numNodes)
 
+	// get set of all node UUIDs, i.e. the valid destinations for any exit
+	validDestinations := make(map[flows.NodeUUID]bool, numNodes)
+	for _, as := range f.ActionSets {
+		validDestinations[as.UUID] = true
+	}
+	for _, rs := range f.RuleSets {
+		validDestinations[rs.UUID] = true
+	}
+
 	for i, actionSet := range f.ActionSets {
-		node, err := migrateActionSet(f.BaseLanguage, actionSet, localization, baseMediaURL)
+		node, err := migrateActionSet(f.BaseLanguage, actionSet, validDestinations, localization, baseMediaURL)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "error migrating action_set[uuid=%s]", actionSet.UUID)
 		}
@@ -1051,7 +1072,7 @@ func migrateNodes(f *Flow, baseMediaURL string) ([]flows.Node, map[flows.NodeUUI
 	}
 
 	for i, ruleSet := range f.RuleSets {
-		node, uiType, uiNodeConfig, err := migrateRuleSet(f.BaseLanguage, ruleSet, localization)
+		node, uiType, uiNodeConfig, err := migrateRuleSet(f.BaseLanguage, ruleSet, validDestinations, localization)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "error migrating rule_set[uuid=%s]", ruleSet.UUID)
 		}

--- a/legacy/definition_test.go
+++ b/legacy/definition_test.go
@@ -142,7 +142,7 @@ func TestFlowMigration(t *testing.T) {
 		legacyFlow, err := legacy.ReadLegacyFlow(tc.Legacy)
 		require.NoError(t, err)
 
-		migratedFlow, err := legacyFlow.Migrate(true, "https://myfiles.com")
+		migratedFlow, err := legacyFlow.Migrate("https://myfiles.com")
 		require.NoError(t, err)
 
 		migratedFlowJSON, err := json.Marshal(migratedFlow)
@@ -169,7 +169,7 @@ func TestActionMigration(t *testing.T) {
 		legacyFlow, err := legacy.ReadLegacyFlow(json.RawMessage(legacyFlowJSON))
 		require.NoError(t, err)
 
-		migratedFlow, err := legacyFlow.Migrate(false, "https://myfiles.com")
+		migratedFlow, err := legacyFlow.Migrate("https://myfiles.com")
 		require.NoError(t, err)
 
 		migratedAction := migratedFlow.Nodes()[0].Actions()[0]
@@ -199,7 +199,7 @@ func TestTestMigration(t *testing.T) {
 		legacyFlow, err := legacy.ReadLegacyFlow(json.RawMessage(legacyFlowJSON))
 		require.NoError(t, err)
 
-		migratedFlow, err := legacyFlow.Migrate(false, "https://myfiles.com")
+		migratedFlow, err := legacyFlow.Migrate("https://myfiles.com")
 		require.NoError(t, err)
 
 		migratedRouter := migratedFlow.Nodes()[0].Router().(*routers.SwitchRouter)
@@ -235,7 +235,7 @@ func TestRuleSetMigration(t *testing.T) {
 		legacyFlow, err := legacy.ReadLegacyFlow(json.RawMessage(legacyFlowJSON))
 		require.NoError(t, err)
 
-		migratedFlow, err := legacyFlow.Migrate(true, "https://myfiles.com")
+		migratedFlow, err := legacyFlow.Migrate("https://myfiles.com")
 		require.NoError(t, err)
 
 		// check we now have a new node in addition to the 3 actionsets used as destinations

--- a/legacy/testdata/flows.json
+++ b/legacy/testdata/flows.json
@@ -617,5 +617,204 @@
                 "stickies": {}
             }
         }
+    },
+    {
+        "description": "legacy flow invalid destinations which should be ignored",
+        "legacy": {
+            "entry": "2810264e-ff2a-4298-a190-77ee715b0b44",
+            "action_sets": [
+                {
+                    "uuid": "55fc8cba-d3a1-426b-9e2a-2e94325e9fab",
+                    "x": 86,
+                    "y": 128,
+                    "destination": "01ba6317-9ddd-4196-bfa7-0ab0434effcc",
+                    "actions": [
+                        {
+                            "type": "reply",
+                            "uuid": "f81e5531-c923-4c83-943d-8bd3bd9e218d",
+                            "msg": {
+                                "eng": "You said yes"
+                            },
+                            "media": {},
+                            "quick_replies": [],
+                            "send_all": false
+                        }
+                    ],
+                    "exit_uuid": "6adefcb5-f369-458e-b99d-60ca9c96a939"
+                }
+            ],
+            "rule_sets": [
+                {
+                    "uuid": "2810264e-ff2a-4298-a190-77ee715b0b44",
+                    "x": 100,
+                    "y": 0,
+                    "label": "Response 1",
+                    "rules": [
+                        {
+                            "uuid": "6bbe46af-f8bb-4241-b25e-f53a314fd0d4",
+                            "category": {
+                                "eng": "Yes"
+                            },
+                            "destination": "55fc8cba-d3a1-426b-9e2a-2e94325e9fab",
+                            "destination_type": "A",
+                            "test": {
+                                "type": "contains_any",
+                                "test": {
+                                    "eng": "yes"
+                                }
+                            },
+                            "label": null
+                        },
+                        {
+                            "uuid": "45e631cc-b409-47e0-a94b-2891e1397926",
+                            "category": {
+                                "eng": "No"
+                            },
+                            "destination": "cd699797-1a04-4143-9a58-a7f1dcbc285e",
+                            "destination_type": "A",
+                            "test": {
+                                "type": "contains_any",
+                                "test": {
+                                    "eng": "No"
+                                }
+                            },
+                            "label": null
+                        },
+                        {
+                            "uuid": "97a39597-fa5d-4ee4-a7bc-0aa18e56f1ec",
+                            "category": {
+                                "eng": "Other"
+                            },
+                            "destination": null,
+                            "destination_type": null,
+                            "test": {
+                                "type": "true"
+                            },
+                            "label": null
+                        }
+                    ],
+                    "finished_key": null,
+                    "ruleset_type": "wait_message",
+                    "response_type": "",
+                    "operand": "@step.value",
+                    "config": {}
+                }
+            ],
+            "base_language": "eng",
+            "flow_type": "M",
+            "version": "11.12",
+            "metadata": {
+                "uuid": "2ff042be-2563-431d-9c6c-567bf071b8c7",
+                "name": "Bad Destinations",
+                "saved_on": "2019-05-27T18:51:37.370652Z",
+                "revision": 4,
+                "expires": 10080
+            }
+        },
+        "expected": {
+            "_ui": {
+                "nodes": {
+                    "2810264e-ff2a-4298-a190-77ee715b0b44": {
+                        "position": {
+                            "left": 100,
+                            "top": 0
+                        },
+                        "type": "wait_for_response"
+                    },
+                    "55fc8cba-d3a1-426b-9e2a-2e94325e9fab": {
+                        "position": {
+                            "left": 86,
+                            "top": 128
+                        },
+                        "type": "execute_actions"
+                    }
+                },
+                "stickies": {}
+            },
+            "expire_after_minutes": 10080,
+            "language": "eng",
+            "localization": {},
+            "name": "Bad Destinations",
+            "nodes": [
+                {
+                    "exits": [
+                        {
+                            "destination_uuid": "55fc8cba-d3a1-426b-9e2a-2e94325e9fab",
+                            "uuid": "6bbe46af-f8bb-4241-b25e-f53a314fd0d4"
+                        },
+                        {
+                            "uuid": "45e631cc-b409-47e0-a94b-2891e1397926"
+                        },
+                        {
+                            "uuid": "97a39597-fa5d-4ee4-a7bc-0aa18e56f1ec"
+                        }
+                    ],
+                    "router": {
+                        "cases": [
+                            {
+                                "arguments": [
+                                    "yes"
+                                ],
+                                "category_uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+                                "type": "has_any_word",
+                                "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
+                            },
+                            {
+                                "arguments": [
+                                    "No"
+                                ],
+                                "category_uuid": "692926ea-09d6-4942-bd38-d266ec8d3716",
+                                "type": "has_any_word",
+                                "uuid": "5802813d-6c58-4292-8228-9728778b6c98"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "exit_uuid": "6bbe46af-f8bb-4241-b25e-f53a314fd0d4",
+                                "name": "Yes",
+                                "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5"
+                            },
+                            {
+                                "exit_uuid": "45e631cc-b409-47e0-a94b-2891e1397926",
+                                "name": "No",
+                                "uuid": "692926ea-09d6-4942-bd38-d266ec8d3716"
+                            },
+                            {
+                                "exit_uuid": "97a39597-fa5d-4ee4-a7bc-0aa18e56f1ec",
+                                "name": "Other",
+                                "uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094"
+                            }
+                        ],
+                        "default_category_uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094",
+                        "operand": "@input",
+                        "result_name": "Response 1",
+                        "type": "switch",
+                        "wait": {
+                            "type": "msg"
+                        }
+                    },
+                    "uuid": "2810264e-ff2a-4298-a190-77ee715b0b44"
+                },
+                {
+                    "actions": [
+                        {
+                            "text": "You said yes",
+                            "type": "send_msg",
+                            "uuid": "f81e5531-c923-4c83-943d-8bd3bd9e218d"
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "6adefcb5-f369-458e-b99d-60ca9c96a939"
+                        }
+                    ],
+                    "uuid": "55fc8cba-d3a1-426b-9e2a-2e94325e9fab"
+                }
+            ],
+            "revision": 4,
+            "spec_version": "13.0.0",
+            "type": "messaging",
+            "uuid": "2ff042be-2563-431d-9c6c-567bf071b8c7"
+        }
     }
 ]

--- a/test/uuid_test.go
+++ b/test/uuid_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSeededUUID4Generator(t *testing.T) {
+func TestSeededUUIDGenerator(t *testing.T) {
 	defer utils.SetUUIDGenerator(utils.DefaultUUIDGenerator)
 
 	utils.SetUUIDGenerator(test.NewSeededUUIDGenerator(123456))


### PR DESCRIPTION
There are flows out there which we can't migrate cuz they have rule or actionset destinations which aren't valid