### PR TITLE
☎️  check that numbers are actually valid in our has phone test

### DIFF
--- a/flows/routers/cases/tests.go
+++ b/flows/routers/cases/tests.go
@@ -557,7 +557,7 @@ func HasPhone(env utils.Environment, text types.XText, args ...types.XValue) typ
 		return FalseResult
 	}
 
-	if !phonenumbers.IsPossibleNumber(phone) {
+	if !phonenumbers.IsValidNumber(phone) {
 		return FalseResult
 	}
 

--- a/flows/routers/cases/tests_test.go
+++ b/flows/routers/cases/tests_test.go
@@ -317,6 +317,8 @@ func TestHasPhone(t *testing.T) {
 		expected string
 	}{
 		{"+250788123123", "", "+250788123123"},
+		{"u812111005611", "ID", "+62812111005611"}, // we try hard to find a number, but check it is valid, it is in this case for ID
+		{"oioas812111", "ID", ""},                  // in this case we also try hard, but the final result is not a valid ID number
 		{"+593979111111", "", "+593979111111"},
 		{"0788123123", "", "+250788123123"}, // uses environment default
 		{"0788123123", "RW", "+250788123123"},
@@ -324,10 +326,10 @@ func TestHasPhone(t *testing.T) {
 		{"+12065551212", "RW", "+12065551212"}, // if num has country code, doesn't need to match test country
 		{"12065551212", "US", "+12065551212"},
 		{"206 555 1212", "US", "+12065551212"},
-		{"+10001112222", "US", "+10001112222"},
+		{"+10001112222", "US", ""},
 		{"0815 1053 7962", "ID", "+6281510537962"}, // Indonesian numbers with 12 digits
-		{"0954 1053 7962", "ID", "+6295410537962"},
-		{"0811-1005-611", "ID", "+628111005611"}, // and with 11 digits
+		{"0954 1053 7962", "ID", ""},               // Invalid Indonesian number
+		{"0811-1005-611", "ID", "+628111005611"},   // Valid with 11 digits
 		{"10000", "US", ""},
 		{"12067799294", "BW", ""},
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/nyaruka/gocommon v0.2.0
-	github.com/nyaruka/phonenumbers v1.0.35
+	github.com/nyaruka/phonenumbers v1.0.41
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/nyaruka/gocommon v0.2.0 h1:1Le4Ok0Zp2RYULue0n4/02zL+1MrykN/C79HhirGeR
 github.com/nyaruka/gocommon v0.2.0/go.mod h1:ZrhaOKNc+kK1qWNuCuZivskT+ygLyIwu4KZVgcaC1mw=
 github.com/nyaruka/phonenumbers v1.0.35 h1:ZOXkPjBMVBTVwaNYyUGJHN1fCiwrcTgsY4SVeo0r/tk=
 github.com/nyaruka/phonenumbers v1.0.35/go.mod h1:Hhae+eypC1YKMaQlBJUCGZDzBrIHHNWhJX1xG/8sOC8=
+github.com/nyaruka/phonenumbers v1.0.41 h1:loSZuHtv1khLKGkWS0J2gnAxDqWr2TOrvX79DPZMPbY=
+github.com/nyaruka/phonenumbers v1.0.41/go.mod h1:Hhae+eypC1YKMaQlBJUCGZDzBrIHHNWhJX1xG/8sOC8=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
We go back and forth on this but in the case of this test I think the right thing is to be aggressive in our search for a phone number but strict in what we find is a valid phone number. This matches our old RapidPro behavior BTW.