### PR TITLE
🤯 Use std lib function to check HTTP headers

### DIFF
--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -2,20 +2,18 @@ package actions
 
 import (
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/http/httpguts"
 )
 
 func init() {
 	RegisterType(TypeCallWebhook, func() flows.Action { return &CallWebhookAction{} })
 }
-
-var headerNameRegex = regexp.MustCompile(`^[\w\-]+$`)
 
 // TypeCallWebhook is the type for the call webhook action
 const TypeCallWebhook string = "call_webhook"
@@ -68,7 +66,7 @@ func (a *CallWebhookAction) Validate() error {
 	}
 
 	for key := range a.Headers {
-		if !headerNameRegex.MatchString(key) {
+		if !httpguts.ValidHeaderFieldName(key) {
 			return errors.Errorf("header '%s' is not a valid HTTP header", key)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/sergi/go-diff v1.0.0
 	github.com/shopspring/decimal v0.0.0-20180319170823-2df3e6ddaf6e
 	github.com/stretchr/testify v1.2.1
+	golang.org/x/net v0.0.0-20180921000356-2f5d2388922f
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	golang.org/x/text v0.3.0
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/nyaruka/gocommon v0.2.0 h1:1Le4Ok0Zp2RYULue0n4/02zL+1MrykN/C79HhirGeRw=
 github.com/nyaruka/gocommon v0.2.0/go.mod h1:ZrhaOKNc+kK1qWNuCuZivskT+ygLyIwu4KZVgcaC1mw=
-github.com/nyaruka/phonenumbers v1.0.35 h1:ZOXkPjBMVBTVwaNYyUGJHN1fCiwrcTgsY4SVeo0r/tk=
-github.com/nyaruka/phonenumbers v1.0.35/go.mod h1:Hhae+eypC1YKMaQlBJUCGZDzBrIHHNWhJX1xG/8sOC8=
 github.com/nyaruka/phonenumbers v1.0.41 h1:loSZuHtv1khLKGkWS0J2gnAxDqWr2TOrvX79DPZMPbY=
 github.com/nyaruka/phonenumbers v1.0.41/go.mod h1:Hhae+eypC1YKMaQlBJUCGZDzBrIHHNWhJX1xG/8sOC8=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
@@ -31,6 +29,7 @@ github.com/shopspring/decimal v0.0.0-20180319170823-2df3e6ddaf6e h1:VEm1QiS3pE06
 github.com/shopspring/decimal v0.0.0-20180319170823-2df3e6ddaf6e/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/stretchr/testify v1.2.1 h1:52QO5WkIUcHGIR7EnGagH88x1bUzqGXTC5/1bDTUQ7U=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/net v0.0.0-20180921000356-2f5d2388922f h1:QM2QVxvDoW9PFSPp/zy9FgxJLfaWTZlS61KEPtBwacM=
 golang.org/x/net v0.0.0-20180921000356-2f5d2388922f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=


### PR DESCRIPTION
Currently only allow `[\w\-]+` which is too strict. According to https://godoc.org/golang.org/x/net/http/httpguts#ValidHeaderFieldName it's...

```
RFC 7230 says:
 header-field   = field-name ":" OWS field-value OWS
 field-name     = token
 token          = 1*tchar
 tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
         "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
```