### PR TITLE
🛏️ Relax requirement for field assets to have UUID

### DIFF
--- a/assets/static/types/field.go
+++ b/assets/static/types/field.go
@@ -6,7 +6,7 @@ import (
 
 // Field is a JSON serializable implementation of a field asset
 type Field struct {
-	UUID_ assets.FieldUUID `json:"uuid" validate:"required"`
+	UUID_ assets.FieldUUID `json:"uuid"`
 	Key_  string           `json:"key" validate:"required"`
 	Name_ string           `json:"name"`
 	Type_ assets.FieldType `json:"type" validate:"required"`


### PR DESCRIPTION
Engine doesn't use this - we only added it so that mailroom could use it for it's tracking of field assets

And it being required, means that surveyor can't load previously saved assets that have fields without UUIDs 🤦‍♂ 