### PR TITLE
🧰 Session Current Context Tweaks

### DIFF
--- a/excellent/tools/context_walk.go
+++ b/excellent/tools/context_walk.go
@@ -9,8 +9,8 @@ func ContextWalk(context *types.XObject, callback func(types.XValue)) {
 	contextWalk(context, callback)
 }
 
-// ContextFindObjects traverses the given context invoking the callback for each object found
-func ContextFindObjects(context *types.XObject, callback func(*types.XObject)) {
+// ContextWalkObjects traverses the given context invoking the callback for each object found
+func ContextWalkObjects(context *types.XObject, callback func(*types.XObject)) {
 	contextWalk(context, func(v types.XValue) {
 		switch typed := v.(type) {
 		case *types.XObject:

--- a/excellent/tools/context_walk.go
+++ b/excellent/tools/context_walk.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"github.com/nyaruka/goflow/excellent/types"
+)
+
+// ContextWalk traverses the given context invoking the callback for each value
+func ContextWalk(context *types.XObject, callback func(types.XValue)) {
+	contextWalk(context, callback)
+}
+
+// ContextFindObjects traverses the given context invoking the callback for each object found
+func ContextFindObjects(context *types.XObject, callback func(*types.XObject)) {
+	contextWalk(context, func(v types.XValue) {
+		switch typed := v.(type) {
+		case *types.XObject:
+			callback(typed)
+		}
+	})
+}
+
+func contextWalk(v types.XValue, callback func(types.XValue)) {
+	callback(v)
+
+	switch typed := v.(type) {
+	case *types.XObject:
+		for _, p := range typed.Properties() {
+			c, _ := typed.Get(p)
+			contextWalk(c, callback)
+		}
+	case *types.XArray:
+		for i := 0; i < typed.Count(); i++ {
+			c := typed.Get(i)
+			contextWalk(c, callback)
+		}
+	}
+}

--- a/excellent/tools/context_walk_test.go
+++ b/excellent/tools/context_walk_test.go
@@ -1,0 +1,52 @@
+package tools_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/goflow/excellent/tools"
+	"github.com/nyaruka/goflow/excellent/types"
+	"github.com/nyaruka/goflow/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextWalk(t *testing.T) {
+	context := types.NewXObject(map[string]types.XValue{
+		"__default__": types.NewXText("Bob"),
+		"foo": types.NewXArray(
+			types.NewXObject(map[string]types.XValue{
+				"__default__": types.NewXText("Bob"),
+				"bar":         types.NewXNumberFromInt(123),
+			}),
+			types.NewXNumberFromInt(256),
+		),
+		"bar": types.NewXNumberFromInt(256),
+		"zed": types.NewXObject(map[string]types.XValue{
+			"bar": types.NewXNumberFromInt(345),
+		}),
+	})
+
+	count := 0
+	tools.ContextWalk(context, func(v types.XValue) {
+		count++
+	})
+	assert.Equal(t, 8, count)
+
+	// test finding just objects
+	actual := make([]types.XValue, 0)
+	tools.ContextFindObjects(context, func(o *types.XObject) {
+		actual = append(actual, o)
+	})
+
+	expected := types.NewXArray(
+		context,
+		types.NewXObject(map[string]types.XValue{
+			"__default__": types.NewXText("Bob"),
+			"bar":         types.NewXNumberFromInt(123),
+		}),
+		types.NewXObject(map[string]types.XValue{
+			"bar": types.NewXNumberFromInt(345),
+		}),
+	)
+
+	test.AssertXEqual(t, expected, types.NewXArray(actual...), "found objects mismatch")
+}

--- a/excellent/tools/context_walk_test.go
+++ b/excellent/tools/context_walk_test.go
@@ -33,7 +33,7 @@ func TestContextWalk(t *testing.T) {
 
 	// test finding just objects
 	actual := make([]types.XValue, 0)
-	tools.ContextFindObjects(context, func(o *types.XObject) {
+	tools.ContextWalkObjects(context, func(o *types.XObject) {
 		actual = append(actual, o)
 	})
 

--- a/excellent/types/object.go
+++ b/excellent/types/object.go
@@ -27,9 +27,10 @@ type XObject struct {
 	XValue
 	XCountable
 
-	def    XValue
-	props  map[string]XValue
-	source func() map[string]XValue
+	def            XValue
+	props          map[string]XValue
+	source         func() map[string]XValue
+	marshalDefault bool
 }
 
 // NewXObject returns a new object with the given properties
@@ -99,6 +100,14 @@ func (x *XObject) MarshalJSON() ([]byte, error) {
 			marshaled[p] = json.RawMessage(asJSON.Native())
 		}
 	}
+
+	if x.hasDefault() && x.marshalDefault {
+		asJSON, err := ToXJSON(x.def)
+		if err == nil {
+			marshaled[serializeDefaultAs] = json.RawMessage(asJSON.Native())
+		}
+	}
+
 	return json.Marshal(marshaled)
 }
 
@@ -193,6 +202,10 @@ func (x *XObject) properties() map[string]XValue {
 func (x *XObject) Default() XValue {
 	x.ensureInitialized()
 	return x.def
+}
+
+func (x *XObject) SetMarshalDefault(marshal bool) {
+	x.marshalDefault = marshal
 }
 
 // Default returns the default value for this

--- a/excellent/types/object_test.go
+++ b/excellent/types/object_test.go
@@ -35,7 +35,13 @@ func TestXObject(t *testing.T) {
 	assert.Equal(t, `XObject{bar: XNumber(123), foo: XText("abc"), xxx: nil, zed: XBoolean(false)}`, object.String())
 	assert.Equal(t, "object", object.Describe())
 
+	// test marshaling to JSON
 	asJSON, _ := types.ToXJSON(object)
+	assert.Equal(t, types.NewXText(`{"bar":123,"foo":"abc","xxx":null,"zed":false}`), asJSON)
+
+	// if there is no explicit default, it's never included
+	object.SetMarshalDefault(true)
+	asJSON, _ = types.ToXJSON(object)
 	assert.Equal(t, types.NewXText(`{"bar":123,"foo":"abc","xxx":null,"zed":false}`), asJSON)
 
 	// test equality
@@ -94,6 +100,10 @@ func TestXObjectWithDefault(t *testing.T) {
 
 	asJSON, _ := types.ToXJSON(object)
 	assert.Equal(t, types.NewXText(`{"bar":123,"foo":"abc","zed":false}`), asJSON)
+
+	object.SetMarshalDefault(true)
+	asJSON, _ = types.ToXJSON(object)
+	assert.Equal(t, types.NewXText(`{"__default__":"abc-123","bar":123,"foo":"abc","zed":false}`), asJSON)
 
 	// test equality
 	test.AssertXEqual(t, object, types.NewXObject(map[string]types.XValue{

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -100,13 +100,13 @@ func (s *session) ParentRun() flows.RunSummary {
 func (s *session) Status() flows.SessionStatus { return s.status }
 func (s *session) Wait() flows.ActivatedWait   { return s.wait }
 
-func (s *session) CurrentContext() map[string]types.XValue {
+func (s *session) CurrentContext() *types.XObject {
 	run := s.waitingRun()
 	if run == nil {
 		return nil
 	}
 
-	return run.RootContext(s.env)
+	return types.NewXObject(run.RootContext(s.env))
 }
 
 // looks through this session's run for the one that is waiting

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -364,7 +364,7 @@ type Session interface {
 	GetRun(RunUUID) (FlowRun, error)
 	GetCurrentChild(FlowRun) FlowRun
 	ParentRun() RunSummary
-	CurrentContext() map[string]types.XValue
+	CurrentContext() *types.XObject
 
 	Engine() Engine
 }


### PR DESCRIPTION
* Add support for marshaling XObjects with their defaults
* Add tool for walking the context to find objects

So that in mailroom we can do...

```go
context := session.CurrentContext()

tools.ContextFindObjects(context, func(o *types.XObject) {
  o.SetMarshalDefault(true)
})
```

and get a version of the context where objects defaults are included in JSON as `__default__`
