### PR TITLE
🧯 Allow globals with empty values

### DIFF
--- a/assets/static/types/global.go
+++ b/assets/static/types/global.go
@@ -8,7 +8,7 @@ import (
 type Global struct {
 	Key_   string `json:"key" validate:"required"`
 	Name_  string `json:"name"`
-	Value_ string `json:"value" validate:"required"`
+	Value_ string `json:"value"`
 }
 
 // NewGlobal creates a new global

--- a/flows/definition/legacy/testdata/actions.json
+++ b/flows/definition/legacy/testdata/actions.json
@@ -301,6 +301,25 @@
     {
         "legacy_action": {
             "type": "save",
+            "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
+            "field": "gender",
+            "label": "Gender",
+            "value": "@(\"\")"
+        },
+        "expected_action": {
+            "type": "set_contact_field",
+            "uuid": "5a4d00aa-807e-44af-9693-64b9fdedd352",
+            "field": {
+                "key": "gender",
+                "name": "Gender"
+            },
+            "value": ""
+        },
+        "expected_localization": {}
+    },
+    {
+        "legacy_action": {
+            "type": "save",
             "uuid": "5dbb462b-ed55-4cf3-b14c-6ed52f217b06",
             "label": "Phone Number",
             "field": "tel",


### PR DESCRIPTION
They already exist apparently, e.g. https://sentry.io/organizations/nyaruka/issues/1473043636/?project=1281372&referrer=alert_email