### PR TITLE
🔍 Group conditions and fixes in contact queries

### DIFF
--- a/contactql/parser.go
+++ b/contactql/parser.go
@@ -147,18 +147,28 @@ func (c *Condition) Evaluate(env envs.Environment, queryable Queryable) (bool, e
 		return false, nil
 	}
 
-	// check each resolved value
+	// evaluate condition against each resolved value
+	anyTrue := false
+	allTrue := true
 	for _, val := range vals {
 		res, err := c.evaluateValue(env, val)
 		if err != nil {
 			return false, err
 		}
 		if res {
-			return true, nil
+			anyTrue = true
+		} else {
+			allTrue = false
 		}
 	}
 
-	return false, nil
+	// foo != x is only true if all values of foo are not x
+	if c.comparator == ComparatorNotEqual {
+		return allTrue, nil
+	}
+
+	// foo = x is true if any value of foo is x
+	return anyTrue, nil
 }
 
 func (c *Condition) evaluateValue(env envs.Environment, val interface{}) (bool, error) {

--- a/contactql/parser_test.go
+++ b/contactql/parser_test.go
@@ -51,6 +51,11 @@ func TestParseQuery(t *testing.T) {
 		{`name != "felix"`, `name != "felix"`, "", envs.RedactionPolicyNone}, // is not equal to value
 		{`Name ~ ""`, ``, "value must contain a word of at least 2 characters long for a contains condition on name", envs.RedactionPolicyNone},
 
+		// explicit attribute conditions
+		{`language = spa`, `language = "spa"`, "", envs.RedactionPolicyNone},
+		{`Group IS U-Reporters`, `group = "U-Reporters"`, "", envs.RedactionPolicyNone},
+		{`CREATED_ON>27-01-2020`, `created_on > "27-01-2020"`, "", envs.RedactionPolicyNone},
+
 		// explicit conditions on URN
 		{`tel=""`, `tel = ""`, "", envs.RedactionPolicyNone},
 		{`tel!=""`, `tel != ""`, "", envs.RedactionPolicyNone},
@@ -111,6 +116,58 @@ func TestParseQuery(t *testing.T) {
 		{`xyz != ""`, "", "can't resolve 'xyz' to attribute, scheme or field", envs.RedactionPolicyNone},
 
 		{`name = "O\"Leary"`, `name = "O\"Leary"`, "", envs.RedactionPolicyNone}, // string unquoting
+
+		// = supported for everything
+		{`id = 02352`, `id = 02352`, "", envs.RedactionPolicyNone},
+		{`name = felix`, `name = "felix"`, "", envs.RedactionPolicyNone},
+		{`language = eng`, `language = "eng"`, "", envs.RedactionPolicyNone},
+		{`group = reporters`, `group = "reporters"`, "", envs.RedactionPolicyNone},
+		{`created_on = 20-02-2020`, `created_on = "20-02-2020"`, "", envs.RedactionPolicyNone},
+		{`tel = 02352`, `tel = 02352`, "", envs.RedactionPolicyNone},
+		{`urn = 02352`, `urn = 02352`, "", envs.RedactionPolicyNone},
+		{`age = 18`, `age = 18`, "", envs.RedactionPolicyNone},
+		{`gender = male`, `gender = "male"`, "", envs.RedactionPolicyNone},
+		{`dob = 20-02-2020`, `dob = "20-02-2020"`, "", envs.RedactionPolicyNone},
+		{`state = Pichincha`, `state = "Pichincha"`, "", envs.RedactionPolicyNone},
+
+		// != supported for everything
+		{`id != 02352`, `id != 02352`, "", envs.RedactionPolicyNone},
+		{`name != felix`, `name != "felix"`, "", envs.RedactionPolicyNone},
+		{`language != eng`, `language != "eng"`, "", envs.RedactionPolicyNone},
+		{`group != reporters`, `group != "reporters"`, "", envs.RedactionPolicyNone},
+		{`created_on != 20-02-2020`, `created_on != "20-02-2020"`, "", envs.RedactionPolicyNone},
+		{`tel != 02352`, `tel != 02352`, "", envs.RedactionPolicyNone},
+		{`urn != 02352`, `urn != 02352`, "", envs.RedactionPolicyNone},
+		{`age != 18`, `age != 18`, "", envs.RedactionPolicyNone},
+		{`gender != male`, `gender != "male"`, "", envs.RedactionPolicyNone},
+		{`dob != 20-02-2020`, `dob != "20-02-2020"`, "", envs.RedactionPolicyNone},
+		{`state != Pichincha`, `state != "Pichincha"`, "", envs.RedactionPolicyNone},
+
+		// ~ only supported for name and URNs
+		{`id ~ 02352`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+		{`name ~ felix`, `name ~ "felix"`, "", envs.RedactionPolicyNone},
+		{`language ~ eng`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+		{`group ~ porters`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+		{`created_on ~ 2018`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+		{`tel ~ 02352`, `tel ~ 02352`, "", envs.RedactionPolicyNone},
+		{`urn ~ 02352`, `urn ~ 02352`, "", envs.RedactionPolicyNone},
+		{`age ~ 18`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+		{`gender ~ mal`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+		{`dob ~ 20-02-2020`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+		{`state ~ Pichincha`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
+
+		// > >= < <= only supported for numeric or date fields
+		{`id > 02352`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
+		{`name > felix`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
+		{`language > eng`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
+		{`group > reporters`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
+		{`created_on > 20-02-2020`, `created_on > "20-02-2020"`, "", envs.RedactionPolicyNone},
+		{`tel > 02352`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
+		{`urn > 02352`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
+		{`age > 18`, `age > 18`, "", envs.RedactionPolicyNone},
+		{`gender > male`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
+		{`dob > 20-02-2020`, `dob > "20-02-2020"`, "", envs.RedactionPolicyNone},
+		{`state > Pichincha`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
 	}
 
 	fields := map[string]assets.Field{

--- a/contactql/visitor.go
+++ b/contactql/visitor.go
@@ -31,14 +31,16 @@ const (
 	AttributeName      = "name"
 	AttributeLanguage  = "language"
 	AttributeURN       = "urn"
+	AttributeGroup     = "group"
 	AttributeCreatedOn = "created_on"
 )
 
 var attributes = map[string]assets.FieldType{
-	AttributeID:        assets.FieldTypeNumber,
+	AttributeID:        assets.FieldTypeText,
 	AttributeName:      assets.FieldTypeText,
 	AttributeLanguage:  assets.FieldTypeText,
 	AttributeURN:       assets.FieldTypeText,
+	AttributeGroup:     assets.FieldTypeText,
 	AttributeCreatedOn: assets.FieldTypeDatetime,
 }
 

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -409,6 +409,12 @@ func (c *Contact) QueryProperty(env envs.Environment, key string, propType conta
 				vals[i] = urn.URN().Path()
 			}
 			return vals
+		case contactql.AttributeGroup:
+			vals := make([]interface{}, c.Groups().Count())
+			for i, group := range c.Groups().All() {
+				vals[i] = group.Name()
+			}
+			return vals
 		case contactql.AttributeCreatedOn:
 			return []interface{}{c.createdOn}
 		default:

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -329,9 +329,17 @@ func TestContactQuery(t *testing.T) {
 		"fields": {
 			"gender": {"text": "Male"}
 		},
+		"groups": [
+			{"uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d", "name": "Testers"},
+        	{"uuid": "4f1f98fc-27a7-4a69-bbdb-24744ba739a9", "name": "Males"}
+		],
 		"language": "eng",
 		"timezone": "America/Guayaquil",
-		"urns": ["tel:+12065551212", "twitter:ewok"],
+		"urns": [
+			"tel:+12065551212", 
+			"tel:+12065551313", 
+			"twitter:ewok"
+		],
 		"created_on": "2020-01-24T13:24:30.000000000-00:00"
 	}`)
 
@@ -364,6 +372,7 @@ func TestContactQuery(t *testing.T) {
 		{`created_on > 26-01-2020`, false},
 
 		{`tel = +12065551212`, true},
+		{`tel = +12065551313`, true},
 		{`tel = +13065551212`, false},
 		{`tel ~ 555`, true},
 		{`tel ~ 666`, false},
@@ -377,8 +386,14 @@ func TestContactQuery(t *testing.T) {
 		{`urn = +12065551212`, true},
 		{`urn = ewok`, true},
 		{`urn = +13065551212`, false},
+		{`urn != +13065551212`, true},
 		{`urn ~ 555`, true},
 		{`urn ~ 666`, false},
+
+		{`group = testers`, true},
+		{`group != testers`, false},
+		{`group = spammers`, false},
+		{`group != spammers`, true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
* Add `group` as an attribute meaning "any group"
* Fix != with multiple values (e.g. multiple URNs or groups)
* Fix `id` conditions being allowed with `>` `>=` `<` `<=`