### PR TITLE
👮 Stricter contact query parsing

### DIFF
--- a/contactql/evaluator_test.go
+++ b/contactql/evaluator_test.go
@@ -121,7 +121,7 @@ func TestEvaluateQuery(t *testing.T) {
 		{`(age = 36 OR gender = female) AND age > 35`, true},
 	}
 
-	fields := map[string]assets.Field{
+	resolver := contactql.NewMockResolver(map[string]assets.Field{
 		"age":      types.NewField(assets.FieldUUID("f1b5aea6-6586-41c7-9020-1a6326cc6565"), "age", "Age", assets.FieldTypeNumber),
 		"dob":      types.NewField(assets.FieldUUID("3810a485-3fda-4011-a589-7320c0b8dbef"), "dob", "DOB", assets.FieldTypeDatetime),
 		"gender":   types.NewField(assets.FieldUUID("d66a7823-eada-40e5-9a3a-57239d4690bf"), "gender", "Gender", assets.FieldTypeText),
@@ -130,11 +130,10 @@ func TestEvaluateQuery(t *testing.T) {
 		"ward":     types.NewField(assets.FieldUUID("e9e738ce-617d-4c61-bfce-3d3b55cfe3dd"), "ward", "Ward", assets.FieldTypeWard),
 		"empty":    types.NewField(assets.FieldUUID("023f733d-ce00-4a61-96e4-b411987028ea"), "empty", "Empty", assets.FieldTypeText),
 		"xyz":      types.NewField(assets.FieldUUID("81e25783-a1d8-42b9-85e4-68c7ab2df39d"), "xyz", "XYZ", assets.FieldTypeText),
-	}
-	fieldResolver := func(key string) assets.Field { return fields[key] }
+	}, map[string]assets.Group{})
 
 	for _, test := range tests {
-		parsed, err := contactql.ParseQuery(test.query, envs.RedactionPolicyNone, "", fieldResolver)
+		parsed, err := contactql.ParseQuery(test.query, envs.RedactionPolicyNone, "", resolver)
 		assert.NoError(t, err, "unexpected error parsing '%s'", test.query)
 
 		actualResult, err := contactql.EvaluateQuery(env, parsed, testObj)
@@ -162,15 +161,14 @@ func TestEvaluationErrors(t *testing.T) {
 		{`name = Bob OR dob = 32`, "string '32' couldn't be parsed as a date"},
 	}
 
-	fields := map[string]assets.Field{
+	resolver := contactql.NewMockResolver(map[string]assets.Field{
 		"age":    types.NewField(assets.FieldUUID("f1b5aea6-6586-41c7-9020-1a6326cc6565"), "age", "Age", assets.FieldTypeNumber),
 		"dob":    types.NewField(assets.FieldUUID("3810a485-3fda-4011-a589-7320c0b8dbef"), "dob", "DOB", assets.FieldTypeDatetime),
 		"gender": types.NewField(assets.FieldUUID("d66a7823-eada-40e5-9a3a-57239d4690bf"), "gender", "Gender", assets.FieldTypeText),
-	}
-	fieldResolver := func(key string) assets.Field { return fields[key] }
+	}, map[string]assets.Group{})
 
 	for _, test := range tests {
-		parsed, err := contactql.ParseQuery(test.query, envs.RedactionPolicyNone, "", fieldResolver)
+		parsed, err := contactql.ParseQuery(test.query, envs.RedactionPolicyNone, "", resolver)
 		assert.NoError(t, err, "unexpected error parsing '%s'", test.query)
 
 		actualResult, err := contactql.EvaluateQuery(env, parsed, testObj)

--- a/contactql/mock.go
+++ b/contactql/mock.go
@@ -1,0 +1,36 @@
+package contactql
+
+import (
+	"strings"
+
+	"github.com/nyaruka/goflow/assets"
+)
+
+type mockResolver struct {
+	fields map[string]assets.Field
+	groups map[string]assets.Group
+}
+
+// NewMockResolver creates a new mock resolver for fields and groups
+func NewMockResolver(fields map[string]assets.Field, groups map[string]assets.Group) Resolver {
+	return &mockResolver{
+		fields: fields,
+		groups: groups,
+	}
+}
+
+func (r *mockResolver) ResolveField(key string) assets.Field {
+	field, found := r.fields[key]
+	if !found {
+		return nil
+	}
+	return field
+}
+
+func (r *mockResolver) ResolveGroup(name string) assets.Group {
+	group, found := r.groups[strings.ToLower(name)]
+	if !found {
+		return nil
+	}
+	return group
+}

--- a/contactql/parser.go
+++ b/contactql/parser.go
@@ -131,15 +131,23 @@ func (c *Condition) Validate(resolver Resolver) error {
 		case AttributeID, AttributeCreatedOn, AttributeGroup:
 			return errors.Errorf("can't check whether '%s' is set or not set", c.propKey)
 		}
-	}
-
-	// if group condition, check group exists
-	if c.propKey == AttributeGroup {
-		group := resolver.ResolveGroup(c.value)
-		if group == nil {
-			return errors.Errorf("'%s' is not a valid group name", c.value)
+	} else {
+		// check values are valid for the attribute type
+		switch c.propKey {
+		case AttributeGroup:
+			group := resolver.ResolveGroup(c.value)
+			if group == nil {
+				return errors.Errorf("'%s' is not a valid group name", c.value)
+			}
+			c.value = group.Name()
+		case AttributeLanguage:
+			if c.value != "" {
+				_, err := envs.ParseLanguage(c.value)
+				if err != nil {
+					return errors.Errorf("'%s' is not a valid language code", c.value)
+				}
+			}
 		}
-		c.value = group.Name()
 	}
 
 	return nil

--- a/contactql/parser_test.go
+++ b/contactql/parser_test.go
@@ -113,7 +113,8 @@ func TestParseQuery(t *testing.T) {
 			envs.RedactionPolicyNone,
 		},
 
-		{`xyz != ""`, "", "can't resolve 'xyz' to attribute, scheme or field", envs.RedactionPolicyNone},
+		{`xyz != ""`, ``, "can't resolve 'xyz' to attribute, scheme or field", envs.RedactionPolicyNone},
+		{`group != "Gamers"`, ``, "'Gamers' is not a valid group name", envs.RedactionPolicyNone},
 
 		{`name = "O\"Leary"`, `name = "O\"Leary"`, "", envs.RedactionPolicyNone}, // string unquoting
 
@@ -121,7 +122,7 @@ func TestParseQuery(t *testing.T) {
 		{`id = 02352`, `id = 02352`, "", envs.RedactionPolicyNone},
 		{`name = felix`, `name = "felix"`, "", envs.RedactionPolicyNone},
 		{`language = eng`, `language = "eng"`, "", envs.RedactionPolicyNone},
-		{`group = reporters`, `group = "reporters"`, "", envs.RedactionPolicyNone},
+		{`group = u-reporters`, `group = "U-Reporters"`, "", envs.RedactionPolicyNone},
 		{`created_on = 20-02-2020`, `created_on = "20-02-2020"`, "", envs.RedactionPolicyNone},
 		{`tel = 02352`, `tel = 02352`, "", envs.RedactionPolicyNone},
 		{`urn = 02352`, `urn = 02352`, "", envs.RedactionPolicyNone},
@@ -134,7 +135,7 @@ func TestParseQuery(t *testing.T) {
 		{`id != 02352`, `id != 02352`, "", envs.RedactionPolicyNone},
 		{`name != felix`, `name != "felix"`, "", envs.RedactionPolicyNone},
 		{`language != eng`, `language != "eng"`, "", envs.RedactionPolicyNone},
-		{`group != reporters`, `group != "reporters"`, "", envs.RedactionPolicyNone},
+		{`group != u-reporters`, `group != "U-Reporters"`, "", envs.RedactionPolicyNone},
 		{`created_on != 20-02-2020`, `created_on != "20-02-2020"`, "", envs.RedactionPolicyNone},
 		{`tel != 02352`, `tel != 02352`, "", envs.RedactionPolicyNone},
 		{`urn != 02352`, `urn != 02352`, "", envs.RedactionPolicyNone},
@@ -142,6 +143,19 @@ func TestParseQuery(t *testing.T) {
 		{`gender != male`, `gender != "male"`, "", envs.RedactionPolicyNone},
 		{`dob != 20-02-2020`, `dob != "20-02-2020"`, "", envs.RedactionPolicyNone},
 		{`state != Pichincha`, `state != "Pichincha"`, "", envs.RedactionPolicyNone},
+
+		// = "" supported for name, language, fields and urns
+		{`id = ""`, ``, "can't check whether 'id' is set or not set", envs.RedactionPolicyNone},
+		{`name = ""`, `name = ""`, "", envs.RedactionPolicyNone},
+		{`language = ""`, `language = ""`, "", envs.RedactionPolicyNone},
+		{`group = ""`, ``, "can't check whether 'group' is set or not set", envs.RedactionPolicyNone},
+		{`created_on = ""`, ``, "can't check whether 'created_on' is set or not set", envs.RedactionPolicyNone},
+		{`tel = ""`, `tel = ""`, "", envs.RedactionPolicyNone},
+		{`urn = ""`, `urn = ""`, "", envs.RedactionPolicyNone},
+		{`age = ""`, `age = ""`, "", envs.RedactionPolicyNone},
+		{`gender = ""`, `gender = ""`, "", envs.RedactionPolicyNone},
+		{`dob = ""`, `dob = ""`, "", envs.RedactionPolicyNone},
+		{`state = ""`, `state = ""`, "", envs.RedactionPolicyNone},
 
 		// ~ only supported for name and URNs
 		{`id ~ 02352`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
@@ -170,16 +184,17 @@ func TestParseQuery(t *testing.T) {
 		{`state > Pichincha`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
 	}
 
-	fields := map[string]assets.Field{
+	resolver := contactql.NewMockResolver(map[string]assets.Field{
 		"age":    types.NewField(assets.FieldUUID("f1b5aea6-6586-41c7-9020-1a6326cc6565"), "age", "Age", assets.FieldTypeNumber),
 		"gender": types.NewField(assets.FieldUUID("d66a7823-eada-40e5-9a3a-57239d4690bf"), "gender", "Gender", assets.FieldTypeText),
 		"state":  types.NewField(assets.FieldUUID("165def68-3216-4ebf-96bc-f6f1ee5bd966"), "state", "State", assets.FieldTypeState),
 		"dob":    types.NewField(assets.FieldUUID("85baf5e1-b57a-46dc-a726-a84e8c4229c7"), "dob", "DOB", assets.FieldTypeDatetime),
-	}
-	fieldResolver := func(key string) assets.Field { return fields[key] }
+	}, map[string]assets.Group{
+		"u-reporters": types.NewGroup(assets.GroupUUID(""), "U-Reporters", ""),
+	})
 
 	for _, tc := range tests {
-		parsed, err := contactql.ParseQuery(tc.text, tc.redact, "US", fieldResolver)
+		parsed, err := contactql.ParseQuery(tc.text, tc.redact, "US", resolver)
 		if tc.err != "" {
 			assert.EqualError(t, err, tc.err, "error mismatch for '%s'", tc.text)
 			assert.Nil(t, parsed)

--- a/contactql/parser_test.go
+++ b/contactql/parser_test.go
@@ -115,6 +115,7 @@ func TestParseQuery(t *testing.T) {
 
 		{`xyz != ""`, ``, "can't resolve 'xyz' to attribute, scheme or field", envs.RedactionPolicyNone},
 		{`group != "Gamers"`, ``, "'Gamers' is not a valid group name", envs.RedactionPolicyNone},
+		{`language = "xxxx"`, ``, "'xxxx' is not a valid language code", envs.RedactionPolicyNone},
 
 		{`name = "O\"Leary"`, `name = "O\"Leary"`, "", envs.RedactionPolicyNone}, // string unquoting
 

--- a/flows/actions/modifiers/base.go
+++ b/flows/actions/modifiers/base.go
@@ -40,7 +40,7 @@ func (m *baseModifier) Type() string { return m.Type_ }
 
 // helper to re-evaluate dynamic groups and log any changes to membership
 func (m *baseModifier) reevaluateDynamicGroups(env envs.Environment, assets flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) {
-	added, removed, errors := contact.ReevaluateDynamicGroups(env, assets.Groups(), assets.Fields())
+	added, removed, errors := contact.ReevaluateDynamicGroups(env)
 
 	// add error event for each group we couldn't re-evaluate
 	for _, err := range errors {

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -355,17 +355,17 @@ func (c *Contact) UpdatePreferredChannel(channel *Channel) bool {
 }
 
 // ReevaluateDynamicGroups reevaluates membership of all dynamic groups for this contact
-func (c *Contact) ReevaluateDynamicGroups(env envs.Environment, allGroups *GroupAssets, allFields *FieldAssets) ([]*Group, []*Group, []error) {
+func (c *Contact) ReevaluateDynamicGroups(env envs.Environment) ([]*Group, []*Group, []error) {
 	added := make([]*Group, 0)
 	removed := make([]*Group, 0)
 	errs := make([]error, 0)
 
-	for _, group := range allGroups.All() {
+	for _, group := range c.assets.Groups().All() {
 		if !group.IsDynamic() {
 			continue
 		}
 
-		qualifies, err := group.CheckDynamicMembership(env, c, allFields)
+		qualifies, err := group.CheckDynamicMembership(env, c, c.assets)
 		if err != nil {
 			errs = append(errs, errors.Wrapf(err, "unable to re-evaluate membership of group '%s'", group.Name()))
 		}

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -360,14 +360,12 @@ func TestContactQuery(t *testing.T) {
 
 		{`group = testers`, true},
 		{`group != testers`, false},
-		{`group = spammers`, false},
-		{`group != spammers`, true},
-		{`group = ""`, false},
-		{`group != ""`, true},
+		{`group = customers`, false},
+		{`group != customers`, true},
 	}
 
 	for _, tc := range testCases {
-		query, err := contactql.ParseQuery(tc.query, envs.RedactionPolicyNone, "US", session.Assets().Fields().Resolve)
+		query, err := contactql.ParseQuery(tc.query, envs.RedactionPolicyNone, "US", session.Assets())
 		require.NoError(t, err, "unexpected error parsing '%s'", tc.query)
 
 		result, err := contactql.EvaluateQuery(session.Environment(), query, contact)

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -90,3 +90,18 @@ func (s *sessionAssets) Labels() *flows.LabelAssets           { return s.labels 
 func (s *sessionAssets) Locations() *flows.LocationAssets     { return s.locations }
 func (s *sessionAssets) Resthooks() *flows.ResthookAssets     { return s.resthooks }
 func (s *sessionAssets) Templates() *flows.TemplateAssets     { return s.templates }
+
+func (s *sessionAssets) ResolveField(key string) assets.Field {
+	f := s.Fields().Get(key)
+	if f == nil {
+		return nil
+	}
+	return f
+}
+func (s *sessionAssets) ResolveGroup(name string) assets.Group {
+	g := s.Groups().FindByName(name)
+	if g == nil {
+		return nil
+	}
+	return g
+}

--- a/flows/field.go
+++ b/flows/field.go
@@ -365,12 +365,3 @@ func (s *FieldAssets) FirstOfType(valueType assets.FieldType) *Field {
 	}
 	return nil
 }
-
-// Resolve implements FieldResolver for use in contact queries
-func (s *FieldAssets) Resolve(key string) assets.Field {
-	f := s.Get(key)
-	if f == nil {
-		return nil // don't let nil f become non-nil assets.Field interface
-	}
-	return f
-}

--- a/flows/group.go
+++ b/flows/group.go
@@ -26,10 +26,10 @@ func NewGroup(asset assets.Group) *Group {
 func (g *Group) Asset() assets.Group { return g.Group }
 
 // the parsed query of a dynamic group (cached)
-func (g *Group) parsedQuery(env envs.Environment, fields *FieldAssets) (*contactql.ContactQuery, error) {
+func (g *Group) parsedQuery(env envs.Environment, sa SessionAssets) (*contactql.ContactQuery, error) {
 	if g.Query() != "" && g.cachedQuery == nil {
 		var err error
-		if g.cachedQuery, err = contactql.ParseQuery(g.Query(), env.RedactionPolicy(), env.DefaultCountry(), fields.Resolve); err != nil {
+		if g.cachedQuery, err = contactql.ParseQuery(g.Query(), env.RedactionPolicy(), env.DefaultCountry(), sa); err != nil {
 			return nil, err
 		}
 	}
@@ -40,11 +40,11 @@ func (g *Group) parsedQuery(env envs.Environment, fields *FieldAssets) (*contact
 func (g *Group) IsDynamic() bool { return g.Query() != "" }
 
 // CheckDynamicMembership returns whether the given contact belongs in this dynamic group
-func (g *Group) CheckDynamicMembership(env envs.Environment, contact *Contact, fields *FieldAssets) (bool, error) {
+func (g *Group) CheckDynamicMembership(env envs.Environment, contact *Contact, sa SessionAssets) (bool, error) {
 	if !g.IsDynamic() {
 		panic("can't check membership on a non-dynamic group")
 	}
-	parsedQuery, err := g.parsedQuery(env, fields)
+	parsedQuery, err := g.parsedQuery(env, sa)
 	if err != nil {
 		return false, err
 	}

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/excellent/types"
@@ -109,6 +110,8 @@ type FlowAssets interface {
 
 // SessionAssets is the assets available to a session
 type SessionAssets interface {
+	contactql.Resolver
+
 	Source() assets.Source
 
 	Channels() *ChannelAssets

--- a/flows/triggers/base.go
+++ b/flows/triggers/base.go
@@ -109,9 +109,7 @@ func (t *baseTrigger) Context(env envs.Environment) map[string]types.XValue {
 // EnsureDynamicGroups ensures that our session contact is in the correct dynamic groups as
 // as far as the engine is concerned
 func EnsureDynamicGroups(session flows.Session, logEvent flows.EventCallback) {
-	allGroups := session.Assets().Groups()
-	allFields := session.Assets().Fields()
-	added, removed, errors := session.Contact().ReevaluateDynamicGroups(session.Environment(), allGroups, allFields)
+	added, removed, errors := session.Contact().ReevaluateDynamicGroups(session.Environment())
 
 	// add error event for each group we couldn't re-evaluate
 	for _, err := range errors {


### PR DESCRIPTION
 * Validate that groups exist 
 * Validate that language codes are valid
 * Disallow `= ""` except for name, language, fields and urns