### PR TITLE
🗺️ Override env country if contact has preferred channel with country

### DIFF
--- a/cmd/flowrunner/main_test.go
+++ b/cmd/flowrunner/main_test.go
@@ -39,4 +39,12 @@ func TestRunFlow(t *testing.T) {
 		"💬 message created \"Great, you are done!\"",
 		"",
 	}, lines)
+
+	// run again but don't specify the flow
+	in = strings.NewReader("I like red\npepsi\n")
+	out = &strings.Builder{}
+	_, err = main.RunFlow(test.NewEngine(), "testdata/two_questions.json", "", "", "eng", in, out)
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), "Starting flow 'Two Questions'")
 }

--- a/flows/actions/testdata/send_broadcast.json
+++ b/flows/actions/testdata/send_broadcast.json
@@ -92,7 +92,7 @@
             "legacy_vars": [
                 "@(\"\")",
                 "@contact.fields.gender",
-                "@(\"0788123123\")",
+                "@(\"5129165834\")",
                 "@contact.urn"
             ],
             "text": "Hi there!"
@@ -129,7 +129,7 @@
                 "urns": [
                     "tel:+1234567890",
                     "tel:male",
-                    "tel:+250788123123",
+                    "tel:+15129165834",
                     "tel:+12065551212"
                 ]
             }
@@ -137,7 +137,7 @@
         "templates": [
             "@(\"\")",
             "@contact.fields.gender",
-            "@(\"0788123123\")",
+            "@(\"5129165834\")",
             "@contact.urn",
             "Hi there!"
         ],

--- a/flows/actions/testdata/start_session.json
+++ b/flows/actions/testdata/start_session.json
@@ -102,7 +102,7 @@
             ],
             "contact_query": "age > 20 OR gender = @fields.gender",
             "legacy_vars": [
-                "@(\"0788123123\")"
+                "@(\"5129165834\")"
             ],
             "flow": {
                 "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
@@ -133,7 +133,7 @@
                 "contact_query": "age > 20 OR gender = \"Male\"",
                 "urns": [
                     "tel:+1234567890",
-                    "tel:+250788123123"
+                    "tel:+15129165834"
                 ],
                 "run_summary": {
                     "uuid": "e7187099-7d38-4f60-955c-325957214c42",
@@ -174,7 +174,7 @@
         ],
         "templates": [
             "age > 20 OR gender = @fields.gender",
-            "@(\"0788123123\")"
+            "@(\"5129165834\")"
         ],
         "inspection": {
             "dependencies": [

--- a/flows/runs/environment.go
+++ b/flows/runs/environment.go
@@ -34,6 +34,19 @@ func (e *runEnvironment) Timezone() *time.Location {
 	return e.run.Session().Environment().Timezone()
 }
 
+func (e *runEnvironment) DefaultCountry() envs.Country {
+	contact := e.run.Contact()
+
+	// if run has a contact with a preferred channel with a country, that overrides the environment's country
+	if contact != nil {
+		ch := contact.PreferredChannel()
+		if ch != nil && ch.Country() != envs.NilCountry {
+			return ch.Country()
+		}
+	}
+	return e.run.Session().Environment().DefaultCountry()
+}
+
 func (e *runEnvironment) Locations() (assets.LocationHierarchy, error) {
 	sessionAssets := e.run.Session().Assets()
 	hierarchies := sessionAssets.Locations().Hierarchies()

--- a/flows/runs/environment_test.go
+++ b/flows/runs/environment_test.go
@@ -1,0 +1,83 @@
+package runs_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/assets/static"
+	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/engine"
+	"github.com/nyaruka/goflow/flows/triggers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var assetsJSON = `{
+    "flows": [
+        {
+            "uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
+            "name": "Test",
+            "spec_version": "13.1.0",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": []
+        }
+	],
+	"channels": [
+    	{
+			"uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
+			"name": "Android Channel",
+			"address": "+17036975131",
+			"schemes": ["tel"],
+			"roles": ["send", "receive"],
+			"country": "US"
+    	}
+  	]
+}`
+
+const contactJSON = `{
+	"uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
+	"id": 1234567,
+	"name": "Ben Haggerty",
+	"created_on": "2018-01-01T12:00:00.000000000-00:00",
+	"fields": {},
+	"timezone": "America/Guayaquil",
+	"urns": [
+		"tel:+12065551212"
+	]
+}`
+
+func TestRunEnvironment(t *testing.T) {
+	tzRW, _ := time.LoadLocation("Africa/Kigali")
+	tzEC, _ := time.LoadLocation("America/Guayaquil")
+
+	env := envs.NewBuilder().
+		WithDefaultCountry("RW").
+		WithTimezone(tzRW).
+		Build()
+	source, err := static.NewSource([]byte(assetsJSON))
+	require.NoError(t, err)
+
+	sa, err := engine.NewSessionAssets(env, source, nil)
+	require.NoError(t, err)
+
+	contact, err := flows.ReadContact(sa, []byte(contactJSON), assets.IgnoreMissing)
+	require.NoError(t, err)
+
+	trigger := triggers.NewManual(env, assets.NewFlowReference("76f0a02f-3b75-4b86-9064-e9195e1b3a02", "Test"), contact, nil)
+	eng := engine.NewBuilder().Build()
+
+	session, _, err := eng.NewSession(sa, trigger)
+	require.NoError(t, err)
+
+	// environment on the session has the values we started with
+	assert.Equal(t, envs.Country("RW"), session.Environment().DefaultCountry())
+	assert.Equal(t, tzRW, session.Environment().Timezone())
+
+	// environment on the run has values from the contact
+	runEnv := session.Runs()[0].Environment()
+	assert.Equal(t, envs.Country("US"), runEnv.DefaultCountry())
+	assert.Equal(t, tzEC, runEnv.Timezone())
+}

--- a/test/testdata/runner/phone_number.json
+++ b/test/testdata/runner/phone_number.json
@@ -1,0 +1,176 @@
+{
+  "flows": [
+    {
+      "name": "Phone Numbers",
+      "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4",
+      "spec_version": "13.1.0",
+      "language": "eng",
+      "type": "messaging",
+      "nodes": [
+        {
+          "uuid": "626c8aa2-2903-4453-9ac5-1a2e6d21acf6",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "Enter a backup phone number",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "03d29ca0-05e4-4e4f-b3ac-d5054238c642"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "12f9509b-f60d-49a1-a34f-df27643638f3",
+              "destination_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139"
+            }
+          ]
+        },
+        {
+          "uuid": "36e57807-2608-471f-b5c8-0798aac2667e",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "Sorry that doesn't look like a phone number. Try again.",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "feb3e9b8-afe1-4b33-93e7-2530544aece6"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "573e9804-2429-47bd-86a7-b673574f5e2c",
+              "destination_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139"
+            }
+          ]
+        },
+        {
+          "uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+          "actions": [],
+          "router": {
+            "type": "switch",
+            "default_category_uuid": "dfa6a34b-bda6-46a4-ada0-e26668b77de8",
+            "cases": [
+              {
+                "arguments": [],
+                "type": "has_phone",
+                "uuid": "602b2de0-3674-40ce-ae48-2f8dfd44032d",
+                "category_uuid": "a8a442ce-41b9-4477-880e-8b507898bdce"
+              }
+            ],
+            "categories": [
+              {
+                "uuid": "a8a442ce-41b9-4477-880e-8b507898bdce",
+                "name": "Has Phone",
+                "exit_uuid": "2b9ce880-3556-410a-af5a-edd366a1d628"
+              },
+              {
+                "uuid": "dfa6a34b-bda6-46a4-ada0-e26668b77de8",
+                "name": "Other",
+                "exit_uuid": "6083707c-109a-442b-a2c6-b6d60bb1eaed"
+              }
+            ],
+            "operand": "@input.text",
+            "wait": {
+              "type": "msg"
+            },
+            "result_name": "Backup Phone"
+          },
+          "exits": [
+            {
+              "uuid": "2b9ce880-3556-410a-af5a-edd366a1d628",
+              "destination_uuid": "b7653335-7790-4f00-aede-7c6d03c8f829"
+            },
+            {
+              "uuid": "6083707c-109a-442b-a2c6-b6d60bb1eaed",
+              "destination_uuid": "36e57807-2608-471f-b5c8-0798aac2667e"
+            }
+          ]
+        },
+        {
+          "uuid": "b7653335-7790-4f00-aede-7c6d03c8f829",
+          "actions": [
+            {
+              "type": "add_contact_urn",
+              "uuid": "4f552bf3-31ad-4125-84e9-9011ab2c1e99",
+              "scheme": "tel",
+              "path": "@results.backup_phone"
+            },
+            {
+              "attachments": [],
+              "text": "Ok you've added @(format_urn(\"tel:\" & results.backup_phone))",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "717a7fae-7929-4e06-88ef-764b392009fa"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "91023689-f038-405e-a3c0-c4e8e8580bd9",
+              "destination_uuid": null
+            }
+          ]
+        }
+      ],
+      "_ui": {
+        "nodes": {
+          "626c8aa2-2903-4453-9ac5-1a2e6d21acf6": {
+            "position": {
+              "left": 220,
+              "top": 0
+            },
+            "type": "execute_actions"
+          },
+          "6e15badb-5c42-41e1-ae77-a34b9b850139": {
+            "type": "wait_for_response",
+            "position": {
+              "left": 300,
+              "top": 160
+            },
+            "config": {
+              "cases": {}
+            }
+          },
+          "36e57807-2608-471f-b5c8-0798aac2667e": {
+            "position": {
+              "left": 580,
+              "top": 100
+            },
+            "type": "execute_actions"
+          },
+          "b7653335-7790-4f00-aede-7c6d03c8f829": {
+            "position": {
+              "left": 280,
+              "top": 360
+            },
+            "type": "execute_actions"
+          }
+        }
+      },
+      "revision": 18,
+      "expire_after_minutes": 10080,
+      "localization": {}
+    }
+  ],
+  "groups": [
+    {
+      "uuid": "b75f451a-f180-4494-b597-8d9f4ef43d75",
+      "name": "NYC Area",
+      "query": "tel ~ +1718"
+    }
+  ],
+  "channels": [
+    {
+      "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
+      "name": "Android Channel",
+      "address": "+17036975131",
+      "schemes": [
+        "tel"
+      ],
+      "roles": [
+        "send",
+        "receive"
+      ],
+      "country": "US"
+    }
+  ]
+}

--- a/test/testdata/runner/phone_number.test.json
+++ b/test/testdata/runner/phone_number.test.json
@@ -1,0 +1,744 @@
+{
+    "outputs": [
+        {
+            "events": [
+                {
+                    "created_on": "2018-07-06T12:30:04.123456789Z",
+                    "msg": {
+                        "channel": {
+                            "name": "Android Channel",
+                            "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                        },
+                        "text": "Enter a backup phone number",
+                        "urn": "tel:+12065551212",
+                        "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
+                    },
+                    "step_uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094",
+                    "type": "msg_created"
+                },
+                {
+                    "created_on": "2018-07-06T12:30:07.123456789Z",
+                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "type": "msg_wait"
+                }
+            ],
+            "session": {
+                "contact": {
+                    "created_on": "2018-01-01T12:00:00Z",
+                    "id": 1234567,
+                    "language": "eng",
+                    "name": "Ben Haggerty",
+                    "timezone": "America/Guayaquil",
+                    "urns": [
+                        "tel:+12065551212",
+                        "facebook:1122334455667788",
+                        "mailto:ben@macklemore"
+                    ],
+                    "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                },
+                "environment": {
+                    "allowed_languages": [
+                        "eng",
+                        "eng"
+                    ],
+                    "date_format": "YYYY-MM-DD",
+                    "max_value_length": 640,
+                    "number_format": {
+                        "decimal_symbol": ".",
+                        "digit_grouping_symbol": ","
+                    },
+                    "redaction_policy": "none",
+                    "time_format": "tt:mm",
+                    "timezone": "America/Los_Angeles"
+                },
+                "runs": [
+                    {
+                        "created_on": "2018-07-06T12:30:00.123456789Z",
+                        "events": [
+                            {
+                                "created_on": "2018-07-06T12:30:04.123456789Z",
+                                "msg": {
+                                    "channel": {
+                                        "name": "Android Channel",
+                                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                                    },
+                                    "text": "Enter a backup phone number",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
+                                },
+                                "step_uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094",
+                                "type": "msg_created"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:07.123456789Z",
+                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "type": "msg_wait"
+                            }
+                        ],
+                        "exited_on": null,
+                        "expires_on": "2018-07-13T12:30:01.123456789Z",
+                        "flow": {
+                            "name": "Phone Numbers",
+                            "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
+                        },
+                        "modified_on": "2018-07-06T12:30:09.123456789Z",
+                        "path": [
+                            {
+                                "arrived_on": "2018-07-06T12:30:03.123456789Z",
+                                "exit_uuid": "12f9509b-f60d-49a1-a34f-df27643638f3",
+                                "node_uuid": "626c8aa2-2903-4453-9ac5-1a2e6d21acf6",
+                                "uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:06.123456789Z",
+                                "node_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+                                "uuid": "5802813d-6c58-4292-8228-9728778b6c98"
+                            }
+                        ],
+                        "status": "waiting",
+                        "uuid": "692926ea-09d6-4942-bd38-d266ec8d3716"
+                    }
+                ],
+                "status": "waiting",
+                "trigger": {
+                    "contact": {
+                        "created_on": "2018-01-01T12:00:00Z",
+                        "id": 1234567,
+                        "language": "eng",
+                        "name": "Ben Haggerty",
+                        "timezone": "America/Guayaquil",
+                        "urns": [
+                            "tel:+12065551212",
+                            "facebook:1122334455667788",
+                            "mailto:ben@macklemore"
+                        ],
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                    },
+                    "environment": {
+                        "allowed_languages": [
+                            "eng",
+                            "eng"
+                        ],
+                        "date_format": "YYYY-MM-DD",
+                        "max_value_length": 640,
+                        "number_format": {
+                            "decimal_symbol": ".",
+                            "digit_grouping_symbol": ","
+                        },
+                        "redaction_policy": "none",
+                        "time_format": "tt:mm",
+                        "timezone": "America/Los_Angeles"
+                    },
+                    "flow": {
+                        "name": "Phone Numbers",
+                        "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
+                    },
+                    "triggered_on": "2020-03-19T16:37:26.928919-05:00",
+                    "type": "manual"
+                },
+                "type": "messaging",
+                "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+                "wait": {
+                    "type": "msg"
+                }
+            }
+        },
+        {
+            "events": [
+                {
+                    "created_on": "2018-07-06T12:30:12.123456789Z",
+                    "msg": {
+                        "text": "135532",
+                        "urn": "tel:+12065551212",
+                        "uuid": "ba05c12e-16b2-4e13-8d89-e0cc9530a8fb"
+                    },
+                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "type": "msg_received"
+                },
+                {
+                    "category": "Other",
+                    "created_on": "2018-07-06T12:30:17.123456789Z",
+                    "input": "135532",
+                    "name": "Backup Phone",
+                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "type": "run_result_changed",
+                    "value": "135532"
+                },
+                {
+                    "created_on": "2018-07-06T12:30:20.123456789Z",
+                    "msg": {
+                        "channel": {
+                            "name": "Android Channel",
+                            "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                        },
+                        "text": "Sorry that doesn't look like a phone number. Try again.",
+                        "urn": "tel:+12065551212",
+                        "uuid": "5ecda5fc-951c-437b-a17e-f85e49829fb9"
+                    },
+                    "step_uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623",
+                    "type": "msg_created"
+                },
+                {
+                    "created_on": "2018-07-06T12:30:23.123456789Z",
+                    "step_uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671",
+                    "type": "msg_wait"
+                }
+            ],
+            "session": {
+                "contact": {
+                    "created_on": "2018-01-01T12:00:00Z",
+                    "id": 1234567,
+                    "language": "eng",
+                    "name": "Ben Haggerty",
+                    "timezone": "America/Guayaquil",
+                    "urns": [
+                        "tel:+12065551212",
+                        "facebook:1122334455667788",
+                        "mailto:ben@macklemore"
+                    ],
+                    "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                },
+                "environment": {
+                    "allowed_languages": [
+                        "eng",
+                        "eng"
+                    ],
+                    "date_format": "YYYY-MM-DD",
+                    "max_value_length": 640,
+                    "number_format": {
+                        "decimal_symbol": ".",
+                        "digit_grouping_symbol": ","
+                    },
+                    "redaction_policy": "none",
+                    "time_format": "tt:mm",
+                    "timezone": "America/Los_Angeles"
+                },
+                "input": {
+                    "created_on": "2020-03-19T16:37:31.207472-05:00",
+                    "text": "135532",
+                    "type": "msg",
+                    "urn": "tel:+12065551212",
+                    "uuid": "ba05c12e-16b2-4e13-8d89-e0cc9530a8fb"
+                },
+                "runs": [
+                    {
+                        "created_on": "2018-07-06T12:30:00.123456789Z",
+                        "events": [
+                            {
+                                "created_on": "2018-07-06T12:30:04.123456789Z",
+                                "msg": {
+                                    "channel": {
+                                        "name": "Android Channel",
+                                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                                    },
+                                    "text": "Enter a backup phone number",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
+                                },
+                                "step_uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094",
+                                "type": "msg_created"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:07.123456789Z",
+                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "type": "msg_wait"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:12.123456789Z",
+                                "msg": {
+                                    "text": "135532",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "ba05c12e-16b2-4e13-8d89-e0cc9530a8fb"
+                                },
+                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "type": "msg_received"
+                            },
+                            {
+                                "category": "Other",
+                                "created_on": "2018-07-06T12:30:17.123456789Z",
+                                "input": "135532",
+                                "name": "Backup Phone",
+                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "type": "run_result_changed",
+                                "value": "135532"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:20.123456789Z",
+                                "msg": {
+                                    "channel": {
+                                        "name": "Android Channel",
+                                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                                    },
+                                    "text": "Sorry that doesn't look like a phone number. Try again.",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "5ecda5fc-951c-437b-a17e-f85e49829fb9"
+                                },
+                                "step_uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623",
+                                "type": "msg_created"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:23.123456789Z",
+                                "step_uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671",
+                                "type": "msg_wait"
+                            }
+                        ],
+                        "exited_on": null,
+                        "expires_on": "2018-07-13T12:30:10.123456789Z",
+                        "flow": {
+                            "name": "Phone Numbers",
+                            "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
+                        },
+                        "modified_on": "2018-07-06T12:30:25.123456789Z",
+                        "path": [
+                            {
+                                "arrived_on": "2018-07-06T12:30:03.123456789Z",
+                                "exit_uuid": "12f9509b-f60d-49a1-a34f-df27643638f3",
+                                "node_uuid": "626c8aa2-2903-4453-9ac5-1a2e6d21acf6",
+                                "uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:06.123456789Z",
+                                "exit_uuid": "6083707c-109a-442b-a2c6-b6d60bb1eaed",
+                                "node_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+                                "uuid": "5802813d-6c58-4292-8228-9728778b6c98"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:19.123456789Z",
+                                "exit_uuid": "573e9804-2429-47bd-86a7-b673574f5e2c",
+                                "node_uuid": "36e57807-2608-471f-b5c8-0798aac2667e",
+                                "uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:22.123456789Z",
+                                "node_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+                                "uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671"
+                            }
+                        ],
+                        "results": {
+                            "backup_phone": {
+                                "category": "Other",
+                                "created_on": "2018-07-06T12:30:15.123456789Z",
+                                "input": "135532",
+                                "name": "Backup Phone",
+                                "node_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+                                "value": "135532"
+                            }
+                        },
+                        "status": "waiting",
+                        "uuid": "692926ea-09d6-4942-bd38-d266ec8d3716"
+                    }
+                ],
+                "status": "waiting",
+                "trigger": {
+                    "contact": {
+                        "created_on": "2018-01-01T12:00:00Z",
+                        "id": 1234567,
+                        "language": "eng",
+                        "name": "Ben Haggerty",
+                        "timezone": "America/Guayaquil",
+                        "urns": [
+                            "tel:+12065551212",
+                            "facebook:1122334455667788",
+                            "mailto:ben@macklemore"
+                        ],
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                    },
+                    "environment": {
+                        "allowed_languages": [
+                            "eng",
+                            "eng"
+                        ],
+                        "date_format": "YYYY-MM-DD",
+                        "max_value_length": 640,
+                        "number_format": {
+                            "decimal_symbol": ".",
+                            "digit_grouping_symbol": ","
+                        },
+                        "redaction_policy": "none",
+                        "time_format": "tt:mm",
+                        "timezone": "America/Los_Angeles"
+                    },
+                    "flow": {
+                        "name": "Phone Numbers",
+                        "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
+                    },
+                    "triggered_on": "2020-03-19T16:37:26.928919-05:00",
+                    "type": "manual"
+                },
+                "type": "messaging",
+                "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+                "wait": {
+                    "type": "msg"
+                }
+            }
+        },
+        {
+            "events": [
+                {
+                    "created_on": "2018-07-06T12:30:28.123456789Z",
+                    "msg": {
+                        "text": "718-456-7890",
+                        "urn": "tel:+12065551212",
+                        "uuid": "5c94ee12-4c29-4f77-b3f2-c81ee6f5f445"
+                    },
+                    "step_uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671",
+                    "type": "msg_received"
+                },
+                {
+                    "category": "Has Phone",
+                    "created_on": "2018-07-06T12:30:33.123456789Z",
+                    "input": "718-456-7890",
+                    "name": "Backup Phone",
+                    "step_uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671",
+                    "type": "run_result_changed",
+                    "value": "+17184567890"
+                },
+                {
+                    "created_on": "2018-07-06T12:30:36.123456789Z",
+                    "step_uuid": "a4d15ed4-5b24-407f-b86e-4b881f09a186",
+                    "type": "contact_urns_changed",
+                    "urns": [
+                        "tel:+12065551212",
+                        "facebook:1122334455667788",
+                        "mailto:ben@macklemore",
+                        "tel:+17184567890"
+                    ]
+                },
+                {
+                    "created_on": "2018-07-06T12:30:38.123456789Z",
+                    "groups_added": [
+                        {
+                            "name": "NYC Area",
+                            "uuid": "b75f451a-f180-4494-b597-8d9f4ef43d75"
+                        }
+                    ],
+                    "step_uuid": "a4d15ed4-5b24-407f-b86e-4b881f09a186",
+                    "type": "contact_groups_changed"
+                },
+                {
+                    "created_on": "2018-07-06T12:30:40.123456789Z",
+                    "msg": {
+                        "channel": {
+                            "name": "Android Channel",
+                            "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                        },
+                        "text": "Ok you've added (718) 456-7890",
+                        "urn": "tel:+12065551212",
+                        "uuid": "b88ce93d-4360-4455-a691-235cbe720980"
+                    },
+                    "step_uuid": "a4d15ed4-5b24-407f-b86e-4b881f09a186",
+                    "type": "msg_created"
+                }
+            ],
+            "session": {
+                "contact": {
+                    "created_on": "2018-01-01T12:00:00Z",
+                    "groups": [
+                        {
+                            "name": "NYC Area",
+                            "uuid": "b75f451a-f180-4494-b597-8d9f4ef43d75"
+                        }
+                    ],
+                    "id": 1234567,
+                    "language": "eng",
+                    "name": "Ben Haggerty",
+                    "timezone": "America/Guayaquil",
+                    "urns": [
+                        "tel:+12065551212",
+                        "facebook:1122334455667788",
+                        "mailto:ben@macklemore",
+                        "tel:+17184567890"
+                    ],
+                    "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                },
+                "environment": {
+                    "allowed_languages": [
+                        "eng",
+                        "eng"
+                    ],
+                    "date_format": "YYYY-MM-DD",
+                    "max_value_length": 640,
+                    "number_format": {
+                        "decimal_symbol": ".",
+                        "digit_grouping_symbol": ","
+                    },
+                    "redaction_policy": "none",
+                    "time_format": "tt:mm",
+                    "timezone": "America/Los_Angeles"
+                },
+                "input": {
+                    "created_on": "2020-03-19T16:37:38.453883-05:00",
+                    "text": "718-456-7890",
+                    "type": "msg",
+                    "urn": "tel:+12065551212",
+                    "uuid": "5c94ee12-4c29-4f77-b3f2-c81ee6f5f445"
+                },
+                "runs": [
+                    {
+                        "created_on": "2018-07-06T12:30:00.123456789Z",
+                        "events": [
+                            {
+                                "created_on": "2018-07-06T12:30:04.123456789Z",
+                                "msg": {
+                                    "channel": {
+                                        "name": "Android Channel",
+                                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                                    },
+                                    "text": "Enter a backup phone number",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
+                                },
+                                "step_uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094",
+                                "type": "msg_created"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:07.123456789Z",
+                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "type": "msg_wait"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:12.123456789Z",
+                                "msg": {
+                                    "text": "135532",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "ba05c12e-16b2-4e13-8d89-e0cc9530a8fb"
+                                },
+                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "type": "msg_received"
+                            },
+                            {
+                                "category": "Other",
+                                "created_on": "2018-07-06T12:30:17.123456789Z",
+                                "input": "135532",
+                                "name": "Backup Phone",
+                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "type": "run_result_changed",
+                                "value": "135532"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:20.123456789Z",
+                                "msg": {
+                                    "channel": {
+                                        "name": "Android Channel",
+                                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                                    },
+                                    "text": "Sorry that doesn't look like a phone number. Try again.",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "5ecda5fc-951c-437b-a17e-f85e49829fb9"
+                                },
+                                "step_uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623",
+                                "type": "msg_created"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:23.123456789Z",
+                                "step_uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671",
+                                "type": "msg_wait"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:28.123456789Z",
+                                "msg": {
+                                    "text": "718-456-7890",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "5c94ee12-4c29-4f77-b3f2-c81ee6f5f445"
+                                },
+                                "step_uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671",
+                                "type": "msg_received"
+                            },
+                            {
+                                "category": "Has Phone",
+                                "created_on": "2018-07-06T12:30:33.123456789Z",
+                                "input": "718-456-7890",
+                                "name": "Backup Phone",
+                                "step_uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671",
+                                "type": "run_result_changed",
+                                "value": "+17184567890"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:36.123456789Z",
+                                "step_uuid": "a4d15ed4-5b24-407f-b86e-4b881f09a186",
+                                "type": "contact_urns_changed",
+                                "urns": [
+                                    "tel:+12065551212",
+                                    "facebook:1122334455667788",
+                                    "mailto:ben@macklemore",
+                                    "tel:+17184567890"
+                                ]
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:38.123456789Z",
+                                "groups_added": [
+                                    {
+                                        "name": "NYC Area",
+                                        "uuid": "b75f451a-f180-4494-b597-8d9f4ef43d75"
+                                    }
+                                ],
+                                "step_uuid": "a4d15ed4-5b24-407f-b86e-4b881f09a186",
+                                "type": "contact_groups_changed"
+                            },
+                            {
+                                "created_on": "2018-07-06T12:30:40.123456789Z",
+                                "msg": {
+                                    "channel": {
+                                        "name": "Android Channel",
+                                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                                    },
+                                    "text": "Ok you've added (718) 456-7890",
+                                    "urn": "tel:+12065551212",
+                                    "uuid": "b88ce93d-4360-4455-a691-235cbe720980"
+                                },
+                                "step_uuid": "a4d15ed4-5b24-407f-b86e-4b881f09a186",
+                                "type": "msg_created"
+                            }
+                        ],
+                        "exited_on": "2018-07-06T12:30:42.123456789Z",
+                        "expires_on": "2018-07-13T12:30:26.123456789Z",
+                        "flow": {
+                            "name": "Phone Numbers",
+                            "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
+                        },
+                        "modified_on": "2018-07-06T12:30:42.123456789Z",
+                        "path": [
+                            {
+                                "arrived_on": "2018-07-06T12:30:03.123456789Z",
+                                "exit_uuid": "12f9509b-f60d-49a1-a34f-df27643638f3",
+                                "node_uuid": "626c8aa2-2903-4453-9ac5-1a2e6d21acf6",
+                                "uuid": "8720f157-ca1c-432f-9c0b-2014ddc77094"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:06.123456789Z",
+                                "exit_uuid": "6083707c-109a-442b-a2c6-b6d60bb1eaed",
+                                "node_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+                                "uuid": "5802813d-6c58-4292-8228-9728778b6c98"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:19.123456789Z",
+                                "exit_uuid": "573e9804-2429-47bd-86a7-b673574f5e2c",
+                                "node_uuid": "36e57807-2608-471f-b5c8-0798aac2667e",
+                                "uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:22.123456789Z",
+                                "exit_uuid": "2b9ce880-3556-410a-af5a-edd366a1d628",
+                                "node_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+                                "uuid": "312d3af0-a565-4c96-ba00-bd7f0d08e671"
+                            },
+                            {
+                                "arrived_on": "2018-07-06T12:30:35.123456789Z",
+                                "exit_uuid": "91023689-f038-405e-a3c0-c4e8e8580bd9",
+                                "node_uuid": "b7653335-7790-4f00-aede-7c6d03c8f829",
+                                "uuid": "a4d15ed4-5b24-407f-b86e-4b881f09a186"
+                            }
+                        ],
+                        "results": {
+                            "backup_phone": {
+                                "category": "Has Phone",
+                                "created_on": "2018-07-06T12:30:31.123456789Z",
+                                "input": "718-456-7890",
+                                "name": "Backup Phone",
+                                "node_uuid": "6e15badb-5c42-41e1-ae77-a34b9b850139",
+                                "value": "+17184567890"
+                            }
+                        },
+                        "status": "completed",
+                        "uuid": "692926ea-09d6-4942-bd38-d266ec8d3716"
+                    }
+                ],
+                "status": "completed",
+                "trigger": {
+                    "contact": {
+                        "created_on": "2018-01-01T12:00:00Z",
+                        "id": 1234567,
+                        "language": "eng",
+                        "name": "Ben Haggerty",
+                        "timezone": "America/Guayaquil",
+                        "urns": [
+                            "tel:+12065551212",
+                            "facebook:1122334455667788",
+                            "mailto:ben@macklemore"
+                        ],
+                        "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+                    },
+                    "environment": {
+                        "allowed_languages": [
+                            "eng",
+                            "eng"
+                        ],
+                        "date_format": "YYYY-MM-DD",
+                        "max_value_length": 640,
+                        "number_format": {
+                            "decimal_symbol": ".",
+                            "digit_grouping_symbol": ","
+                        },
+                        "redaction_policy": "none",
+                        "time_format": "tt:mm",
+                        "timezone": "America/Los_Angeles"
+                    },
+                    "flow": {
+                        "name": "Phone Numbers",
+                        "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
+                    },
+                    "triggered_on": "2020-03-19T16:37:26.928919-05:00",
+                    "type": "manual"
+                },
+                "type": "messaging",
+                "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5"
+            }
+        }
+    ],
+    "resumes": [
+        {
+            "msg": {
+                "text": "135532",
+                "urn": "tel:+12065551212",
+                "uuid": "ba05c12e-16b2-4e13-8d89-e0cc9530a8fb"
+            },
+            "resumed_on": "2020-03-19T16:37:31.207472-05:00",
+            "type": "msg"
+        },
+        {
+            "msg": {
+                "text": "718-456-7890",
+                "urn": "tel:+12065551212",
+                "uuid": "5c94ee12-4c29-4f77-b3f2-c81ee6f5f445"
+            },
+            "resumed_on": "2020-03-19T16:37:38.453883-05:00",
+            "type": "msg"
+        }
+    ],
+    "trigger": {
+        "contact": {
+            "created_on": "2018-01-01T12:00:00Z",
+            "id": 1234567,
+            "language": "eng",
+            "name": "Ben Haggerty",
+            "timezone": "America/Guayaquil",
+            "urns": [
+                "tel:+12065551212",
+                "facebook:1122334455667788",
+                "mailto:ben@macklemore"
+            ],
+            "uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3"
+        },
+        "environment": {
+            "allowed_languages": [
+                "eng",
+                "eng"
+            ],
+            "date_format": "YYYY-MM-DD",
+            "max_value_length": 640,
+            "number_format": {
+                "decimal_symbol": ".",
+                "digit_grouping_symbol": ","
+            },
+            "redaction_policy": "none",
+            "time_format": "tt:mm",
+            "timezone": "America/Los_Angeles"
+        },
+        "flow": {
+            "name": "Phone Numbers",
+            "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
+        },
+        "triggered_on": "2020-03-19T16:37:26.928919-05:00",
+        "type": "manual"
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/rapidpro/rapidpro/issues/1166

Things like excellent functions (`has_phone`) only have access to an `Environment`.. and know nothing about runs and sessions. Inside a run, when we have templates to evaluate, we create a special `RunEnvironment` which overrides things like timezone and language based on values on the current session contact.

