### PR TITLE
⚙️ Rework group asset loading so that parsing is not deferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ import (
     "github.com/nyaruka/goflow/utils"
 )
 
-source, _ := static.LoadSource("myassets.json")
-assets, _ := engine.NewSessionAssets(source, nil)
-contact := flows.NewContact(assets, ...)
 env := envs.NewBuilder().Build()
+source, _ := static.LoadSource("myassets.json")
+assets, _ := engine.NewSessionAssets(env, source, nil)
+contact := flows.NewContact(assets, ...)
 trigger := triggers.NewManual(env, contact, flow.Reference(), nil, nil, time.Now())
 eng := engine.NewBuilder().Build()
 session, sprint, err := eng.NewSession(assets, trigger)

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -104,7 +104,7 @@ func RunFlow(eng flows.Engine, assetsPath string, flowUUID assets.FlowUUID, init
 		return nil, err
 	}
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(envs.NewBuilder().Build(), source, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing assets")
 	}

--- a/cmd/transferairtime/main.go
+++ b/cmd/transferairtime/main.go
@@ -114,13 +114,14 @@ func transferAirtime(destination urns.URN, amount decimal.Decimal, currency stri
 		return err
 	}
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	env := envs.NewBuilder().Build()
+
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	if err != nil {
 		return errors.Wrap(err, "error parsing assets")
 	}
 
 	eng := engine.NewBuilder().WithAirtimeServiceFactory(svcFactory).Build()
-	env := envs.NewBuilder().Build()
 	contact := flows.NewEmptyContact(sa, "", "", nil)
 	contact.AddURN(destination, nil)
 

--- a/flows/actions/modifiers/base_test.go
+++ b/flows/actions/modifiers/base_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestModifierTypes(t *testing.T) {
-	assets, err := test.LoadSessionAssets("testdata/_assets.json")
+	env := envs.NewBuilder().Build()
+	assets, err := test.LoadSessionAssets(env, "testdata/_assets.json")
 	require.NoError(t, err)
 
 	for typeName := range modifiers.RegisteredTypes {
@@ -109,7 +110,8 @@ func testModifierType(t *testing.T, sessionAssets flows.SessionAssets, typeName 
 }
 
 func TestConstructors(t *testing.T) {
-	assets, err := test.LoadSessionAssets("testdata/_assets.json")
+	env := envs.NewBuilder().Build()
+	assets, err := test.LoadSessionAssets(env, "testdata/_assets.json")
 	require.NoError(t, err)
 
 	nexmo := assets.Channels().Get("3a05eaf5-cb1b-4246-bef1-f277419c83a7")
@@ -198,10 +200,11 @@ func TestConstructors(t *testing.T) {
 }
 
 func TestReadModifier(t *testing.T) {
+	env := envs.NewBuilder().Build()
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
 	require.NoError(t, err)
 
 	// error if no type field
@@ -236,7 +239,7 @@ func TestReadModifier(t *testing.T) {
 			{"uuid": "4349cdd6-5385-46f3-8e55-5750dd4f35fb", "name": "Winners"}
 		]
 	}`))
-	sessionAssets, err = engine.NewSessionAssets(source, nil)
+	sessionAssets, err = engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
 
 	mod, err = modifiers.ReadModifier(sessionAssets, []byte(`{"type": "groups", "modification": "add", "groups": [{"uuid": "cd1a2aa6-0d9d-4a8c-b32d-ca5de9c43bdb", "name": "Losers"}, {"uuid": "4349cdd6-5385-46f3-8e55-5750dd4f35fb", "name": "Winners"}]}`), missing)

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -365,7 +365,7 @@ func (c *Contact) ReevaluateDynamicGroups(env envs.Environment) ([]*Group, []*Gr
 			continue
 		}
 
-		qualifies, err := group.CheckDynamicMembership(env, c, c.assets)
+		qualifies, err := group.CheckDynamicMembership(env, c)
 		if err != nil {
 			errs = append(errs, errors.Wrapf(err, "unable to re-evaluate membership of group '%s'", group.Name()))
 		}

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -316,7 +316,8 @@ func TestNewFlow(t *testing.T) {
 }
 
 func TestEmptyFlow(t *testing.T) {
-	flow, err := test.LoadFlowFromAssets("../../test/testdata/runner/empty.json", "76f0a02f-3b75-4b86-9064-e9195e1b3a02")
+	env := envs.NewBuilder().Build()
+	flow, err := test.LoadFlowFromAssets(env, "../../test/testdata/runner/empty.json", "76f0a02f-3b75-4b86-9064-e9195e1b3a02")
 	require.NoError(t, err)
 
 	marshaled, err := jsonx.Marshal(flow)
@@ -454,6 +455,8 @@ func TestReadFlow(t *testing.T) {
 }
 
 func TestExtractTemplates(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	testCases := []struct {
 		path      string
 		uuid      string
@@ -516,7 +519,7 @@ func TestExtractTemplates(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		flow, err := test.LoadFlowFromAssets(tc.path, assets.FlowUUID(tc.uuid))
+		flow, err := test.LoadFlowFromAssets(env, tc.path, assets.FlowUUID(tc.uuid))
 		require.NoError(t, err)
 
 		// try extracting all templates
@@ -526,6 +529,8 @@ func TestExtractTemplates(t *testing.T) {
 }
 
 func TestInspection(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	testCases := []struct {
 		path string
 		uuid string
@@ -557,7 +562,7 @@ func TestInspection(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		sa, err := test.LoadSessionAssets(tc.path)
+		sa, err := test.LoadSessionAssets(env, tc.path)
 		require.NoError(t, err)
 
 		flow, err := sa.Flows().Get(assets.FlowUUID(tc.uuid))

--- a/flows/definition/migrations/base_test.go
+++ b/flows/definition/migrations/base_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/definition"
 	"github.com/nyaruka/goflow/flows/definition/migrations"
@@ -150,6 +151,8 @@ func TestMigrateToLatest(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	testCases := []struct {
 		path string
 		uuid string
@@ -164,7 +167,7 @@ func TestClone(t *testing.T) {
 		uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 		defer uuids.SetGenerator(uuids.DefaultGenerator)
 
-		flow, err := test.LoadFlowFromAssets(tc.path, assets.FlowUUID(tc.uuid))
+		flow, err := test.LoadFlowFromAssets(env, tc.path, assets.FlowUUID(tc.uuid))
 		require.NoError(t, err)
 
 		depMappings := map[uuids.UUID]uuids.UUID{

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/definition"
 	"github.com/nyaruka/goflow/flows/definition/migrations"
@@ -26,7 +27,7 @@ type sessionAssets struct {
 var _ flows.SessionAssets = (*sessionAssets)(nil)
 
 // NewSessionAssets creates a new session assets instance with the provided base URLs
-func NewSessionAssets(source assets.Source, migrationConfig *migrations.Config) (flows.SessionAssets, error) {
+func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfig *migrations.Config) (flows.SessionAssets, error) {
 	channels, err := source.Channels()
 	if err != nil {
 		return nil, err
@@ -64,14 +65,17 @@ func NewSessionAssets(source assets.Source, migrationConfig *migrations.Config) 
 		return nil, err
 	}
 
+	fieldAssets := flows.NewFieldAssets(fields)
+	groupAssets, _ := flows.NewGroupAssets(env, fieldAssets, groups)
+
 	return &sessionAssets{
 		source:      source,
 		channels:    flows.NewChannelAssets(channels),
 		classifiers: flows.NewClassifierAssets(classifiers),
-		fields:      flows.NewFieldAssets(fields),
+		fields:      fieldAssets,
 		flows:       definition.NewFlowAssets(source, migrationConfig),
 		globals:     flows.NewGlobalAssets(globals),
-		groups:      flows.NewGroupAssets(groups),
+		groups:      groupAssets,
 		labels:      flows.NewLabelAssets(labels),
 		locations:   flows.NewLocationAssets(locations),
 		resthooks:   flows.NewResthookAssets(resthooks),

--- a/flows/engine/assets_test.go
+++ b/flows/engine/assets_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
+	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows/engine"
 
 	"github.com/pkg/errors"
@@ -37,10 +38,12 @@ var assetsJSON = `{
 }`
 
 func TestSessionAssets(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, source, sa.Source())
@@ -65,9 +68,11 @@ func TestSessionAssets(t *testing.T) {
 }
 
 func TestSessionAssetsWithSourceErrors(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	source := &testSource{}
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
 
 	source.currentErrType = "flow"
@@ -76,7 +81,7 @@ func TestSessionAssetsWithSourceErrors(t *testing.T) {
 
 	for _, errType := range []string{"channels", "classifiers", "fields", "globals", "groups", "labels", "locations", "resthooks", "templates"} {
 		source.currentErrType = errType
-		_, err = engine.NewSessionAssets(source, nil)
+		_, err = engine.NewSessionAssets(env, source, nil)
 		assert.EqualError(t, err, fmt.Sprintf("unable to load %s assets", errType), "error mismatch for type %s", errType)
 	}
 }

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -129,7 +129,7 @@ func TestReadWithMissingAssets(t *testing.T) {
 	require.NoError(t, err)
 
 	// try to read it back but with no assets
-	sessionAssets, err := engine.NewSessionAssets(static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(session.Environment(), static.NewEmptySource(), nil)
 
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }

--- a/flows/field.go
+++ b/flows/field.go
@@ -365,3 +365,15 @@ func (s *FieldAssets) FirstOfType(valueType assets.FieldType) *Field {
 	}
 	return nil
 }
+
+func (s *FieldAssets) ResolveField(key string) assets.Field {
+	f := s.byKey[key]
+	if f != nil {
+		return f
+	}
+	return nil
+}
+
+func (s *FieldAssets) ResolveGroup(name string) assets.Group {
+	return nil
+}

--- a/flows/group.go
+++ b/flows/group.go
@@ -14,42 +14,36 @@ import (
 type Group struct {
 	assets.Group
 
-	cachedQuery *contactql.ContactQuery
+	parsedQuery *contactql.ContactQuery
 }
 
 // NewGroup returns a new group object from the given group asset
-func NewGroup(asset assets.Group) *Group {
-	return &Group{Group: asset}
+func NewGroup(env envs.Environment, fields *FieldAssets, asset assets.Group) (*Group, error) {
+	if asset.Query() != "" {
+		query, err := contactql.ParseQuery(asset.Query(), env.RedactionPolicy(), env.DefaultCountry(), fields)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Group{Group: asset, parsedQuery: query}, nil
+	}
+
+	return &Group{Group: asset}, nil
 }
 
 // Asset returns the underlying asset
 func (g *Group) Asset() assets.Group { return g.Group }
 
-// the parsed query of a dynamic group (cached)
-func (g *Group) parsedQuery(env envs.Environment, sa SessionAssets) (*contactql.ContactQuery, error) {
-	if g.Query() != "" && g.cachedQuery == nil {
-		var err error
-		if g.cachedQuery, err = contactql.ParseQuery(g.Query(), env.RedactionPolicy(), env.DefaultCountry(), sa); err != nil {
-			return nil, err
-		}
-	}
-	return g.cachedQuery, nil
-}
-
 // IsDynamic returns whether this group is dynamic
 func (g *Group) IsDynamic() bool { return g.Query() != "" }
 
 // CheckDynamicMembership returns whether the given contact belongs in this dynamic group
-func (g *Group) CheckDynamicMembership(env envs.Environment, contact *Contact, sa SessionAssets) (bool, error) {
+func (g *Group) CheckDynamicMembership(env envs.Environment, contact *Contact) (bool, error) {
 	if !g.IsDynamic() {
 		panic("can't check membership on a non-dynamic group")
 	}
-	parsedQuery, err := g.parsedQuery(env, sa)
-	if err != nil {
-		return false, err
-	}
 
-	return contactql.EvaluateQuery(env, parsedQuery, contact)
+	return contactql.EvaluateQuery(env, g.parsedQuery, contact)
 }
 
 // Reference returns a reference to this group
@@ -156,17 +150,22 @@ type GroupAssets struct {
 }
 
 // NewGroupAssets creates a new set of group assets
-func NewGroupAssets(groups []assets.Group) *GroupAssets {
+func NewGroupAssets(env envs.Environment, fields *FieldAssets, groups []assets.Group) (*GroupAssets, []assets.Group) {
+	broken := make([]assets.Group, 0)
 	s := &GroupAssets{
-		all:    make([]*Group, len(groups)),
+		all:    make([]*Group, 0, len(groups)),
 		byUUID: make(map[assets.GroupUUID]*Group, len(groups)),
 	}
-	for i, asset := range groups {
-		group := NewGroup(asset)
-		s.all[i] = group
-		s.byUUID[group.UUID()] = group
+	for _, asset := range groups {
+		group, err := NewGroup(env, fields, asset)
+		if err != nil {
+			broken = append(broken, asset)
+		} else {
+			s.all = append(s.all, group)
+			s.byUUID[group.UUID()] = group
+		}
 	}
-	return s
+	return s, broken
 }
 
 // All returns all the groups

--- a/flows/group_test.go
+++ b/flows/group_test.go
@@ -16,7 +16,16 @@ import (
 )
 
 func TestGroupList(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	source, err := static.NewSource([]byte(`{
+		"fields": [
+			{
+				"key": "gender",
+				"name": "Gender",
+				"type": "text"
+			}
+		],
 		"groups": [
 			{
 				"uuid": "e25852ea-b014-4ac1-9982-d6dcb0c2a1d5",
@@ -30,13 +39,21 @@ func TestGroupList(t *testing.T) {
 				"uuid": "f4f4b78e-f072-42e2-987d-f5c13da3166d",
 				"name": "Males",
 				"query": "gender = \"M\""
+			},
+			{
+				"uuid": "f4f4b78e-f072-42e2-987d-f5c13da3166d",
+				"name": "Broken",
+				"query": "xyz = \"X\""
 			}
 		]
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
+
+	// check we ignored broken group
+	assert.Equal(t, 3, len(sa.Groups().All()))
 
 	testers := sa.Groups().Get("990e1392-1f49-40c5-9662-f39609324bf9")
 	males := sa.Groups().Get("f4f4b78e-f072-42e2-987d-f5c13da3166d")
@@ -65,8 +82,6 @@ func TestGroupList(t *testing.T) {
 
 	assert.Equal(t, males, groups.FindByUUID("f4f4b78e-f072-42e2-987d-f5c13da3166d"))
 	assert.Nil(t, groups.FindByUUID("7cb12d0e-e163-492c-95b1-28549cd04fe4"))
-
-	env := envs.NewBuilder().Build()
 
 	// check use in expressions
 	test.AssertXEqual(t, types.NewXArray(testers.ToXValue(env), males.ToXValue(env)), groups.ToXValue(env))

--- a/flows/inputs/base_test.go
+++ b/flows/inputs/base_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
+	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/flows/inputs"
 
@@ -13,10 +14,12 @@ import (
 )
 
 func TestReadInput(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
 	require.NoError(t, err)
 
 	// error if no type field

--- a/flows/inspect/dependencies_test.go
+++ b/flows/inspect/dependencies_test.go
@@ -27,6 +27,8 @@ func (t *unknownAssetType) Identity() string { return "unknown[]" }
 func (t *unknownAssetType) Variable() bool   { return false }
 
 func TestDependencies(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	action1 := actions.NewSendMsg("ed08e6b9-ed22-4294-9871-c7ac7d82cbd5", "Hi there", nil, nil, false)
 	node1 := definition.NewNode("91b20e13-d6e2-42a9-b74f-bce85c9da8c8", []flows.Action{action1}, nil, nil)
 	router2 := routers.NewRandom(nil, "", nil)
@@ -57,7 +59,7 @@ func TestDependencies(t *testing.T) {
 		}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
 
 	deps := inspect.NewDependencies(refs, sa)

--- a/flows/inspect/issues/base_test.go
+++ b/flows/inspect/issues/base_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestIssueTypes(t *testing.T) {
-	assets, err := test.LoadSessionAssets("testdata/_assets.json")
+	env := envs.NewBuilder().Build()
+
+	assets, err := test.LoadSessionAssets(env, "testdata/_assets.json")
 	require.NoError(t, err)
 
 	for typeName := range issues.RegisteredTypes {
@@ -78,7 +80,9 @@ func testIssueType(t *testing.T, sa flows.SessionAssets, typeName string) {
 }
 
 func TestIssues(t *testing.T) {
-	sa, err := test.LoadSessionAssets("testdata/_assets.json")
+	env := envs.NewBuilder().Build()
+
+	sa, err := test.LoadSessionAssets(env, "testdata/_assets.json")
 	require.NoError(t, err)
 
 	flow, err := definition.ReadFlow([]byte(`{

--- a/flows/resumes/base_test.go
+++ b/flows/resumes/base_test.go
@@ -111,10 +111,12 @@ func testResumeType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 }
 
 func TestReadResume(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
 	require.NoError(t, err)
 
 	// error if no type field

--- a/flows/runs/summary_test.go
+++ b/flows/runs/summary_test.go
@@ -53,7 +53,7 @@ func TestRunSummary(t *testing.T) {
 	assert.Equal(t, "Ryan Lewis@Registration", runs.FormatRunSummary(session.Environment(), summary))
 
 	// try reading with missing assets
-	emptyAssets, err := engine.NewSessionAssets(static.NewEmptySource(), nil)
+	emptyAssets, err := engine.NewSessionAssets(session.Environment(), static.NewEmptySource(), nil)
 
 	summary, err = runs.ReadRunSummary(emptyAssets, marshaled, assets.IgnoreMissing)
 	require.NoError(t, err)

--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -140,13 +140,14 @@ func TestTriggerMarshaling(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(1234))
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
 
+	env := envs.NewBuilder().Build()
+
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
 
-	env := envs.NewBuilder().Build()
 	flow := assets.NewFlowReference(assets.FlowUUID("7c37d7e5-6468-4b31-8109-ced2ef8b5ddc"), "Registration")
 	channel := assets.NewChannelReference("3a05eaf5-cb1b-4246-bef1-f277419c83a7", "Nexmo")
 
@@ -492,10 +493,12 @@ func TestTriggerMarshaling(t *testing.T) {
 }
 
 func TestReadTrigger(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
 	require.NoError(t, err)
 
 	// error if no type field
@@ -508,14 +511,15 @@ func TestReadTrigger(t *testing.T) {
 }
 
 func TestTriggerSessionInitialization(t *testing.T) {
+	env := envs.NewBuilder().WithDateFormat(envs.DateFormatMonthDayYear).Build()
+
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
 
 	defaultEnv := envs.NewBuilder().Build()
-	env := envs.NewBuilder().WithDateFormat(envs.DateFormatMonthDayYear).Build()
 
 	flow := assets.NewFlowReference(assets.FlowUUID("7c37d7e5-6468-4b31-8109-ced2ef8b5ddc"), "Registration")
 

--- a/flows/urn_test.go
+++ b/flows/urn_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestContactURN(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
 	source, err := static.NewSource([]byte(`{
         "channels": [
             {
@@ -36,7 +38,7 @@ func TestContactURN(t *testing.T) {
     }`))
 	require.NoError(t, err)
 
-	sessionAssets, err := engine.NewSessionAssets(source, nil)
+	sessionAssets, err := engine.NewSessionAssets(env, source, nil)
 	require.NoError(t, err)
 
 	channels := sessionAssets.Channels()
@@ -56,7 +58,6 @@ func TestContactURN(t *testing.T) {
 	assert.False(t, urn.Equal(urn3))
 
 	// check using URN in expressions
-	env := envs.NewBuilder().Build()
 	assert.Equal(t, types.NewXText("tel:+250781234567"), urn.ToXValue(env))
 
 	// check when URNs have to be redacted

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -91,8 +91,8 @@ type SessionAssets struct {
 }
 
 // NewSessionAssets creates a new session assets
-func NewSessionAssets(source *AssetsSource) (*SessionAssets, error) {
-	s, err := engine.NewSessionAssets(source.target, &migrations.Config{BaseMediaURL: ""})
+func NewSessionAssets(environment *Environment, source *AssetsSource) (*SessionAssets, error) {
+	s, err := engine.NewSessionAssets(environment.target, source.target, &migrations.Config{BaseMediaURL: ""})
 	if err != nil {
 		return nil, err
 	}

--- a/mobile/bindings_test.go
+++ b/mobile/bindings_test.go
@@ -35,14 +35,14 @@ func TestMobileBindings(t *testing.T) {
 	source, err := mobile.NewAssetsSource(string(assetsJSON))
 	require.NoError(t, err)
 
-	// and create a new session assets
-	sa, err := mobile.NewSessionAssets(source)
-	require.NoError(t, err)
-
 	langs := mobile.NewStringSlice(2)
 	langs.Add("eng")
 	langs.Add("fra")
 	environment, err := mobile.NewEnvironment("DD-MM-YYYY", "tt:mm", "Africa/Kigali", "eng", langs, "RW", "none")
+	require.NoError(t, err)
+
+	// and create a new session assets
+	sa, err := mobile.NewSessionAssets(environment, source)
 	require.NoError(t, err)
 
 	contact := mobile.NewEmptyContact(sa)

--- a/test/assets.go
+++ b/test/assets.go
@@ -8,12 +8,13 @@ import (
 	"github.com/nyaruka/goflow/assets/static/types"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/definition/migrations"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/utils/uuids"
 )
 
 // LoadSessionAssets loads a session assets instance from a static JSON file
-func LoadSessionAssets(path string) (flows.SessionAssets, error) {
+func LoadSessionAssets(env envs.Environment, path string) (flows.SessionAssets, error) {
 	assetsJSON, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -24,11 +25,13 @@ func LoadSessionAssets(path string) (flows.SessionAssets, error) {
 		return nil, err
 	}
 
-	return engine.NewSessionAssets(source, nil)
+	mconfig := &migrations.Config{BaseMediaURL: "http://temba.io/"}
+
+	return engine.NewSessionAssets(env, source, mconfig)
 }
 
-func LoadFlowFromAssets(path string, uuid assets.FlowUUID) (flows.Flow, error) {
-	sa, err := LoadSessionAssets(path)
+func LoadFlowFromAssets(env envs.Environment, path string, uuid assets.FlowUUID) (flows.Flow, error) {
+	sa, err := LoadSessionAssets(env, path)
 	if err != nil {
 		return nil, err
 	}

--- a/test/runner_test.go
+++ b/test/runner_test.go
@@ -12,9 +12,8 @@ import (
 	"time"
 
 	"github.com/nyaruka/goflow/assets"
-	"github.com/nyaruka/goflow/assets/static"
+	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
-	"github.com/nyaruka/goflow/flows/definition/migrations"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/flows/resumes"
 	"github.com/nyaruka/goflow/flows/triggers"
@@ -106,27 +105,9 @@ type runResult struct {
 	outputs []*Output
 }
 
-func loadAssets(path string) (flows.SessionAssets, error) {
-	// load the test specific assets
-	assetsJSON, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	// create the assets source
-	source, err := static.NewSource(assetsJSON)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading test assets '%s'", path)
-	}
-
-	mconfig := &migrations.Config{BaseMediaURL: "http://temba.io/"}
-
-	return engine.NewSessionAssets(source, mconfig)
-}
-
 func runFlow(assetsPath string, rawTrigger json.RawMessage, rawResumes []json.RawMessage) (runResult, error) {
 	// load the test specific assets
-	sa, err := loadAssets(assetsPath)
+	sa, err := LoadSessionAssets(envs.NewBuilder().Build(), assetsPath)
 	if err != nil {
 		return runResult{}, err
 	}

--- a/test/session.go
+++ b/test/session.go
@@ -519,6 +519,8 @@ func CreateTestVoiceSession(testServerURL string) (flows.Session, []flows.Event,
 
 // CreateSessionAssets creates assets from given JSON
 func CreateSessionAssets(assetsJSON json.RawMessage, testServerURL string) (flows.SessionAssets, error) {
+	env := envs.NewBuilder().Build()
+
 	// different tests different ports for the test HTTP server
 	if testServerURL != "" {
 		assetsJSON = json.RawMessage(strings.Replace(string(assetsJSON), "http://localhost", testServerURL, -1))
@@ -531,7 +533,7 @@ func CreateSessionAssets(assetsJSON json.RawMessage, testServerURL string) (flow
 	}
 
 	// create our engine session
-	sa, err := engine.NewSessionAssets(source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating test session assets")
 	}


### PR DESCRIPTION
Pre-requisite for #880. Currently we lazy parse and cache contact queries, but parsing a contact query requires an environment, so we end up using the run-environment of the first contact this gets called for... which might be a different country to subsequent contacts which also use the same session assets.

This PR reworks things so when we're loading assets, we parse group queries, and determine which groups are "broken".