### PR TITLE
🗜️ Merge PO entries with the majority translation

### DIFF
--- a/i18n/po_test.go
+++ b/i18n/po_test.go
@@ -110,9 +110,9 @@ func TestReadPO(t *testing.T) {
 	assert.Equal(t, "Blue", po.Entries[0].MsgID)
 	assert.Equal(t, "Azul", po.Entries[0].MsgStr)
 
-	assert.Equal(t, "e42deebf-90fa-4636-81cb-d247a3d3ba75/quick_replies:0", po.Entries[2].MsgContext)
+	assert.Equal(t, "d1ce3c92-7025-4607-a910-444361a6b9b3/name:0", po.Entries[2].MsgContext)
 	assert.Equal(t, "Red", po.Entries[2].MsgID)
-	assert.Equal(t, "Rojo", po.Entries[2].MsgStr)
+	assert.Equal(t, "Roja", po.Entries[2].MsgStr)
 
 	// try handling an i/o error
 	badReader := iotest.TimeoutReader(strings.NewReader(`# Generated`))

--- a/i18n/testdata/translation_mismatches.noargs.es.po
+++ b/i18n/testdata/translation_mismatches.noargs.es.po
@@ -17,15 +17,14 @@ msgstr "Azul"
 msgid "Other"
 msgstr "Otro"
 
-#: Translated/e42deebf-90fa-4636-81cb-d247a3d3ba75/quick_replies:0
-msgctxt "e42deebf-90fa-4636-81cb-d247a3d3ba75/quick_replies:0"
-msgid "Red"
-msgstr "Rojo"
-
 #: Translated/d1ce3c92-7025-4607-a910-444361a6b9b3/name:0
 msgctxt "d1ce3c92-7025-4607-a910-444361a6b9b3/name:0"
 msgid "Red"
 msgstr "Roja"
+
+#: Translated/e42deebf-90fa-4636-81cb-d247a3d3ba75/quick_replies:0
+msgid "Red"
+msgstr "Rojo"
 
 #: Translated/e42deebf-90fa-4636-81cb-d247a3d3ba75/text:0
 msgid "Which pill?"


### PR DESCRIPTION
When translations differ, still merge the extractions with the majority translation. For example in the covid bot flow there are two places _MENU_ is translated to _Menu_, one where it's translated to _Other_. _Menu_ wins and we create a context-less entry for that, and a context-specific one for _Other_. I.e. this..

<img width="699" alt="Captura de Pantalla 2020-03-26 a la(s) 17 42 35" src="https://user-images.githubusercontent.com/675558/77703639-4fe79080-6f89-11ea-85c0-6c62b7a2c652.png">

becomes..

<img width="710" alt="Captura de Pantalla 2020-03-26 a la(s) 17 43 17" src="https://user-images.githubusercontent.com/675558/77703643-51b15400-6f89-11ea-94bc-d24e958f9401.png">
