### PR TITLE
🦃 Fix default to understand objects with defaults

### DIFF
--- a/docs/expressions.html
+++ b/docs/expressions.html
@@ -320,10 +320,9 @@
 <div class="sourceCode" id="cb38"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><span id="cb38-1"><a href="#cb38-1"></a>@(<span class="kw">default</span>(undeclared.var, <span class="st">&quot;default_value&quot;</span>)) → default_value</span>
 <span id="cb38-2"><a href="#cb38-2"></a>@(<span class="kw">default</span>(<span class="st">&quot;10&quot;</span>, <span class="st">&quot;20&quot;</span>)) → <span class="dv">10</span></span>
 <span id="cb38-3"><a href="#cb38-3"></a>@(<span class="kw">default</span>(<span class="st">&quot;&quot;</span>, <span class="st">&quot;value&quot;</span>)) → value</span>
-<span id="cb38-4"><a href="#cb38-4"></a>@(<span class="kw">default</span>(array(<span class="dv">1</span>, <span class="dv">2</span>), <span class="st">&quot;value&quot;</span>)) → [<span class="dv">1</span>, <span class="dv">2</span>]</span>
-<span id="cb38-5"><a href="#cb38-5"></a>@(<span class="kw">default</span>(array(), <span class="st">&quot;value&quot;</span>)) → value</span>
-<span id="cb38-6"><a href="#cb38-6"></a>@(<span class="kw">default</span>(datetime(<span class="st">&quot;invalid-date&quot;</span>), <span class="st">&quot;today&quot;</span>)) → today</span>
-<span id="cb38-7"><a href="#cb38-7"></a>@(<span class="kw">default</span>(format_urn(<span class="st">&quot;invalid-urn&quot;</span>), <span class="st">&quot;ok&quot;</span>)) → ok</span></code></pre></div>
+<span id="cb38-4"><a href="#cb38-4"></a>@(<span class="kw">default</span>(<span class="st">&quot;  &quot;</span>, <span class="st">&quot;value&quot;</span>)) → \x20\x20</span>
+<span id="cb38-5"><a href="#cb38-5"></a>@(<span class="kw">default</span>(datetime(<span class="st">&quot;invalid-date&quot;</span>), <span class="st">&quot;today&quot;</span>)) → today</span>
+<span id="cb38-6"><a href="#cb38-6"></a>@(<span class="kw">default</span>(format_urn(<span class="st">&quot;invalid-urn&quot;</span>), <span class="st">&quot;ok&quot;</span>)) → ok</span></code></pre></div>
 <h2 class="item_title">
 <a name="function:epoch" href="#function:epoch">epoch(date)</a>
 </h2>

--- a/docs/functions.json
+++ b/docs/functions.json
@@ -314,12 +314,8 @@
                 "output": "value"
             },
             {
-                "template": "@(default(array(1, 2), \"value\"))",
-                "output": "[1, 2]"
-            },
-            {
-                "template": "@(default(array(), \"value\"))",
-                "output": "value"
+                "template": "@(default(\"  \", \"value\"))",
+                "output": "\\x20\\x20"
             },
             {
                 "template": "@(default(datetime(\"invalid-date\"), \"today\"))",

--- a/docs/md/expressions.md
+++ b/docs/md/expressions.md
@@ -485,8 +485,7 @@ Returns `value` if is not empty or an error, otherwise it returns `default`.
 @(default(undeclared.var, "default_value")) → default_value
 @(default("10", "20")) → 10
 @(default("", "value")) → value
-@(default(array(1, 2), "value")) → [1, 2]
-@(default(array(), "value")) → value
+@(default("  ", "value")) → \x20\x20
 @(default(datetime("invalid-date"), "today")) → today
 @(default(format_urn("invalid-urn"), "ok")) → ok
 ```

--- a/docs/md/routing.md
+++ b/docs/md/routing.md
@@ -508,24 +508,6 @@ Tests whether the top intent in a classification result has `name` and minimum `
 @(has_top_intent(results.intent, "book_hotel", 0.5)) → false
 ```
 
-<h2 class="item_title"><a name="test:has_value" href="#test:has_value">has_value(value)</a></h2>
-
-Returns whether `value` is non-nil and not an error
-
-Note that `contact.fields` and `run.results` are considered dynamic, so it is not an error
-to try to retrieve a value from fields or results which don't exist, rather these return an empty
-value.
-
-
-```objectivec
-@(has_value("hello")) → true
-@(has_value("hello").match) → hello
-@(has_value(datetime("foo"))) → false
-@(has_value(not.existing)) → false
-@(has_value(contact.fields.unset)) → false
-@(has_value("")) → false
-```
-
 <h2 class="item_title"><a name="test:has_ward" href="#test:has_ward">has_ward(text, district, state)</a></h2>
 
 Tests whether a ward name is contained in the `text`

--- a/docs/routing.html
+++ b/docs/routing.html
@@ -366,27 +366,16 @@
 <div class="sourceCode" id="cb32"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><span id="cb32-1"><a href="#cb32-1"></a>@(has_top_intent(results.intent, <span class="st">&quot;book_flight&quot;</span>, <span class="fl">0.5</span>)) → true</span>
 <span id="cb32-2"><a href="#cb32-2"></a>@(has_top_intent(results.intent, <span class="st">&quot;book_hotel&quot;</span>, <span class="fl">0.5</span>)) → false</span></code></pre></div>
 <h2 class="item_title">
-<a name="test:has_value" href="#test:has_value">has_value(value)</a>
-</h2>
-<p>Returns whether <code>value</code> is non-nil and not an error</p>
-<p>Note that <code>contact.fields</code> and <code>run.results</code> are considered dynamic, so it is not an error to try to retrieve a value from fields or results which don’t exist, rather these return an empty value.</p>
-<div class="sourceCode" id="cb33"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><span id="cb33-1"><a href="#cb33-1"></a>@(has_value(<span class="st">&quot;hello&quot;</span>)) → true</span>
-<span id="cb33-2"><a href="#cb33-2"></a>@(has_value(<span class="st">&quot;hello&quot;</span>).match) → hello</span>
-<span id="cb33-3"><a href="#cb33-3"></a>@(has_value(datetime(<span class="st">&quot;foo&quot;</span>))) → false</span>
-<span id="cb33-4"><a href="#cb33-4"></a>@(has_value(not.existing)) → false</span>
-<span id="cb33-5"><a href="#cb33-5"></a>@(has_value(contact.fields.unset)) → false</span>
-<span id="cb33-6"><a href="#cb33-6"></a>@(has_value(<span class="st">&quot;&quot;</span>)) → false</span></code></pre></div>
-<h2 class="item_title">
 <a name="test:has_ward" href="#test:has_ward">has_ward(text, district, state)</a>
 </h2>
 <p>Tests whether a ward name is contained in the <code>text</code></p>
-<div class="sourceCode" id="cb34"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><span id="cb34-1"><a href="#cb34-1"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</span>
-<span id="cb34-2"><a href="#cb34-2"></a>@(has_ward(<span class="st">&quot;I live in Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</span>
-<span id="cb34-3"><a href="#cb34-3"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>)) → false</span>
-<span id="cb34-4"><a href="#cb34-4"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</span>
-<span id="cb34-5"><a href="#cb34-5"></a>@(has_ward(<span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</span>
-<span id="cb34-6"><a href="#cb34-6"></a>@(has_ward(<span class="st">&quot;Gasabo&quot;</span>)) → false</span>
-<span id="cb34-7"><a href="#cb34-7"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</span></code></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode objectivec"><code class="sourceCode objectivec"><span id="cb33-1"><a href="#cb33-1"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</span>
+<span id="cb33-2"><a href="#cb33-2"></a>@(has_ward(<span class="st">&quot;I live in Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</span>
+<span id="cb33-3"><a href="#cb33-3"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>)) → false</span>
+<span id="cb33-4"><a href="#cb33-4"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>, <span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</span>
+<span id="cb33-5"><a href="#cb33-5"></a>@(has_ward(<span class="st">&quot;Brooklyn&quot;</span>, <span class="st">&quot;Gasabo&quot;</span>, <span class="st">&quot;Kigali&quot;</span>)) → false</span>
+<span id="cb33-6"><a href="#cb33-6"></a>@(has_ward(<span class="st">&quot;Gasabo&quot;</span>)) → false</span>
+<span id="cb33-7"><a href="#cb33-7"></a>@(has_ward(<span class="st">&quot;Gisozi&quot;</span>).match) → Rwanda &gt; Kigali City &gt; Gasabo &gt; Gisozi</span></code></pre></div>
 </div>
 
     </body>

--- a/excellent/evaluator_test.go
+++ b/excellent/evaluator_test.go
@@ -204,6 +204,14 @@ func TestEvaluateTemplate(t *testing.T) {
 		}),
 		"func": functions.Lookup("upper"),
 		"err":  types.NewXError(errors.Errorf("an error")),
+		"object1": types.NewXObject(map[string]types.XValue{
+			"__default__": types.NewXText("123"),
+			"foo":         types.NewXNumberFromInt(123),
+		}),
+		"object2": types.NewXObject(map[string]types.XValue{
+			"__default__": types.XTextEmpty,
+			"foo":         types.NewXNumberFromInt(234),
+		}),
 	})
 
 	evaluateAsStringTests := []struct {
@@ -290,6 +298,10 @@ func TestEvaluateTemplate(t *testing.T) {
 		{`@(thing.missing)`, "", false},    // missing is nil which becomes empty string
 		{`@(thing.missing.xxx)`, "", true}, // but can't look up a property on nil
 		{`@(thing.xxx)`, "", true},
+
+		// objects with defaults
+		{`@object1`, "123", false},
+		{`@object2`, "", false},
 	}
 
 	env := envs.NewBuilder().Build()

--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -1924,14 +1924,18 @@ func Count(env envs.Environment, value types.XValue) types.XValue {
 //   @(default(undeclared.var, "default_value")) -> default_value
 //   @(default("10", "20")) -> 10
 //   @(default("", "value")) -> value
-//   @(default(array(1, 2), "value")) -> [1, 2]
-//   @(default(array(), "value")) -> value
+//   @(default("  ", "value")) -> \x20\x20
 //   @(default(datetime("invalid-date"), "today")) -> today
 //   @(default(format_urn("invalid-urn"), "ok")) -> ok
 //
 // @function default(value, default)
 func Default(env envs.Environment, value types.XValue, def types.XValue) types.XValue {
-	if types.IsEmpty(value) || types.IsXError(value) {
+	asText, xerr := types.ToXText(env, value)
+	if xerr != nil {
+		return def
+	}
+
+	if len(asText.Native()) == 0 {
 		return def
 	}
 

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -196,6 +196,8 @@ func TestFunctions(t *testing.T) {
 
 		{"default", dmy, []types.XValue{xs("10"), xs("20")}, xs("10")},
 		{"default", dmy, []types.XValue{nil, xs("20")}, xs("20")},
+		{"default", dmy, []types.XValue{types.NewXObject(map[string]types.XValue{"__default__": xs("hello")}), xs("def")}, types.NewXObject(map[string]types.XValue{"__default__": xs("hello")})},
+		{"default", dmy, []types.XValue{types.NewXObject(map[string]types.XValue{"__default__": xs("")}), xs("def")}, xs("def")},
 		{"default", dmy, []types.XValue{types.NewXErrorf("This is error"), xs("20")}, xs("20")},
 		{"default", dmy, []types.XValue{}, ERROR},
 

--- a/excellent/types/base.go
+++ b/excellent/types/base.go
@@ -77,28 +77,6 @@ func Equals(x1 XValue, x2 XValue) bool {
 	}
 }
 
-// IsEmpty determines if the given value is empty
-func IsEmpty(x XValue) bool {
-	// nil is empty
-	if utils.IsNil(x) {
-		return true
-	}
-
-	// empty string is empty
-	text, isText := x.(XText)
-	if isText && text.Length() == 0 {
-		return true
-	}
-
-	// anything with count of zero is empty
-	countable, isCountable := x.(XCountable)
-	if isCountable && countable != nil && countable.Count() == 0 {
-		return true
-	}
-
-	return false
-}
-
 // Describe returns a representation of the given value for use in error messages
 func Describe(x XValue) string {
 	if utils.IsNil(x) {

--- a/excellent/types/base_test.go
+++ b/excellent/types/base_test.go
@@ -37,7 +37,6 @@ func TestXValue(t *testing.T) {
 		rendered  string
 		formatted string
 		asBool    bool
-		isEmpty   bool
 	}{
 		{
 			value:     nil,
@@ -45,140 +44,120 @@ func TestXValue(t *testing.T) {
 			rendered:  "",
 			formatted: "",
 			asBool:    false,
-			isEmpty:   true,
 		}, {
 			value:     types.NewXText(""),
 			marshaled: `""`,
 			rendered:  "",
 			formatted: "",
 			asBool:    false, // empty strings are false
-			isEmpty:   true,
 		}, {
 			value:     types.NewXText("FALSE"),
 			marshaled: `"FALSE"`,
 			rendered:  "FALSE",
 			formatted: "FALSE",
 			asBool:    false, // because it's string value is "false"
-			isEmpty:   false,
 		}, {
 			value:     types.NewXText("hello \"bob\""),
 			marshaled: `"hello \"bob\""`,
 			rendered:  "hello \"bob\"",
 			formatted: "hello \"bob\"",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXNumberFromInt(0),
 			marshaled: `0`,
 			rendered:  "0",
 			formatted: "0",
 			asBool:    false, // because any decimal != 0 is true
-			isEmpty:   false,
 		}, {
 			value:     types.NewXNumberFromInt(1234),
 			marshaled: `1234`,
 			rendered:  "1234",
 			formatted: "1,234",
 			asBool:    true, // because any decimal != 0 is true
-			isEmpty:   false,
 		}, {
 			value:     types.RequireXNumberFromString("123.00"),
 			marshaled: `123`,
 			rendered:  "123",
 			formatted: "123",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.RequireXNumberFromString("1234.5678"),
 			marshaled: `1234.5678`,
 			rendered:  "1234.5678",
 			formatted: "1,234.5678",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXBoolean(false),
 			marshaled: `false`,
 			rendered:  "false",
 			formatted: "false",
 			asBool:    false,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXBoolean(true),
 			marshaled: `true`,
 			rendered:  "true",
 			formatted: "true",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXDateTime(date1),
 			marshaled: `"2017-06-23T15:30:00.000000Z"`,
 			rendered:  "2017-06-23T15:30:00.000000Z",
 			formatted: "23-06-2017 15:30",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXDateTime(date2),
 			marshaled: `"2017-07-18T15:30:00.000000-05:00"`,
 			rendered:  "2017-07-18T15:30:00.000000-05:00",
 			formatted: "18-07-2017 20:30",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXArray(),
 			marshaled: `[]`,
 			rendered:  `[]`,
 			formatted: "",
 			asBool:    false,
-			isEmpty:   true,
 		}, {
 			value:     types.NewXArray(types.NewXNumberFromInt(1), types.NewXNumberFromInt(2)),
 			marshaled: `[1,2]`,
 			rendered:  `[1, 2]`,
 			formatted: "1, 2",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXArray(types.NewXDateTime(date1), types.NewXDateTime(date2)),
 			marshaled: `["2017-06-23T15:30:00.000000Z","2017-07-18T15:30:00.000000-05:00"]`,
 			rendered:  `[2017-06-23T15:30:00.000000Z, 2017-07-18T15:30:00.000000-05:00]`,
 			formatted: "23-06-2017 15:30, 18-07-2017 20:30",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXArray(object1, object2),
 			marshaled: `[{"bar":123,"foo":"Hello"},{"bar":456,"foo":"World"}]`,
 			rendered:  `[{bar: 123, foo: Hello}, {bar: 456, foo: World}]`,
 			formatted: "- bar: 123\n  foo: Hello\n- bar: 456\n  foo: World",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.XObjectEmpty,
 			marshaled: `{}`,
 			rendered:  `{}`,
 			formatted: "",
 			asBool:    false,
-			isEmpty:   true,
 		}, {
 			value:     types.NewXObject(map[string]types.XValue{"first": object1, "second": object2}),
 			marshaled: `{"first":{"bar":123,"foo":"Hello"},"second":{"bar":456,"foo":"World"}}`,
 			rendered:  `{first: {bar: 123, foo: Hello}, second: {bar: 456, foo: World}}`,
 			formatted: "first:\n  bar: 123\n  foo: Hello\nsecond:\n  bar: 456\n  foo: World",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXObject(map[string]types.XValue{"__default__": types.NewXNumberFromInt(1), "foo": object1}),
 			marshaled: `{"foo":{"bar":123,"foo":"Hello"}}`,
 			rendered:  `1`,
 			formatted: "1",
 			asBool:    true,
-			isEmpty:   false,
 		}, {
 			value:     types.NewXError(errors.Errorf("it failed")), // once an error, always an error
 			marshaled: `null`,
 			rendered:  "",
 			formatted: "",
 			asBool:    false,
-			isEmpty:   false,
 		},
 	}
 	for _, test := range tests {
@@ -275,16 +254,4 @@ func TestEquals(t *testing.T) {
 
 type XBogusType struct {
 	types.XText
-}
-
-func TestIsEmpty(t *testing.T) {
-	assert.True(t, types.IsEmpty(nil))
-	assert.True(t, types.IsEmpty(types.NewXArray()))
-	assert.True(t, types.IsEmpty(types.XObjectEmpty))
-	assert.True(t, types.IsEmpty(types.NewXText("")))
-	assert.False(t, types.IsEmpty(types.NewXText("a")))
-	assert.False(t, types.IsEmpty(types.XBooleanFalse))
-	assert.False(t, types.IsEmpty(types.XBooleanTrue))
-	assert.False(t, types.IsEmpty(types.NewXNumberFromInt(0)))
-	assert.False(t, types.IsEmpty(types.NewXNumberFromInt(123)))
 }

--- a/flows/results_test.go
+++ b/flows/results_test.go
@@ -15,15 +15,21 @@ import (
 func TestResults(t *testing.T) {
 	env := envs.NewBuilder().Build()
 
-	result := flows.NewResult("Beer", "skol!", "Skol", "", flows.NodeUUID("26493ebb-a254-4461-a28d-c7761784e276"), "", nil, time.Date(2019, 4, 5, 14, 16, 30, 123456, time.UTC))
-	results := flows.NewResults()
-	results.Save(result)
+	result1 := flows.NewResult("Beer", "skol!", "Skol", "", flows.NodeUUID("26493ebb-a254-4461-a28d-c7761784e276"), "", nil, time.Date(2019, 4, 5, 14, 16, 30, 123456, time.UTC))
+	result2 := flows.NewResult("Empty", "", "", "", flows.NodeUUID("26493ebb-a254-4461-a28d-c7761784e276"), "", nil, time.Date(2019, 4, 5, 14, 16, 30, 123456, time.UTC))
 
-	assert.Equal(t, result, results.Get("beer"))
+	results := flows.NewResults()
+	results.Save(result1)
+	results.Save(result2)
+
+	assert.Equal(t, result1, results.Get("beer"))
+	assert.Equal(t, result2, results.Get("empty"))
 	assert.Nil(t, results.Get("xxx"))
 
+	resultsAsContext := flows.Context(env, results)
+
 	test.AssertXEqual(t, types.NewXObject(map[string]types.XValue{
-		"__default__": types.NewXText("Beer: skol!"),
+		"__default__": types.NewXText("Beer: skol!\nEmpty: "),
 		"beer": types.NewXObject(map[string]types.XValue{
 			"__default__":          types.NewXText("skol!"),
 			"category":             types.NewXText("Skol"),
@@ -38,5 +44,19 @@ func TestResults(t *testing.T) {
 			"value":                types.NewXText("skol!"),
 			"values":               types.NewXArray(types.NewXText("skol!")),
 		}),
-	}), flows.Context(env, results))
+		"empty": types.NewXObject(map[string]types.XValue{
+			"__default__":          types.NewXText(""),
+			"category":             types.NewXText(""),
+			"categories":           types.NewXArray(types.NewXText("")),
+			"category_localized":   types.NewXText(""),
+			"categories_localized": types.NewXArray(types.NewXText("")),
+			"created_on":           types.NewXDateTime(time.Date(2019, 4, 5, 14, 16, 30, 123456, time.UTC)),
+			"extra":                nil,
+			"input":                types.XTextEmpty,
+			"name":                 types.NewXText("Empty"),
+			"node_uuid":            types.NewXText("26493ebb-a254-4461-a28d-c7761784e276"),
+			"value":                types.NewXText(""),
+			"values":               types.NewXArray(types.NewXText("")),
+		}),
+	}), resultsAsContext)
 }

--- a/flows/routers/cases/tests.go
+++ b/flows/routers/cases/tests.go
@@ -37,7 +37,6 @@ func RegisterXTest(name string, function types.XFunction) {
 // XTESTS is our mapping of the excellent test names to their actual functions
 var XTESTS = map[string]types.XFunction{
 	"has_error": functions.OneArgFunction(HasError),
-	"has_value": functions.OneArgFunction(HasValue),
 
 	"has_only_text":   functions.TwoTextFunction(HasOnlyText),
 	"has_phrase":      functions.TwoTextFunction(HasPhrase),
@@ -73,6 +72,9 @@ var XTESTS = map[string]types.XFunction{
 	"has_state":    functions.OneTextFunction(HasState),
 	"has_district": functions.MinAndMaxArgsCheck(1, 2, HasDistrict),
 	"has_ward":     HasWard,
+
+	// for backward compatibility
+	"has_value": functions.OneTextFunction(HasText),
 }
 
 //------------------------------------------------------------------------------------------
@@ -142,28 +144,6 @@ func HasError(env envs.Environment, value types.XValue) types.XValue {
 	}
 
 	return FalseResult
-}
-
-// HasValue returns whether `value` is non-nil and not an error
-//
-// Note that `contact.fields` and `run.results` are considered dynamic, so it is not an error
-// to try to retrieve a value from fields or results which don't exist, rather these return an empty
-// value.
-//
-//   @(has_value("hello")) -> true
-//   @(has_value("hello").match) -> hello
-//   @(has_value(datetime("foo"))) -> false
-//   @(has_value(not.existing)) -> false
-//   @(has_value(contact.fields.unset)) -> false
-//   @(has_value("")) -> false
-//
-// @test has_value(value)
-func HasValue(env envs.Environment, value types.XValue) types.XValue {
-	if types.IsEmpty(value) || types.IsXError(value) {
-		return FalseResult
-	}
-
-	return NewTrueResult(value)
 }
 
 // HasGroup returns whether the `contact` is part of group with the passed in UUID


### PR DESCRIPTION
Also..

 * Simplify implementation of `default` to use the default if ..
    - arg1 an error or 
    - arg1 stringifies as empty
 * Makes `has_value` an alias for `has_text` - we already [removed this](https://github.com/nyaruka/floweditor/issues/725) in the editor and we can do a migration to get rid of it completely at some point.