### PR TITLE
🧹 Remove redundant types on slice items

### DIFF
--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -56,7 +56,7 @@ func TestEventMarshaling(t *testing.T) {
 					ActualAmount:  decimal.RequireFromString("1.00"),
 				},
 				[]*flows.HTTPLog{
-					&flows.HTTPLog{
+					{
 						CreatedOn: dates.Now(),
 						ElapsedMS: 12,
 						Request:   "POST /topup HTTP/1.1\r\nHost: send.money.com\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
@@ -134,7 +134,7 @@ func TestEventMarshaling(t *testing.T) {
 			events.NewClassifierCalled(
 				assets.NewClassifierReference(assets.ClassifierUUID("4b937f49-7fb7-43a5-8e57-14e2f028a471"), "Booking"),
 				[]*flows.HTTPLog{
-					&flows.HTTPLog{
+					{
 						CreatedOn: dates.Now(),
 						ElapsedMS: 12,
 						Request:   "GET /message?v=20170307&q=hello HTTP/1.1\r\nHost: api.wit.ai\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n",
@@ -477,7 +477,7 @@ func TestWebhookCalledEventTrimming(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"http://temba.io/": []httpx.MockResponse{
+		"http://temba.io/": {
 			httpx.NewMockResponse(200, nil, strings.Repeat("Y", 20000)),
 		},
 	}))
@@ -504,7 +504,7 @@ func TestWebhookCalledEventBadUTF8(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"http://temba.io/": []httpx.MockResponse{
+		"http://temba.io/": {
 			httpx.NewMockResponse(200, nil, "\xa0\xa1"),
 		},
 	}))

--- a/flows/info_test.go
+++ b/flows/info_test.go
@@ -28,10 +28,10 @@ func TestNewResultSpecs(t *testing.T) {
 	)
 
 	extracted := []flows.ExtractedResult{
-		flows.ExtractedResult{Node: node1, Info: flows.NewResultInfo("Response 1", []string{"Red", "Green"})},
-		flows.ExtractedResult{Node: node1, Info: flows.NewResultInfo("Response-1", nil)},
-		flows.ExtractedResult{Node: node2, Info: flows.NewResultInfo("Response-1", []string{"Green", "Blue"})},
-		flows.ExtractedResult{Node: node2, Info: flows.NewResultInfo("Favorite Beer", []string{})},
+		{Node: node1, Info: flows.NewResultInfo("Response 1", []string{"Red", "Green"})},
+		{Node: node1, Info: flows.NewResultInfo("Response-1", nil)},
+		{Node: node2, Info: flows.NewResultInfo("Response-1", []string{"Green", "Blue"})},
+		{Node: node2, Info: flows.NewResultInfo("Favorite Beer", []string{})},
 	}
 
 	specs := flows.NewResultSpecs(extracted)

--- a/flows/services_test.go
+++ b/flows/services_test.go
@@ -15,7 +15,7 @@ func TestHTTPLogs(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"http://temba.io/": []httpx.MockResponse{
+		"http://temba.io/": {
 			httpx.NewMockResponse(200, nil, "hello"),
 			httpx.NewMockResponse(400, nil, "is error"),
 			httpx.MockConnectionError,

--- a/services/airtime/dtone/client_test.go
+++ b/services/airtime/dtone/client_test.go
@@ -18,7 +18,7 @@ func TestClient(t *testing.T) {
 	defer dates.SetNowSource(dates.DefaultNowSource)
 
 	mocks := httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://airtime-api.dtone.com/cgi-bin/shop/topup": []httpx.MockResponse{
+		"https://airtime-api.dtone.com/cgi-bin/shop/topup": {
 			httpx.NewMockResponse(200, nil, "info_txt=pong\r\n"),                  // successful ping
 			httpx.NewMockResponse(400, nil, "error_code=1\r\nerror_txt=Oops\r\n"), // unsuccessful ping
 			httpx.NewMockResponse(200, nil, withCRLF(msisdnResponse)),             // successful msdninfo query

--- a/services/airtime/dtone/service_test.go
+++ b/services/airtime/dtone/service_test.go
@@ -80,7 +80,7 @@ func TestServiceWithSuccessfulTopup(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	mocks := httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://airtime-api.dtone.com/cgi-bin/shop/topup": []httpx.MockResponse{
+		"https://airtime-api.dtone.com/cgi-bin/shop/topup": {
 			httpx.NewMockResponse(200, nil, withCRLF(msisdnResponse)),
 			httpx.NewMockResponse(200, nil, withCRLF(reserveResponse)),
 			httpx.NewMockResponse(200, nil, withCRLF(topupResponse)),
@@ -126,7 +126,7 @@ func TestServiceFailedTransfers(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	mocks := httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://airtime-api.dtone.com/cgi-bin/shop/topup": []httpx.MockResponse{
+		"https://airtime-api.dtone.com/cgi-bin/shop/topup": {
 			httpx.NewMockResponse(200, nil, withCRLF(msisdnResponse)),
 			httpx.NewMockResponse(200, nil, withCRLF(msisdnResponse)),
 		},

--- a/services/classification/bothub/client_test.go
+++ b/services/classification/bothub/client_test.go
@@ -15,7 +15,7 @@ func TestPredict(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://nlp.bothub.it/parse": []httpx.MockResponse{
+		"https://nlp.bothub.it/parse": {
 			httpx.NewMockResponse(200, nil, `xx`), // non-JSON response
 			httpx.NewMockResponse(200, nil, `{}`), // invalid JSON response
 			httpx.NewMockResponse(200, nil, `{
@@ -74,13 +74,13 @@ func TestPredict(t *testing.T) {
 	assert.NotNil(t, trace)
 	assert.Equal(t, bothub.IntentMatch{"book_flight", decimal.RequireFromString(`0.8341536248216568`)}, response.Intent)
 	assert.Equal(t, []bothub.IntentMatch{
-		bothub.IntentMatch{"book_flight", decimal.RequireFromString(`0.8341536248216568`)},
-		bothub.IntentMatch{"book_hotel", decimal.RequireFromString(`0.16584637517834322`)},
+		{"book_flight", decimal.RequireFromString(`0.8341536248216568`)},
+		{"book_hotel", decimal.RequireFromString(`0.16584637517834322`)},
 	}, response.IntentRanking)
 	assert.Equal(t, []string{"destination"}, response.LabelsList)
 	assert.Equal(t, []string{"quito"}, response.EntitiesList)
 	assert.Equal(t, map[string][]bothub.EntityMatch{
-		"destination": []bothub.EntityMatch{
+		"destination": {
 			bothub.EntityMatch{Value: "quito", Entity: "quito", Confidence: decimal.RequireFromString(`0.7979280788804916`)},
 		},
 	}, response.Entities)

--- a/services/classification/bothub/service_test.go
+++ b/services/classification/bothub/service_test.go
@@ -29,7 +29,7 @@ func TestService(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2019, 10, 7, 15, 21, 30, 123456789, time.UTC)))
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://nlp.bothub.it/parse": []httpx.MockResponse{
+		"https://nlp.bothub.it/parse": {
 			httpx.NewMockResponse(200, nil, `{
 				"intent": {
 				  "name": "book_flight",
@@ -79,11 +79,11 @@ func TestService(t *testing.T) {
 	classification, err := svc.Classify(session, "book my flight to Quito", httpLogger.Log)
 	assert.NoError(t, err)
 	assert.Equal(t, []flows.ExtractedIntent{
-		flows.ExtractedIntent{Name: "book_flight", Confidence: decimal.RequireFromString(`0.9224673593230207`)},
-		flows.ExtractedIntent{Name: "book_hotel", Confidence: decimal.RequireFromString(`0.07753264067697924`)},
+		{Name: "book_flight", Confidence: decimal.RequireFromString(`0.9224673593230207`)},
+		{Name: "book_hotel", Confidence: decimal.RequireFromString(`0.07753264067697924`)},
 	}, classification.Intents)
 	assert.Equal(t, map[string][]flows.ExtractedEntity{
-		"destination": []flows.ExtractedEntity{
+		"destination": {
 			flows.ExtractedEntity{Value: "quito", Confidence: decimal.RequireFromString(`0.8824543190522534`)},
 		},
 	}, classification.Entities)

--- a/services/classification/luis/client_test.go
+++ b/services/classification/luis/client_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPredict(t *testing.T) {
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/f96abf2f-3b53-4766-8ea6-09a655222a02?verbose=true&subscription-key=3246231&q=Hello": []httpx.MockResponse{
+		"https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/f96abf2f-3b53-4766-8ea6-09a655222a02?verbose=true&subscription-key=3246231&q=Hello": {
 			httpx.NewMockResponse(200, nil, `xx`), // non-JSON response
 			httpx.NewMockResponse(200, nil, `{}`), // invalid JSON response
 			httpx.NewMockResponse(200, nil, `{
@@ -81,12 +81,12 @@ func TestPredict(t *testing.T) {
 	assert.Equal(t, "book a flight to Quito", response.Query)
 	assert.Equal(t, &luis.ExtractedIntent{"Book Flight", decimal.RequireFromString(`0.9106805`)}, response.TopScoringIntent)
 	assert.Equal(t, []luis.ExtractedIntent{
-		luis.ExtractedIntent{"Book Flight", decimal.RequireFromString(`0.9106805`)},
-		luis.ExtractedIntent{"None", decimal.RequireFromString(`0.08910245`)},
-		luis.ExtractedIntent{"Book Hotel", decimal.RequireFromString(`0.07790734`)},
+		{"Book Flight", decimal.RequireFromString(`0.9106805`)},
+		{"None", decimal.RequireFromString(`0.08910245`)},
+		{"Book Hotel", decimal.RequireFromString(`0.07790734`)},
 	}, response.Intents)
 	assert.Equal(t, []luis.ExtractedEntity{
-		luis.ExtractedEntity{Entity: "quito", Type: "City", StartIndex: 17, EndIndex: 21, Score: decimal.RequireFromString(`0.9644149`)},
+		{Entity: "quito", Type: "City", StartIndex: 17, EndIndex: 21, Score: decimal.RequireFromString(`0.9644149`)},
 	}, response.Entities)
 	assert.Equal(t, &luis.SentimentAnalysis{"positive", decimal.RequireFromString(`0.731448531`)}, response.SentimentAnalysis)
 }

--- a/services/classification/luis/service.go
+++ b/services/classification/luis/service.go
@@ -53,14 +53,14 @@ func (s *service) Classify(session flows.Session, input string, logHTTP flows.HT
 
 	for _, entity := range response.Entities {
 		result.Entities[entity.Type] = []flows.ExtractedEntity{
-			flows.ExtractedEntity{Value: entity.Entity, Confidence: entity.Score},
+			{Value: entity.Entity, Confidence: entity.Score},
 		}
 	}
 
 	// if sentiment analysis was included, convert to an entity
 	if response.SentimentAnalysis != nil {
 		result.Entities["sentiment"] = []flows.ExtractedEntity{
-			flows.ExtractedEntity{Value: response.SentimentAnalysis.Label, Confidence: response.SentimentAnalysis.Score},
+			{Value: response.SentimentAnalysis.Label, Confidence: response.SentimentAnalysis.Score},
 		}
 	}
 

--- a/services/classification/luis/service_test.go
+++ b/services/classification/luis/service_test.go
@@ -29,7 +29,7 @@ func TestService(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2019, 10, 7, 15, 21, 30, 123456789, time.UTC)))
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/f96abf2f-3b53-4766-8ea6-09a655222a02?verbose=true&subscription-key=3246231&q=book+flight+to+Quito": []httpx.MockResponse{
+		"https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/f96abf2f-3b53-4766-8ea6-09a655222a02?verbose=true&subscription-key=3246231&q=book+flight+to+Quito": {
 			httpx.NewMockResponse(200, nil, `{
 				"query": "book a flight to Quito",
 				"topScoringIntent": {
@@ -82,15 +82,15 @@ func TestService(t *testing.T) {
 	classification, err := svc.Classify(session, "book flight to Quito", httpLogger.Log)
 	assert.NoError(t, err)
 	assert.Equal(t, []flows.ExtractedIntent{
-		flows.ExtractedIntent{Name: "Book Flight", Confidence: decimal.RequireFromString(`0.9106805`)},
-		flows.ExtractedIntent{Name: "None", Confidence: decimal.RequireFromString(`0.08910245`)},
-		flows.ExtractedIntent{Name: "Book Hotel", Confidence: decimal.RequireFromString(`0.07790734`)},
+		{Name: "Book Flight", Confidence: decimal.RequireFromString(`0.9106805`)},
+		{Name: "None", Confidence: decimal.RequireFromString(`0.08910245`)},
+		{Name: "Book Hotel", Confidence: decimal.RequireFromString(`0.07790734`)},
 	}, classification.Intents)
 	assert.Equal(t, map[string][]flows.ExtractedEntity{
-		"City": []flows.ExtractedEntity{
+		"City": {
 			flows.ExtractedEntity{Value: "quito", Confidence: decimal.RequireFromString(`0.9644149`)},
 		},
-		"sentiment": []flows.ExtractedEntity{
+		"sentiment": {
 			flows.ExtractedEntity{Value: "positive", Confidence: decimal.RequireFromString(`0.731448531`)},
 		},
 	}, classification.Entities)

--- a/services/classification/wit/client_test.go
+++ b/services/classification/wit/client_test.go
@@ -15,7 +15,7 @@ func TestMessage(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://api.wit.ai/message?v=20170307&q=Hello": []httpx.MockResponse{
+		"https://api.wit.ai/message?v=20170307&q=Hello": {
 			httpx.NewMockResponse(200, nil, `xx`), // non-JSON response
 			httpx.NewMockResponse(200, nil, `{}`), // invalid JSON response
 			httpx.NewMockResponse(200, nil, `{"_text":"book flight","entities":{"intent":[{"confidence":0.84709152161066,"value":"book_flight"}]},"msg_id":"1M7fAcDWag76OmgDI"}`),
@@ -41,7 +41,7 @@ func TestMessage(t *testing.T) {
 	assert.NotNil(t, trace)
 	assert.Equal(t, "1M7fAcDWag76OmgDI", response.MsgID)
 	assert.Equal(t, "book flight", response.Text)
-	assert.Equal(t, map[string][]wit.EntityCandidate{"intent": []wit.EntityCandidate{
+	assert.Equal(t, map[string][]wit.EntityCandidate{"intent": {
 		wit.EntityCandidate{Value: "book_flight", Confidence: decimal.RequireFromString(`0.84709152161066`)},
 	}}, response.Entities)
 }

--- a/services/classification/wit/service_test.go
+++ b/services/classification/wit/service_test.go
@@ -29,7 +29,7 @@ func TestService(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2019, 10, 7, 15, 21, 30, 123456789, time.UTC)))
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://api.wit.ai/message?v=20170307&q=book+flight+to+Quito": []httpx.MockResponse{
+		"https://api.wit.ai/message?v=20170307&q=book+flight+to+Quito": {
 			httpx.NewMockResponse(200, nil, `{"_text":"book flight to Quito","entities":{"intent":[{"confidence":0.84709152161066,"value":"book_flight"}]},"msg_id":"1M7fAcDWag76OmgDI"}`),
 		},
 	}))
@@ -46,7 +46,7 @@ func TestService(t *testing.T) {
 	classification, err := svc.Classify(session, "book flight to Quito", httpLogger.Log)
 	assert.NoError(t, err)
 	assert.Equal(t, []flows.ExtractedIntent{
-		flows.ExtractedIntent{Name: "book_flight", Confidence: decimal.RequireFromString(`0.84709152161066`)},
+		{Name: "book_flight", Confidence: decimal.RequireFromString(`0.84709152161066`)},
 	}, classification.Intents)
 	assert.Equal(t, map[string][]flows.ExtractedEntity{}, classification.Entities)
 

--- a/utils/httpx/access_test.go
+++ b/utils/httpx/access_test.go
@@ -16,7 +16,7 @@ func TestAccessConfig(t *testing.T) {
 	access := httpx.NewAccessConfig(30*time.Second, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")})
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://nyaruka.com": []httpx.MockResponse{
+		"https://nyaruka.com": {
 			httpx.NewMockResponse(200, nil, ``),
 		},
 	}))

--- a/utils/httpx/http_test.go
+++ b/utils/httpx/http_test.go
@@ -55,7 +55,7 @@ func TestMaxBodyBytes(t *testing.T) {
 	testBody := `abcdefghijklmnopqrstuvwxyz`
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://temba.io": []httpx.MockResponse{
+		"https://temba.io": {
 			httpx.NewMockResponse(200, nil, testBody),
 			httpx.NewMockResponse(200, nil, testBody),
 			httpx.NewMockResponse(200, nil, testBody),
@@ -93,7 +93,7 @@ func TestNonUTF8(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://temba.io": []httpx.MockResponse{
+		"https://temba.io": {
 			httpx.MockResponse{Status: 200, Headers: nil, Body: []byte{'\xc3', '\x28'}},
 		},
 	}))

--- a/utils/httpx/mock_test.go
+++ b/utils/httpx/mock_test.go
@@ -16,11 +16,11 @@ func TestMockRequestor(t *testing.T) {
 
 	// can create requestor with constructor
 	requestor1 := httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"http://google.com": []httpx.MockResponse{
+		"http://google.com": {
 			httpx.NewMockResponse(200, nil, "this is google"),
 			httpx.NewMockResponse(201, nil, "this is google again"),
 		},
-		"http://yahoo.com": []httpx.MockResponse{
+		"http://yahoo.com": {
 			httpx.NewMockResponse(202, nil, "this is yahoo"),
 			httpx.MockConnectionError,
 		},
@@ -67,11 +67,11 @@ func TestMockRequestor(t *testing.T) {
 func TestMockRequestorMarshaling(t *testing.T) {
 	// can create requestor with constructor
 	requestor1 := httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"http://google.com": []httpx.MockResponse{
+		"http://google.com": {
 			httpx.NewMockResponse(200, nil, "this is google"),
 			httpx.NewMockResponse(201, nil, "this is google again"),
 		},
-		"http://yahoo.com": []httpx.MockResponse{
+		"http://yahoo.com": {
 			httpx.NewMockResponse(202, nil, "this is yahoo"),
 			httpx.MockConnectionError,
 		},

--- a/utils/httpx/retries_test.go
+++ b/utils/httpx/retries_test.go
@@ -57,29 +57,29 @@ func TestDoWithRetries(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	mocks := httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"http://temba.io/1/": []httpx.MockResponse{
+		"http://temba.io/1/": {
 			httpx.NewMockResponse(502, nil, "a"),
 		},
-		"http://temba.io/2/": []httpx.MockResponse{
+		"http://temba.io/2/": {
 			httpx.NewMockResponse(503, nil, "a"),
 			httpx.NewMockResponse(504, nil, "b"),
 			httpx.NewMockResponse(505, nil, "c"),
 		},
-		"http://temba.io/3/": []httpx.MockResponse{
+		"http://temba.io/3/": {
 			httpx.NewMockResponse(200, nil, "a"),
 		},
-		"http://temba.io/4/": []httpx.MockResponse{
+		"http://temba.io/4/": {
 			httpx.NewMockResponse(502, nil, "a"),
 		},
-		"http://temba.io/5/": []httpx.MockResponse{
+		"http://temba.io/5/": {
 			httpx.NewMockResponse(502, nil, "a"),
 			httpx.NewMockResponse(200, nil, "b"),
 		},
-		"http://temba.io/6/": []httpx.MockResponse{
+		"http://temba.io/6/": {
 			httpx.NewMockResponse(429, map[string]string{"Retry-After": "1"}, "a"),
 			httpx.NewMockResponse(201, nil, "b"),
 		},
-		"http://temba.io/7/": []httpx.MockResponse{
+		"http://temba.io/7/": {
 			httpx.NewMockResponse(429, map[string]string{"Retry-After": "100"}, "a"),
 		},
 	})


### PR DESCRIPTION
Not sure when go starting allowing this but vscode offers to fix it and seems it works on 1.13 and 1.14..