### PR TITLE
📇 URNs modifier to replace/set all URNs

### DIFF
--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -75,6 +75,6 @@ func (a *AddContactURNAction) Execute(run flows.FlowRun, step flows.Step, logMod
 		return nil
 	}
 
-	a.applyModifier(run, modifiers.NewURN(urn, modifiers.URNAppend), logModifier, logEvent)
+	a.applyModifier(run, modifiers.NewURNs([]urns.URN{urn}, modifiers.URNsAppend), logModifier, logEvent)
 	return nil
 }

--- a/flows/actions/modifiers/base_test.go
+++ b/flows/actions/modifiers/base_test.go
@@ -211,6 +211,14 @@ func TestConstructors(t *testing.T) {
 				"modification": "append"
 			}`,
 		},
+		{
+			modifiers.NewURNs([]urns.URN{urns.URN("tel:+1234567890"), urns.URN("tel:+1234567891")}, modifiers.URNsSet),
+			`{
+				"type": "urns",
+				"urns": ["tel:+1234567890", "tel:+1234567891"],
+				"modification": "set"
+			}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/flows/actions/modifiers/testdata/urns.json
+++ b/flows/actions/modifiers/testdata/urns.json
@@ -1,0 +1,193 @@
+[
+    {
+        "description": "URNs changed event if URNs added",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "urns": [
+                "tel:+17036971111"
+            ],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "urns",
+            "urns": [
+                "tel:+17036972222",
+                "tel:+17036973333"
+            ],
+            "modification": "append"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "created_on": "2018-06-20T11:40:30.123456789Z",
+            "urns": [
+                "tel:+17036971111",
+                "tel:+17036972222",
+                "tel:+17036973333"
+            ]
+        },
+        "events": [
+            {
+                "type": "contact_urns_changed",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "urns": [
+                    "tel:+17036971111",
+                    "tel:+17036972222",
+                    "tel:+17036973333"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "URNs changed event if URNs removed",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "urns": [
+                "tel:+17036971111",
+                "tel:+17036972222"
+            ],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "urns",
+            "urns": [
+                "tel:+17036972222"
+            ],
+            "modification": "remove"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "created_on": "2018-06-20T11:40:30.123456789Z",
+            "urns": [
+                "tel:+17036971111"
+            ]
+        },
+        "events": [
+            {
+                "type": "contact_urns_changed",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "urns": [
+                    "tel:+17036971111"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "URNs changed event if URNs set",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "urns": [
+                "tel:+17036971111",
+                "tel:+17036972222"
+            ],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "urns",
+            "urns": [
+                "tel:+17036972222",
+                "tel:+17036973333"
+            ],
+            "modification": "set"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "created_on": "2018-06-20T11:40:30.123456789Z",
+            "urns": [
+                "tel:+17036972222",
+                "tel:+17036973333"
+            ]
+        },
+        "events": [
+            {
+                "type": "contact_urns_changed",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "urns": [
+                    "tel:+17036972222",
+                    "tel:+17036973333"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "URN normalized before checking existence",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "urns": [
+                "tel:+17010000000"
+            ],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "urns",
+            "urns": [
+                "tel:+1 (701) 222 2222"
+            ],
+            "modification": "append"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "created_on": "2018-06-20T11:40:30.123456789Z",
+            "urns": [
+                "tel:+17010000000",
+                "tel:+17012222222"
+            ]
+        },
+        "events": [
+            {
+                "type": "contact_urns_changed",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "urns": [
+                    "tel:+17010000000",
+                    "tel:+17012222222"
+                ]
+            }
+        ]
+    },
+    {
+        "description": "noop if URNs unchanged",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "urns": [
+                "tel:+17010000000",
+                "tel:+17012222222"
+            ],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "urns",
+            "urns": [
+                "tel:+17012222222"
+            ],
+            "modification": "append"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "created_on": "2018-06-20T11:40:30.123456789Z",
+            "urns": [
+                "tel:+17010000000",
+                "tel:+17012222222"
+            ]
+        },
+        "events": []
+    }
+]

--- a/flows/actions/modifiers/urn.go
+++ b/flows/actions/modifiers/urn.go
@@ -27,7 +27,8 @@ const (
 	URNRemove URNModification = "remove"
 )
 
-// URNModifier modifies a URN on a contact
+// URNModifier modifies a URN on a contact. This has been replaced by URNsModifier but is kept here for now
+// to support processing of old Surveyor submissions.
 type URNModifier struct {
 	baseModifier
 

--- a/flows/actions/modifiers/urns.go
+++ b/flows/actions/modifiers/urns.go
@@ -1,0 +1,82 @@
+package modifiers
+
+import (
+	"encoding/json"
+
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/events"
+	"github.com/nyaruka/goflow/utils"
+)
+
+func init() {
+	registerType(TypeURNs, readURNsModifier)
+}
+
+// TypeURNs is the type of our URNs modifier
+const TypeURNs string = "urns"
+
+// URNsModification is the type of modification to make
+type URNsModification string
+
+// the supported types of modification
+const (
+	URNsAppend URNsModification = "append"
+	URNsRemove URNsModification = "remove"
+	URNsSet    URNsModification = "set"
+)
+
+// URNsModifier modifies the URNs on a contact
+type URNsModifier struct {
+	baseModifier
+
+	URNs         []urns.URN       `json:"urns" validate:"required"`
+	Modification URNsModification `json:"modification" validate:"required,eq=append|eq=remove|eq=set"`
+}
+
+// NewURNs creates a new URNs modifier
+func NewURNs(urnz []urns.URN, modification URNsModification) *URNsModifier {
+	return &URNsModifier{
+		baseModifier: newBaseModifier(TypeURNs),
+		URNs:         urnz,
+		Modification: modification,
+	}
+}
+
+// Apply applies this modification to the given contact
+func (m *URNsModifier) Apply(env envs.Environment, assets flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) {
+	modified := false
+
+	if m.Modification == URNsSet {
+		contact.ClearURNs()
+	}
+
+	for _, urn := range m.URNs {
+		// normalize the URN
+		urn := urn.Normalize(string(env.DefaultCountry()))
+
+		if m.Modification == URNsAppend || m.Modification == URNsSet {
+			modified = contact.AddURN(urn, nil)
+		} else {
+			modified = contact.RemoveURN(urn)
+		}
+	}
+
+	if modified {
+		log(events.NewContactURNsChanged(contact.URNs().RawURNs()))
+		m.reevaluateGroups(env, assets, contact, log)
+	}
+}
+
+var _ flows.Modifier = (*URNsModifier)(nil)
+
+//------------------------------------------------------------------------------------------
+// JSON Encoding / Decoding
+//------------------------------------------------------------------------------------------
+
+func readURNsModifier(assets flows.SessionAssets, data json.RawMessage, missing assets.MissingCallback) (flows.Modifier, error) {
+	m := &URNsModifier{}
+	return m, utils.UnmarshalAndValidate(data, m)
+}

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -199,6 +199,13 @@ func (c *Contact) Name() string { return c.name }
 // URNs returns the URNs of this contact
 func (c *Contact) URNs() URNList { return c.urns }
 
+// ClearURNs clears the URNs on this contact
+func (c *Contact) ClearURNs() bool {
+	hadURNS := len(c.urns) > 0
+	c.urns = URNList{}
+	return hadURNS
+}
+
 // AddURN adds a new URN to this contact
 func (c *Contact) AddURN(urn urns.URN, channel *Channel) bool {
 	if c.HasURN(urn) {

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -133,6 +133,10 @@ func TestContact(t *testing.T) {
 		"urns":        contact.URNs().ToXValue(env),
 		"uuid":        types.NewXText(string(contact.UUID())),
 	}), flows.Context(env, contact))
+
+	assert.True(t, contact.ClearURNs()) // did have URNs
+	assert.False(t, contact.ClearURNs())
+	assert.Equal(t, flows.URNList{}, contact.URNs())
 }
 
 func TestContactFormat(t *testing.T) {


### PR DESCRIPTION
From the RP UI you can completely change/reorder the contact URNs, which currently we'd have to describe using a sequence of single URN add/remove modifiers. This adds a new "URNs" modifier which can eventually replace the "URN" modifier.