### PR TITLE
🏗️ Add builder for triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ env := envs.NewBuilder().Build()
 source, _ := static.LoadSource("myassets.json")
 assets, _ := engine.NewSessionAssets(env, source, nil)
 contact := flows.NewContact(assets, ...)
-trigger := triggers.NewManual(env, contact, flow.Reference(), nil, false, nil, time.Now())
+trigger := triggers.NewBuilder(env, contact, flow.Reference()).Manual().Build()
 eng := engine.NewBuilder().Build()
 session, sprint, err := eng.NewSession(assets, trigger)
 ```

--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -148,9 +148,9 @@ func RunFlow(eng flows.Engine, assetsPath string, flowUUID assets.FlowUUID, init
 
 	if initialMsg != "" {
 		msg := createMessage(contact, initialMsg)
-		repro.Trigger = triggers.NewMsg(env, flow.Reference(), contact, msg, nil)
+		repro.Trigger = triggers.NewBuilder(env, flow.Reference(), contact).Msg(msg).Build()
 	} else {
-		repro.Trigger = triggers.NewManual(env, flow.Reference(), contact, false, nil)
+		repro.Trigger = triggers.NewBuilder(env, flow.Reference(), contact).Manual().Build()
 	}
 	fmt.Fprintf(out, "Starting flow '%s'....\n---------------------------------------\n", flow.Name())
 

--- a/cmd/transferairtime/main.go
+++ b/cmd/transferairtime/main.go
@@ -125,7 +125,9 @@ func transferAirtime(destination urns.URN, amount decimal.Decimal, currency stri
 	contact := flows.NewEmptyContact(sa, "", "", nil)
 	contact.AddURN(destination, nil)
 
-	_, sprint, err := eng.NewSession(sa, triggers.NewManual(env, assets.NewFlowReference(assets.FlowUUID("2374f60d-7412-442c-9177-585967afa972"), "Airtime"), contact, false, nil))
+	trigger := triggers.NewBuilder(env, assets.NewFlowReference(assets.FlowUUID("2374f60d-7412-442c-9177-585967afa972"), "Airtime"), contact).Manual().Build()
+
+	_, sprint, err := eng.NewSession(sa, trigger)
 	if err != nil {
 		return err
 	}

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -185,14 +185,14 @@ func testActionType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 		var trigger flows.Trigger
 		ignoreEventCount := 0
 		if tc.NoInput || tc.AsBatch {
-			var connection *flows.Connection
+			tb := triggers.NewBuilder(env, flow.Reference(), contact).Manual().AsBatch()
+
 			if flow.Type() == flows.FlowTypeVoice {
 				channel := sa.Channels().Get("57f1078f-88aa-46f4-a59a-948a5739c03d")
-				connection = flows.NewConnection(channel.Reference(), urns.URN("tel:+12065551212"))
-				trigger = triggers.NewManualVoice(env, flow.Reference(), contact, connection, tc.AsBatch, nil)
-			} else {
-				trigger = triggers.NewManual(env, flow.Reference(), contact, tc.AsBatch, nil)
+				tb = tb.WithConnection(channel.Reference(), urns.URN("tel:+12065551212"))
 			}
+
+			trigger = tb.Build()
 		} else {
 			msg := flows.NewMsgIn(
 				flows.MsgUUID("aa90ce99-3b4d-44ba-b0ca-79e63d9ed842"),
@@ -204,7 +204,7 @@ func testActionType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 					"audio/mp3:http://s3.amazon.com/bucket/test.mp3",
 				},
 			)
-			trigger = triggers.NewMsg(env, flow.Reference(), contact, msg, nil)
+			trigger = triggers.NewBuilder(env, flow.Reference(), contact).Msg(msg).Build()
 			ignoreEventCount = 1 // need to ignore the msg_received event this trigger creates
 		}
 

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -238,13 +238,11 @@ func TestReevaluateDynamicGroups(t *testing.T) {
 		contact, err := flows.ReadContact(sa, tc.ContactBefore, assets.IgnoreMissing)
 		require.NoError(t, err)
 
-		trigger := triggers.NewManual(
+		trigger := triggers.NewBuilder(
 			env,
 			assets.NewFlowReference("76f0a02f-3b75-4b86-9064-e9195e1b3a02", "Empty Flow"),
 			contact,
-			false,
-			nil,
-		)
+		).Manual().Build()
 
 		eng := engine.NewBuilder().Build()
 		session, _, _ := eng.NewSession(sa, trigger)

--- a/flows/resumes/base_test.go
+++ b/flows/resumes/base_test.go
@@ -87,7 +87,7 @@ func testResumeType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 		env := envs.NewBuilder().Build()
 		eng := engine.NewBuilder().Build()
 		contact := flows.NewEmptyContact(sa, "Bob", envs.Language("eng"), nil)
-		trigger := triggers.NewManual(env, flow.Reference(), contact, false, nil)
+		trigger := triggers.NewBuilder(env, flow.Reference(), contact).Manual().Build()
 		session, _, err := eng.NewSession(sa, trigger)
 		require.NoError(t, err)
 		require.Equal(t, flows.SessionStatusWaiting, session.Status())

--- a/flows/routers/base_test.go
+++ b/flows/routers/base_test.go
@@ -100,7 +100,7 @@ func testRouterType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 		contact, err := flows.ReadContact(sa, json.RawMessage(contactJSON), assets.PanicOnMissing)
 		require.NoError(t, err)
 
-		trigger := triggers.NewManual(envs.NewBuilder().Build(), flow.Reference(), contact, false, nil)
+		trigger := triggers.NewBuilder(envs.NewBuilder().Build(), flow.Reference(), contact).Manual().Build()
 
 		eng := test.NewEngine()
 		session, _, err := eng.NewSession(sa, trigger)

--- a/flows/routers/waits/msg_test.go
+++ b/flows/routers/waits/msg_test.go
@@ -77,7 +77,7 @@ func TestMsgWaitSkipIfInitial(t *testing.T) {
 	contact := flows.NewEmptyContact(sa, "Ben Haggerty", envs.Language("eng"), nil)
 
 	// a manual trigger will wait at the initial wait
-	trigger := triggers.NewManual(env, flow.Reference(), contact, false, nil)
+	trigger := triggers.NewBuilder(env, flow.Reference(), contact).Manual().Build()
 
 	session, sprint, err := eng.NewSession(sa, trigger)
 	require.NoError(t, err)
@@ -90,9 +90,9 @@ func TestMsgWaitSkipIfInitial(t *testing.T) {
 
 	// whereas a msg trigger will skip over it
 	msg := flows.NewMsgIn(flows.MsgUUID(uuids.New()), urns.NilURN, nil, "Hi there", nil)
-	trigger = triggers.NewMsg(env, flow.Reference(), contact, msg, nil)
+	trigger2 := triggers.NewBuilder(env, flow.Reference(), contact).Msg(msg).Build()
 
-	session, sprint, err = eng.NewSession(sa, trigger)
+	session, sprint, err = eng.NewSession(sa, trigger2)
 	require.NoError(t, err)
 
 	assert.Equal(t, flows.SessionStatusCompleted, session.Status())

--- a/flows/runs/environment_test.go
+++ b/flows/runs/environment_test.go
@@ -95,7 +95,7 @@ func TestRunEnvironment(t *testing.T) {
 	contact, err := flows.ReadContact(sa, []byte(contactJSON), assets.IgnoreMissing)
 	require.NoError(t, err)
 
-	trigger := triggers.NewManual(env, assets.NewFlowReference("76f0a02f-3b75-4b86-9064-e9195e1b3a02", "Test"), contact, false, nil)
+	trigger := triggers.NewBuilder(env, assets.NewFlowReference("76f0a02f-3b75-4b86-9064-e9195e1b3a02", "Test"), contact).Manual().Build()
 	eng := engine.NewBuilder().Build()
 
 	session, _, err := eng.NewSession(sa, trigger)

--- a/flows/triggers/base.go
+++ b/flows/triggers/base.go
@@ -134,6 +134,26 @@ func EnsureDynamicGroups(session flows.Session, logEvent flows.EventCallback) {
 }
 
 //------------------------------------------------------------------------------------------
+// Builder
+//------------------------------------------------------------------------------------------
+
+// Builder is a builder for triggers
+type Builder struct {
+	environment envs.Environment
+	flow        *assets.FlowReference
+	contact     *flows.Contact
+}
+
+// NewBuilder creates a new trigger builder
+func NewBuilder(env envs.Environment, flow *assets.FlowReference, contact *flows.Contact) *Builder {
+	return &Builder{
+		environment: env,
+		flow:        flow,
+		contact:     contact,
+	}
+}
+
+//------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding
 //------------------------------------------------------------------------------------------
 

--- a/flows/triggers/campaign.go
+++ b/flows/triggers/campaign.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 
 	"github.com/nyaruka/goflow/assets"
-	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/goflow/utils/jsonx"
+	"github.com/nyaruka/goflow/utils/uuids"
 )
 
 func init() {
@@ -17,26 +17,27 @@ func init() {
 // TypeCampaign is the type for sessions triggered by campaign events
 const TypeCampaign string = "campaign"
 
+// CampaignUUID is the type for campaign UUIDs
+type CampaignUUID uuids.UUID
+
+// CampaignEventUUID is the type for campaign event UUIDs
+type CampaignEventUUID uuids.UUID
+
 // CampaignReference is a reference to the campaign that triggered the session
 type CampaignReference struct {
-	UUID string `json:"uuid" validate:"required,uuid4"`
-	Name string `json:"name" validate:"required"`
+	UUID CampaignUUID `json:"uuid" validate:"required,uuid4"`
+	Name string       `json:"name" validate:"required"`
 }
 
 // NewCampaignReference creates a new campaign reference
-func NewCampaignReference(uuid, name string) *CampaignReference {
+func NewCampaignReference(uuid CampaignUUID, name string) *CampaignReference {
 	return &CampaignReference{UUID: uuid, Name: name}
 }
 
 // CampaignEvent describes the specific event in the campaign that triggered the session
 type CampaignEvent struct {
-	UUID     string             `json:"uuid" validate:"required,uuid4"`
+	UUID     CampaignEventUUID  `json:"uuid" validate:"required,uuid4"`
 	Campaign *CampaignReference `json:"campaign" validate:"required,dive"`
-}
-
-// NewCampaignEvent creates a new campaign event
-func NewCampaignEvent(uuid string, campaign *CampaignReference) *CampaignEvent {
-	return &CampaignEvent{UUID: uuid, Campaign: campaign}
 }
 
 // CampaignTrigger is used when a session was triggered by a campaign event
@@ -62,15 +63,31 @@ type CampaignTrigger struct {
 	event *CampaignEvent
 }
 
-// NewCampaign creates a new campaign trigger with the passed in values
-func NewCampaign(env envs.Environment, flow *assets.FlowReference, contact *flows.Contact, event *CampaignEvent) *CampaignTrigger {
-	return &CampaignTrigger{
-		baseTrigger: newBaseTrigger(TypeCampaign, env, flow, contact, nil, false, nil),
-		event:       event,
+var _ flows.Trigger = (*CampaignTrigger)(nil)
+
+//------------------------------------------------------------------------------------------
+// Builder
+//------------------------------------------------------------------------------------------
+
+// CampaignBuilder is a builder for campaign type triggers
+type CampaignBuilder struct {
+	t *CampaignTrigger
+}
+
+// Campaign returns a campaign trigger builder
+func (b *Builder) Campaign(campaign *CampaignReference, eventUUID CampaignEventUUID) *CampaignBuilder {
+	return &CampaignBuilder{
+		t: &CampaignTrigger{
+			baseTrigger: newBaseTrigger(TypeCampaign, b.environment, b.flow, b.contact, nil, false, nil),
+			event:       &CampaignEvent{UUID: eventUUID, Campaign: campaign},
+		},
 	}
 }
 
-var _ flows.Trigger = (*CampaignTrigger)(nil)
+// Build builds the trigger
+func (b *CampaignBuilder) Build() *CampaignTrigger {
+	return b.t
+}
 
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding

--- a/flows/triggers/channel.go
+++ b/flows/triggers/channel.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
-	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
@@ -34,11 +33,6 @@ type ChannelEvent struct {
 	Channel *assets.ChannelReference `json:"channel" validate:"required,dive"`
 }
 
-// NewChannelEvent creates a new channel event
-func NewChannelEvent(typeName ChannelEventType, channel *assets.ChannelReference) *ChannelEvent {
-	return &ChannelEvent{Type: typeName, Channel: channel}
-}
-
 // ChannelTrigger is used when a session was triggered by a channel event
 //
 //   {
@@ -62,30 +56,43 @@ type ChannelTrigger struct {
 	event *ChannelEvent
 }
 
-// NewChannel creates a new channel trigger with the passed in values
-func NewChannel(env envs.Environment, flow *assets.FlowReference, contact *flows.Contact, event *ChannelEvent, params *types.XObject) *ChannelTrigger {
-	if params == nil {
-		params = types.XObjectEmpty
-	}
-
-	return &ChannelTrigger{
-		baseTrigger: newBaseTrigger(TypeChannel, env, flow, contact, nil, false, params),
-		event:       event,
-	}
-}
-
-// NewIncomingCall creates a new channel trigger with the passed in values
-func NewIncomingCall(env envs.Environment, flow *assets.FlowReference, contact *flows.Contact, urn urns.URN, channel *assets.ChannelReference) *ChannelTrigger {
-	event := NewChannelEvent(ChannelEventTypeIncomingCall, channel)
-	connection := flows.NewConnection(channel, urn)
-
-	return &ChannelTrigger{
-		baseTrigger: newBaseTrigger(TypeChannel, env, flow, contact, connection, false, types.XObjectEmpty),
-		event:       event,
-	}
-}
-
 var _ flows.Trigger = (*ChannelTrigger)(nil)
+
+//------------------------------------------------------------------------------------------
+// Builder
+//------------------------------------------------------------------------------------------
+
+// ChannelBuilder is a builder for channel type triggers
+type ChannelBuilder struct {
+	t *ChannelTrigger
+}
+
+// Channel returns a channel trigger builder
+func (b *Builder) Channel(channel *assets.ChannelReference, eventType ChannelEventType) *ChannelBuilder {
+	return &ChannelBuilder{
+		t: &ChannelTrigger{
+			baseTrigger: newBaseTrigger(TypeChannel, b.environment, b.flow, b.contact, nil, false, types.XObjectEmpty),
+			event:       &ChannelEvent{Type: eventType, Channel: channel},
+		},
+	}
+}
+
+// WithConnection sets the channel connection for the trigger
+func (b *ChannelBuilder) WithConnection(urn urns.URN) *ChannelBuilder {
+	b.t.connection = flows.NewConnection(b.t.event.Channel, urn)
+	return b
+}
+
+// WithParams sets the params for the trigger
+func (b *ChannelBuilder) WithParams(params *types.XObject) *ChannelBuilder {
+	b.t.params = params
+	return b
+}
+
+// Build builds the trigger
+func (b *ChannelBuilder) Build() *ChannelTrigger {
+	return b.t
+}
 
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding

--- a/flows/triggers/manual.go
+++ b/flows/triggers/manual.go
@@ -3,6 +3,7 @@ package triggers
 import (
 	"encoding/json"
 
+	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
@@ -36,20 +37,6 @@ type ManualTrigger struct {
 	baseTrigger
 }
 
-// NewManual creates a new manual trigger
-func NewManual(env envs.Environment, flow *assets.FlowReference, contact *flows.Contact, batch bool, params *types.XObject) flows.Trigger {
-	return &ManualTrigger{
-		baseTrigger: newBaseTrigger(TypeManual, env, flow, contact, nil, batch, params),
-	}
-}
-
-// NewManualVoice creates a new manual trigger with a channel connection for voice
-func NewManualVoice(env envs.Environment, flow *assets.FlowReference, contact *flows.Contact, connection *flows.Connection, batch bool, params *types.XObject) flows.Trigger {
-	return &ManualTrigger{
-		baseTrigger: newBaseTrigger(TypeManual, env, flow, contact, connection, batch, params),
-	}
-}
-
 // Context for manual triggers always has non-nil params
 func (t *ManualTrigger) Context(env envs.Environment) map[string]types.XValue {
 	params := t.params
@@ -65,6 +52,45 @@ func (t *ManualTrigger) Context(env envs.Environment) map[string]types.XValue {
 }
 
 var _ flows.Trigger = (*ManualTrigger)(nil)
+
+//------------------------------------------------------------------------------------------
+// Builder
+//------------------------------------------------------------------------------------------
+
+// ManualBuilder is a builder for manual type triggers
+type ManualBuilder struct {
+	t *ManualTrigger
+}
+
+// Manual returns a manual trigger builder
+func (b *Builder) Manual() *ManualBuilder {
+	return &ManualBuilder{
+		t: &ManualTrigger{baseTrigger: newBaseTrigger(TypeManual, b.environment, b.flow, b.contact, nil, false, nil)},
+	}
+}
+
+// WithParams sets the params for the trigger
+func (b *ManualBuilder) WithParams(params *types.XObject) *ManualBuilder {
+	b.t.params = params
+	return b
+}
+
+// WithConnection sets the channel connection for the trigger
+func (b *ManualBuilder) WithConnection(channel *assets.ChannelReference, urn urns.URN) *ManualBuilder {
+	b.t.connection = flows.NewConnection(channel, urn)
+	return b
+}
+
+// AsBatch sets batch mode on for the trigger
+func (b *ManualBuilder) AsBatch() *ManualBuilder {
+	b.t.batch = true
+	return b
+}
+
+// Build builds the trigger
+func (b *ManualBuilder) Build() *ManualTrigger {
+	return b.t
+}
 
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding

--- a/flows/triggers/msg.go
+++ b/flows/triggers/msg.go
@@ -71,15 +71,6 @@ func NewKeywordMatch(typeName KeywordMatchType, keyword string) *KeywordMatch {
 	return &KeywordMatch{Type: typeName, Keyword: keyword}
 }
 
-// NewMsg creates a new message trigger
-func NewMsg(env envs.Environment, flow *assets.FlowReference, contact *flows.Contact, msg *flows.MsgIn, match *KeywordMatch) flows.Trigger {
-	return &MsgTrigger{
-		baseTrigger: newBaseTrigger(TypeMsg, env, flow, contact, nil, false, nil),
-		msg:         msg,
-		match:       match,
-	}
-}
-
 // InitializeRun performs additional initialization when we visit our first node
 func (t *MsgTrigger) InitializeRun(run flows.FlowRun, logEvent flows.EventCallback) error {
 	// update our input
@@ -109,6 +100,36 @@ func (t *MsgTrigger) Context(env envs.Environment) map[string]types.XValue {
 }
 
 var _ flows.Trigger = (*MsgTrigger)(nil)
+
+//------------------------------------------------------------------------------------------
+// Builder
+//------------------------------------------------------------------------------------------
+
+// MsgBuilder is a builder for msg type triggers
+type MsgBuilder struct {
+	t *MsgTrigger
+}
+
+// Msg returns a msg trigger builder
+func (b *Builder) Msg(msg *flows.MsgIn) *MsgBuilder {
+	return &MsgBuilder{
+		t: &MsgTrigger{
+			baseTrigger: newBaseTrigger(TypeMsg, b.environment, b.flow, b.contact, nil, false, nil),
+			msg:         msg,
+		},
+	}
+}
+
+// WithMatch sets the keyword match for the trigger
+func (b *MsgBuilder) WithMatch(match *KeywordMatch) *MsgBuilder {
+	b.t.match = match
+	return b
+}
+
+// Build builds the trigger
+func (b *MsgBuilder) Build() *MsgTrigger {
+	return b.t
+}
 
 //------------------------------------------------------------------------------------------
 // JSON Encoding / Decoding

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -163,7 +163,7 @@ type Trigger struct {
 func NewManualTrigger(environment *Environment, contact *Contact, flow *FlowReference) *Trigger {
 	flowRef := assets.NewFlowReference(assets.FlowUUID(flow.uuid), flow.name)
 	return &Trigger{
-		target: triggers.NewManual(environment.target, flowRef, contact.target, false, nil),
+		target: triggers.NewBuilder(environment.target, flowRef, contact.target).Manual().Build(),
 	}
 }
 

--- a/test/session.go
+++ b/test/session.go
@@ -562,7 +562,7 @@ func CreateSession(assetsJSON json.RawMessage, flowUUID assets.FlowUUID) (flows.
 
 	env := envs.NewBuilder().Build()
 	contact := flows.NewEmptyContact(sa, "Bob", envs.NilLanguage, nil)
-	trigger := triggers.NewManual(env, flow.Reference(), contact, false, nil)
+	trigger := triggers.NewBuilder(env, flow.Reference(), contact).Manual().Build()
 	eng := engine.NewBuilder().Build()
 
 	return eng.NewSession(sa, trigger)


### PR DESCRIPTION
Trying to think of a way to not make our convoluted trigger constructors more convoluted by adding even more arguments, e.g. https://github.com/nyaruka/goflow/issues/929 and whilst still keeping triggers immutable.

The complication here is that there are different types of triggers with different params..

```go
t := triggers.NewBuilder(env, flow.Reference(), contact).  <-- required opts for all triggers here
    Msg(msg).                                              <-- type and required opts for that type
    WithMatch(keyword).                                    <-- optional opts
    Build()
```