### PR TITLE
🧪 ContactQL parser errors should contain more info

### DIFF
--- a/contactql/error.go
+++ b/contactql/error.go
@@ -3,21 +3,40 @@ package contactql
 import (
 	"fmt"
 
+	"github.com/nyaruka/goflow/utils"
 	"github.com/pkg/errors"
 )
 
 // QueryError is used when an error is a result of an invalid query
 type QueryError struct {
-	msg string
-}
-
-func (e *QueryError) Error() string {
-	return e.msg
+	msg   string
+	code  string
+	extra map[string]string
 }
 
 // NewQueryErrorf creates a new query error
 func NewQueryErrorf(err string, args ...interface{}) *QueryError {
-	return &QueryError{fmt.Sprintf(err, args...)}
+	return &QueryError{msg: fmt.Sprintf(err, args...)}
+}
+
+// NewQueryError creates a new query error
+func NewQueryError(msg string, code string, extra map[string]string) *QueryError {
+	return &QueryError{msg: msg, code: code, extra: extra}
+}
+
+// Error returns the error message
+func (e *QueryError) Error() string {
+	return e.msg
+}
+
+// Code returns a code representing this error condition
+func (e *QueryError) Code() string {
+	return e.code
+}
+
+// Extra returns additional data about the error
+func (e *QueryError) Extra() map[string]string {
+	return e.extra
 }
 
 // IsQueryError is a utility to determine if the cause of an error was a query error
@@ -29,3 +48,5 @@ func IsQueryError(err error) (bool, error) {
 		return false, nil
 	}
 }
+
+var _ utils.RichError = (*QueryError)(nil)

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -1,0 +1,8 @@
+package utils
+
+// RichError is a common interface for error types that can provide more detail
+type RichError interface {
+	error
+	Code() string
+	Extra() map[string]string
+}


### PR DESCRIPTION
See https://github.com/rapidpro/rapidpro/issues/1289. Currently if a mailroom web handler returns an error it's returned as JSON as

```json
{
  "error": "oops something went wrong"
}
```

But we could make it so that if it sees the error implements `utils.RichError`, then it can render it like..

```json
{
  "error": "oops something went wrong",
  "code": "missing_foo",
  "extra": {"bar": "yes"}
}
```

So in the case of a users searching for $ the mailroom response would look like

```json
{
  "error": "mismatched input '$' expecting {'(', TEXT, STRING}",
  "code": "query_unexpected_token",
  "extra": {"token": "$"}
}
```

And RP can send that back to the user like `_("Invalid search syntax at %(token)s") % token`.. and you could use this for other types of errors, missing fields, un-parseable dates etc.
