### PR TITLE
🛑 No groups for blocked or stopped contacts

### DIFF
--- a/flows/modifiers/groups.go
+++ b/flows/modifiers/groups.go
@@ -46,6 +46,11 @@ func NewGroups(groups []*flows.Group, modification GroupsModification) *GroupsMo
 
 // Apply applies this modification to the given contact
 func (m *GroupsModifier) Apply(env envs.Environment, assets flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) {
+	if contact.Status() == flows.ContactStatusBlocked || contact.Status() == flows.ContactStatusStopped {
+		log(events.NewErrorf("can't add blocked or stopped contacts to groups"))
+		return
+	}
+
 	diff := make([]*flows.Group, 0, len(m.groups))
 
 	if m.modification == GroupsAdd {

--- a/flows/modifiers/testdata/groups.json
+++ b/flows/modifiers/testdata/groups.json
@@ -257,5 +257,71 @@
                 ]
             }
         ]
+    },
+    {
+        "description": "error event if adding contact who is blocked",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "blocked",
+            "groups": [],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "groups",
+            "groups": [
+                {
+                    "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
+                    "name": "Testers"
+                }
+            ],
+            "modification": "add"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "blocked",
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "events": [
+            {
+                "type": "error",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "text": "can't add blocked or stopped contacts to groups"
+            }
+        ]
+    },
+    {
+        "description": "error event if adding contact who is stopped",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "stopped",
+            "groups": [],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "groups",
+            "groups": [
+                {
+                    "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
+                    "name": "Testers"
+                }
+            ],
+            "modification": "add"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "stopped",
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "events": [
+            {
+                "type": "error",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "text": "can't add blocked or stopped contacts to groups"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Turns out this is not critical because after after modifier we check if they should be pulled out of groups, but seems we should generate an error event rather than putting them in a group and then removing them.