### PR TITLE
⚠️ Rework error handling in contactql 

### DIFF
--- a/contactql/error.go
+++ b/contactql/error.go
@@ -31,9 +31,9 @@ type QueryError struct {
 	extra map[string]string
 }
 
-// NewQueryErrorf creates a new query error
-func NewQueryErrorf(err string, args ...interface{}) *QueryError {
-	return &QueryError{msg: fmt.Sprintf(err, args...)}
+// NewQueryError creates a new query error
+func NewQueryError(code, err string, args ...interface{}) *QueryError {
+	return &QueryError{code: code, msg: fmt.Sprintf(err, args...)}
 }
 
 func (e *QueryError) withExtra(k, v string) *QueryError {
@@ -41,11 +41,6 @@ func (e *QueryError) withExtra(k, v string) *QueryError {
 		e.extra = make(map[string]string)
 	}
 	e.extra[k] = v
-	return e
-}
-
-func (e *QueryError) withCode(code string) *QueryError {
-	e.code = code
 	return e
 }
 

--- a/contactql/error.go
+++ b/contactql/error.go
@@ -4,7 +4,22 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/goflow/utils"
+
 	"github.com/pkg/errors"
+)
+
+// error codes with values included in extra
+const (
+	ErrUnexpectedToken       = "unexpected_token"       // `token` the unexpected token
+	ErrInvalidNumber         = "invalid_number"         // `value` the value we tried to parse as a number
+	ErrInvalidDate           = "invalid_date"           // `value` the value we tried to parse as a date
+	ErrInvalidLanguage       = "invalid_language"       // `value` the value we tried to parse as a language code
+	ErrInvalidGroup          = "invalid_group"          // `value` the value we tried to parse as a group name
+	ErrUnsupportedContains   = "unsupported_contains"   // `property` the property key
+	ErrUnsupportedComparison = "unsupported_comparison" // `property` the property key, `operator` one of =>, <, >=, <=
+	ErrUnsupportedSetCheck   = "unsupported_setcheck"   // `property` the property key, `operator` one of =, !=
+	ErrUnknownProperty       = "unknown_property"       // `property` the property key
+	ErrRedactedURNs          = "redacted_urns"
 )
 
 // QueryError is used when an error is a result of an invalid query
@@ -19,9 +34,17 @@ func NewQueryErrorf(err string, args ...interface{}) *QueryError {
 	return &QueryError{msg: fmt.Sprintf(err, args...)}
 }
 
-// NewQueryError creates a new query error
-func NewQueryError(msg string, code string, extra map[string]string) *QueryError {
-	return &QueryError{msg: msg, code: code, extra: extra}
+func (e *QueryError) withExtra(k, v string) *QueryError {
+	if e.extra == nil {
+		e.extra = make(map[string]string)
+	}
+	e.extra[k] = v
+	return e
+}
+
+func (e *QueryError) withCode(code string) *QueryError {
+	e.code = code
+	return e
 }
 
 // Error returns the error message

--- a/contactql/error.go
+++ b/contactql/error.go
@@ -15,6 +15,8 @@ const (
 	ErrInvalidDate           = "invalid_date"           // `value` the value we tried to parse as a date
 	ErrInvalidLanguage       = "invalid_language"       // `value` the value we tried to parse as a language code
 	ErrInvalidGroup          = "invalid_group"          // `value` the value we tried to parse as a group name
+	ErrInvalidPartialName    = "invalid_partial_name"   // `min_token_length` the minimum length of token required for name contains condition
+	ErrInvalidPartialURN     = "invalid_partial_urn"    // `min_value_length` the minimum length of value required for URN contains condition
 	ErrUnsupportedContains   = "unsupported_contains"   // `property` the property key
 	ErrUnsupportedComparison = "unsupported_comparison" // `property` the property key, `operator` one of =>, <, >=, <=
 	ErrUnsupportedSetCheck   = "unsupported_setcheck"   // `property` the property key, `operator` one of =, !=

--- a/contactql/error_test.go
+++ b/contactql/error_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestQueryError(t *testing.T) {
-	e := contactql.NewQueryErrorf("bad query")
+	e := contactql.NewQueryError("bad_query", "Bad Query")
 
-	assert.Equal(t, "bad query", e.Error())
+	assert.Equal(t, "Bad Query", e.Error())
 
 	e1 := errors.Wrap(errors.Wrap(e, "wrapped once"), "wrapped twice")
 	isQueryError, cause := contactql.IsQueryError(e1)

--- a/contactql/es/es.go
+++ b/contactql/es/es.go
@@ -10,7 +10,6 @@ import (
 	"github.com/nyaruka/goflow/utils/dates"
 	"github.com/olivere/elastic"
 	"github.com/pkg/errors"
-	"github.com/shopspring/decimal"
 )
 
 // ToElasticQuery converts a contactql query to an Elastic query returning the normalized view as well as the elastic query
@@ -139,10 +138,7 @@ func conditionToElasticQuery(env envs.Environment, resolver contactql.Resolver, 
 			return elastic.NewNestedQuery("fields", elastic.NewBoolQuery().Must(fieldQuery, query)), nil
 
 		} else if fieldType == assets.FieldTypeNumber {
-			value, err := decimal.NewFromString(c.Value())
-			if err != nil {
-				return nil, queryError("can't convert '%s' to a number", c.Value())
-			}
+			value := c.ValueAsNumber()
 
 			if c.Comparator() == contactql.ComparatorEqual {
 				query = elastic.NewMatchQuery("fields.number", value)
@@ -170,10 +166,7 @@ func conditionToElasticQuery(env envs.Environment, resolver contactql.Resolver, 
 			return elastic.NewNestedQuery("fields", elastic.NewBoolQuery().Must(fieldQuery, query)), nil
 
 		} else if fieldType == assets.FieldTypeDatetime {
-			value, err := envs.DateTimeFromString(env, c.Value(), false)
-			if err != nil {
-				return nil, queryError("string '%s' couldn't be parsed as a date", c.Value())
-			}
+			value := c.ValueAsDate()
 			start, end := dates.DayToUTCRange(value, value.Location())
 
 			if c.Comparator() == contactql.ComparatorEqual {
@@ -276,10 +269,7 @@ func conditionToElasticQuery(env envs.Environment, resolver contactql.Resolver, 
 				return nil, queryError("unsupported language comparator: %s", c.Comparator())
 			}
 		} else if key == contactql.AttributeCreatedOn {
-			value, err := envs.DateTimeFromString(env, c.Value(), false)
-			if err != nil {
-				return nil, queryError("string '%s' couldn't be parsed as a date", c.Value())
-			}
+			value := c.ValueAsDate()
 			start, end := dates.DayToUTCRange(value, value.Location())
 
 			if c.Comparator() == contactql.ComparatorEqual {

--- a/contactql/es/es.go
+++ b/contactql/es/es.go
@@ -367,5 +367,5 @@ func not(queries ...elastic.Query) *elastic.BoolQuery {
 }
 
 func queryError(err string, args ...interface{}) error {
-	return contactql.NewQueryErrorf(err, args...)
+	return contactql.NewQueryError("", err, args...)
 }

--- a/contactql/es/es_test.go
+++ b/contactql/es/es_test.go
@@ -101,7 +101,7 @@ func TestElasticQuery(t *testing.T) {
 		}
 		env := envs.NewBuilder().WithTimezone(ny).WithRedactionPolicy(redactionPolicy).Build()
 
-		qlQuery, err := contactql.ParseQuery(tc.Query, env.RedactionPolicy(), env.DefaultCountry(), resolver)
+		qlQuery, err := contactql.ParseQuery(env, tc.Query, resolver)
 
 		var query elastic.Query
 		if err == nil {

--- a/contactql/es/testdata/to_query.json
+++ b/contactql/es/testdata/to_query.json
@@ -372,7 +372,7 @@
     {
         "description": "invalid datetime operand",
         "query": "dob=10",
-        "error": "string '10' couldn't be parsed as a date"
+        "error": "can't convert '10' to a date"
     },
     {
         "description": "invalid number >",
@@ -1336,7 +1336,7 @@
     {
         "description": "invalid created_on operand",
         "query": "created_on<dog",
-        "error": "string 'dog' couldn't be parsed as a date"
+        "error": "can't convert 'dog' to a date"
     },
     {
         "description": "valid tel is set",

--- a/contactql/evaluator_test.go
+++ b/contactql/evaluator_test.go
@@ -143,46 +143,11 @@ func TestEvaluateQuery(t *testing.T) {
 	}, map[string]assets.Group{})
 
 	for _, test := range tests {
-		parsed, err := contactql.ParseQuery(test.query, envs.RedactionPolicyNone, "", resolver)
+		parsed, err := contactql.ParseQuery(env, test.query, resolver)
 		assert.NoError(t, err, "unexpected error parsing '%s'", test.query)
 
 		actualResult, err := contactql.EvaluateQuery(env, parsed, testObj)
 		assert.NoError(t, err, "unexpected error evaluating '%s'", test.query)
 		assert.Equal(t, test.result, actualResult, "unexpected result for '%s'", test.query)
-	}
-}
-
-func TestEvaluationErrors(t *testing.T) {
-	env := envs.NewBuilder().Build()
-	var testObj = TestQueryable{
-		"name":   []interface{}{"Bob Smithwick"},
-		"gender": []interface{}{"male"},
-		"age":    []interface{}{decimal.NewFromFloat(36)},
-		"dob":    []interface{}{time.Date(1981, 5, 28, 13, 30, 23, 0, time.UTC)},
-	}
-
-	tests := []struct {
-		query  string
-		errMsg string
-	}{
-		{`age = 3X`, "can't convert '3X' to a number"},
-		{`dob = 32`, "can't convert '32' to a date"},
-		{`dob = 32 AND name = Bob`, "can't convert '32' to a date"},
-		{`name = Bob OR dob = 32`, "can't convert '32' to a date"},
-	}
-
-	resolver := contactql.NewMockResolver(map[string]assets.Field{
-		"age":    types.NewField(assets.FieldUUID("f1b5aea6-6586-41c7-9020-1a6326cc6565"), "age", "Age", assets.FieldTypeNumber),
-		"dob":    types.NewField(assets.FieldUUID("3810a485-3fda-4011-a589-7320c0b8dbef"), "dob", "DOB", assets.FieldTypeDatetime),
-		"gender": types.NewField(assets.FieldUUID("d66a7823-eada-40e5-9a3a-57239d4690bf"), "gender", "Gender", assets.FieldTypeText),
-	}, map[string]assets.Group{})
-
-	for _, test := range tests {
-		parsed, err := contactql.ParseQuery(test.query, envs.RedactionPolicyNone, "", resolver)
-		assert.NoError(t, err, "unexpected error parsing '%s'", test.query)
-
-		actualResult, err := contactql.EvaluateQuery(env, parsed, testObj)
-		assert.EqualError(t, err, test.errMsg, "unexpected error evaluating '%s'", test.query)
-		assert.False(t, actualResult, "unexpected non-false result for '%s'", test.query)
 	}
 }

--- a/contactql/inspect_test.go
+++ b/contactql/inspect_test.go
@@ -63,6 +63,7 @@ func TestInspect(t *testing.T) {
 		},
 	}
 
+	env := envs.NewBuilder().Build()
 	resolver := contactql.NewMockResolver(map[string]assets.Field{
 		"age":    types.NewField(assets.FieldUUID("f1b5aea6-6586-41c7-9020-1a6326cc6565"), "age", "Age", assets.FieldTypeNumber),
 		"dob":    types.NewField(assets.FieldUUID("3810a485-3fda-4011-a589-7320c0b8dbef"), "dob", "DOB", assets.FieldTypeDatetime),
@@ -72,7 +73,7 @@ func TestInspect(t *testing.T) {
 	})
 
 	for _, tc := range tests {
-		query, err := contactql.ParseQuery(tc.Query, envs.RedactionPolicyNone, envs.NilCountry, resolver)
+		query, err := contactql.ParseQuery(env, tc.Query, resolver)
 		require.NoError(t, err, "error parsing %s", tc.Query)
 
 		assert.Equal(t, tc.Inspection, contactql.Inspect(query), "inspect mismatch for query %s", tc.Query)

--- a/contactql/parser.go
+++ b/contactql/parser.go
@@ -71,12 +71,14 @@ type QueryNode interface {
 
 // Condition represents a comparison between a keywed value on the contact and a provided value
 type Condition struct {
-	propType   PropertyType
-	propKey    string
-	comparator Comparator
-	value      string
-	valueType  assets.FieldType
-	reference  assets.Reference
+	propType      PropertyType
+	propKey       string
+	comparator    Comparator
+	value         string
+	valueAsNumber decimal.Decimal
+	valueAsDate   time.Time
+	valueType     assets.FieldType
+	reference     assets.Reference
 }
 
 func newCondition(propType PropertyType, propKey string, comparator Comparator, value string, valueType assets.FieldType, reference assets.Reference) *Condition {
@@ -102,8 +104,14 @@ func (c *Condition) Comparator() Comparator { return c.comparator }
 // Value returns the value being compared against
 func (c *Condition) Value() string { return c.value }
 
+// ValueAsNumber returns the value as a number if value type is number
+func (c *Condition) ValueAsNumber() decimal.Decimal { return c.valueAsNumber }
+
+// ValueAsDate returns the value as a date if condition is datetime
+func (c *Condition) ValueAsDate() time.Time { return c.valueAsDate }
+
 // Validate checks that this condition is valid (and thus can be evaluated)
-func (c *Condition) Validate(resolver Resolver) error {
+func (c *Condition) Validate(env envs.Environment, resolver Resolver) error {
 	switch c.comparator {
 	case ComparatorContains:
 		if c.propKey == AttributeName {
@@ -116,36 +124,50 @@ func (c *Condition) Validate(resolver Resolver) error {
 			}
 		} else {
 			// ~ can only be used with the name/urn attributes or actual URNs
-			return NewQueryErrorf("contains conditions can only be used with name or URN values")
+			return NewQueryErrorf("contains conditions can only be used with name or URN values").withCode(ErrUnsupportedContains).withExtra("property", c.propKey)
 		}
 
 	case ComparatorGreaterThan, ComparatorGreaterThanOrEqual, ComparatorLessThan, ComparatorLessThanOrEqual:
 		if c.valueType != assets.FieldTypeNumber && c.valueType != assets.FieldTypeDatetime {
-			return NewQueryErrorf("comparisons with %s can only be used with date and number fields", c.comparator)
+			return NewQueryErrorf("comparisons with %s can only be used with date and number fields", c.comparator).withCode(ErrUnsupportedComparison).withExtra("property", c.propKey).withExtra("operator", string(c.comparator))
 		}
 	}
 
 	// if existence check, disallow certain attributes
-	if c.value == "" {
+	if (c.comparator == ComparatorEqual || c.comparator == ComparatorNotEqual) && c.value == "" {
 		switch c.propKey {
 		case AttributeUUID, AttributeID, AttributeCreatedOn, AttributeGroup:
-			return NewQueryErrorf("can't check whether '%s' is set or not set", c.propKey)
+			return NewQueryErrorf("can't check whether '%s' is set or not set", c.propKey).withCode(ErrUnsupportedSetCheck).withExtra("property", c.propKey).withExtra("operator", string(c.comparator))
 		}
 	} else {
 		// check values are valid for the attribute type
-		switch c.propKey {
-		case AttributeGroup:
+		if c.valueType == assets.FieldTypeNumber {
+			asDecimal, err := decimal.NewFromString(c.value)
+			if err != nil {
+				return NewQueryErrorf("can't convert '%s' to a number", c.value).withCode(ErrInvalidNumber).withExtra("value", c.value)
+			}
+			c.valueAsNumber = asDecimal
+
+		} else if c.valueType == assets.FieldTypeDatetime {
+			asDate, err := envs.DateTimeFromString(env, c.value, false)
+			if err != nil {
+				return NewQueryErrorf("can't convert '%s' to a date", c.value).withCode(ErrInvalidDate).withExtra("value", c.value)
+			}
+			c.valueAsDate = asDate
+
+		} else if c.propKey == AttributeGroup {
 			group := resolver.ResolveGroup(c.value)
 			if group == nil {
-				return NewQueryErrorf("'%s' is not a valid group name", c.value)
+				return NewQueryErrorf("'%s' is not a valid group name", c.value).withCode(ErrInvalidGroup).withExtra("value", c.value)
 			}
 			c.value = group.Name()
 			c.reference = assets.NewGroupReference(group.UUID(), group.Name())
-		case AttributeLanguage:
+
+		} else if c.propKey == AttributeLanguage {
 			if c.value != "" {
 				_, err := envs.ParseLanguage(c.value)
 				if err != nil {
-					return NewQueryErrorf("'%s' is not a valid language code", c.value)
+					return NewQueryErrorf("'%s' is not a valid language code", c.value).withCode(ErrInvalidLanguage).withExtra("value", c.value)
 				}
 			}
 		}
@@ -205,18 +227,10 @@ func (c *Condition) evaluateValue(env envs.Environment, val interface{}) (bool, 
 		return textComparison(val.(string), c.comparator, c.value, isName)
 
 	case decimal.Decimal:
-		asDecimal, err := decimal.NewFromString(c.value)
-		if err != nil {
-			return false, NewQueryErrorf("can't convert '%s' to a number", c.value)
-		}
-		return numberComparison(val.(decimal.Decimal), c.comparator, asDecimal)
+		return numberComparison(val.(decimal.Decimal), c.comparator, c.valueAsNumber)
 
 	case time.Time:
-		asDate, err := envs.DateTimeFromString(env, c.value, false)
-		if err != nil {
-			return false, NewQueryErrorf("can't convert '%s' to a date", c.value)
-		}
-		return dateComparison(val.(time.Time), c.comparator, asDate)
+		return dateComparison(val.(time.Time), c.comparator, c.valueAsDate)
 	}
 
 	panic(fmt.Sprintf("unsupported query data type: %T", val))
@@ -311,13 +325,13 @@ func (q *ContactQuery) String() string {
 }
 
 // ParseQuery parses a ContactQL query from the given input
-func ParseQuery(text string, redaction envs.RedactionPolicy, country envs.Country, resolver Resolver) (*ContactQuery, error) {
+func ParseQuery(env envs.Environment, text string, resolver Resolver) (*ContactQuery, error) {
 	// preprocess text before parsing
 	text = strings.TrimSpace(text)
 
 	// if query is a valid number, rewrite as a tel = query
-	if redaction != envs.RedactionPolicyURNs {
-		if number := utils.ParsePhoneNumber(text, string(country)); number != "" {
+	if env.RedactionPolicy() != envs.RedactionPolicyURNs {
+		if number := utils.ParsePhoneNumber(text, string(env.DefaultCountry())); number != "" {
 			text = fmt.Sprintf(`tel = %s`, number)
 		}
 	}
@@ -337,7 +351,7 @@ func ParseQuery(text string, redaction envs.RedactionPolicy, country envs.Countr
 		return nil, err
 	}
 
-	visitor := newVisitor(redaction, resolver)
+	visitor := newVisitor(env, resolver)
 	rootNode := visitor.Visit(tree).(QueryNode)
 
 	if len(visitor.errors) > 0 {
@@ -365,7 +379,7 @@ func (l *errorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol
 	switch typed := e.(type) {
 	case *antlr.InputMisMatchException:
 		token := typed.GetOffendingToken().GetText()
-		err = NewQueryError(msg, "query_unexpected_token", map[string]string{"token": token})
+		err = NewQueryErrorf(msg).withCode(ErrUnexpectedToken).withExtra("token", token)
 	default:
 		err = NewQueryErrorf(msg)
 	}

--- a/contactql/parser_test.go
+++ b/contactql/parser_test.go
@@ -50,7 +50,7 @@ func TestParseQuery(t *testing.T) {
 		{`name is ""`, `name = ""`, "", envs.RedactionPolicyNone},            // is not set
 		{`name != ""`, `name != ""`, "", envs.RedactionPolicyNone},           // is set
 		{`name != "felix"`, `name != "felix"`, "", envs.RedactionPolicyNone}, // is not equal to value
-		{`Name ~ ""`, ``, "value must contain a word of at least 2 characters long for a contains condition on name", envs.RedactionPolicyNone},
+		{`Name ~ ""`, ``, "contains operator on name requires token of minimum length 2", envs.RedactionPolicyNone},
 
 		// explicit attribute conditions
 		{`language = spa`, `language = "spa"`, "", envs.RedactionPolicyNone},
@@ -62,7 +62,7 @@ func TestParseQuery(t *testing.T) {
 		{`tel!=""`, `tel != ""`, "", envs.RedactionPolicyNone},
 		{`tel IS 233`, `tel = 233`, "", envs.RedactionPolicyNone},
 		{`tel HAS 233`, `tel ~ 233`, "", envs.RedactionPolicyNone},
-		{`tel ~ 23`, ``, "value must be least 3 characters long for a contains condition on a URN", envs.RedactionPolicyNone},
+		{`tel ~ 23`, ``, "contains operator on URN requires value of minimum length 3", envs.RedactionPolicyNone},
 		{`mailto = user@example.com`, `mailto = "user@example.com"`, "", envs.RedactionPolicyNone},
 		{`MAILTO ~ user@example.com`, `mailto ~ "user@example.com"`, "", envs.RedactionPolicyNone},
 		{`URN=ewok`, `urn = "ewok"`, "", envs.RedactionPolicyNone},

--- a/contactql/visitor.go
+++ b/contactql/visitor.go
@@ -54,15 +54,15 @@ type Resolver interface {
 type visitor struct {
 	gen.BaseContactQLVisitor
 
-	redaction envs.RedactionPolicy
-	resolver  Resolver
+	env      envs.Environment
+	resolver Resolver
 
 	errors []error
 }
 
 // creates a new ContactQL visitor
-func newVisitor(redaction envs.RedactionPolicy, resolver Resolver) *visitor {
-	return &visitor{redaction: redaction, resolver: resolver}
+func newVisitor(env envs.Environment, resolver Resolver) *visitor {
+	return &visitor{env: env, resolver: resolver}
 }
 
 // Visit the top level parse tree
@@ -81,7 +81,7 @@ func (v *visitor) VisitImplicitCondition(ctx *gen.ImplicitConditionContext) inte
 
 	asURN, _ := urns.Parse(value)
 
-	if v.redaction == envs.RedactionPolicyURNs {
+	if v.env.RedactionPolicy() == envs.RedactionPolicyURNs {
 		num, err := strconv.Atoi(value)
 		if err == nil {
 			return newCondition(PropertyTypeAttribute, AttributeID, ComparatorEqual, strconv.Itoa(num), attributes[AttributeID], nil)
@@ -105,7 +105,7 @@ func (v *visitor) VisitImplicitCondition(ctx *gen.ImplicitConditionContext) inte
 
 	condition := newCondition(PropertyTypeAttribute, AttributeName, comparator, value, attributes[AttributeName], nil)
 
-	if err := condition.Validate(v.resolver); err != nil {
+	if err := condition.Validate(v.env, v.resolver); err != nil {
 		v.addError(err)
 	}
 
@@ -131,8 +131,8 @@ func (v *visitor) VisitCondition(ctx *gen.ConditionContext) interface{} {
 	if isAttribute {
 		propType = PropertyTypeAttribute
 
-		if propKey == AttributeURN && v.redaction == envs.RedactionPolicyURNs && value != "" {
-			v.addError(NewQueryErrorf("cannot query on redacted URNs"))
+		if propKey == AttributeURN && v.env.RedactionPolicy() == envs.RedactionPolicyURNs && value != "" {
+			v.addError(NewQueryErrorf("cannot query on redacted URNs").withCode(ErrRedactedURNs))
 		}
 
 	} else if urns.IsValidScheme(propKey) {
@@ -140,8 +140,8 @@ func (v *visitor) VisitCondition(ctx *gen.ConditionContext) interface{} {
 		propType = PropertyTypeScheme
 		valueType = assets.FieldTypeText
 
-		if v.redaction == envs.RedactionPolicyURNs && value != "" {
-			v.addError(NewQueryErrorf("cannot query on redacted URNs"))
+		if v.env.RedactionPolicy() == envs.RedactionPolicyURNs && value != "" {
+			v.addError(NewQueryErrorf("cannot query on redacted URNs").withCode(ErrRedactedURNs))
 		}
 	} else {
 		field := v.resolver.ResolveField(propKey)
@@ -150,13 +150,13 @@ func (v *visitor) VisitCondition(ctx *gen.ConditionContext) interface{} {
 			valueType = field.Type()
 			reference = assets.NewFieldReference(field.Key(), field.Name())
 		} else {
-			v.addError(NewQueryErrorf("can't resolve '%s' to attribute, scheme or field", propKey))
+			v.addError(NewQueryErrorf("can't resolve '%s' to attribute, scheme or field", propKey).withCode(ErrUnknownProperty).withExtra("property", propKey))
 		}
 	}
 
 	condition := newCondition(propType, propKey, comparator, value, valueType, reference)
 
-	if err := condition.Validate(v.resolver); err != nil {
+	if err := condition.Validate(v.env, v.resolver); err != nil {
 		v.addError(err)
 	}
 

--- a/contactql/visitor.go
+++ b/contactql/visitor.go
@@ -132,7 +132,7 @@ func (v *visitor) VisitCondition(ctx *gen.ConditionContext) interface{} {
 		propType = PropertyTypeAttribute
 
 		if propKey == AttributeURN && v.env.RedactionPolicy() == envs.RedactionPolicyURNs && value != "" {
-			v.addError(NewQueryErrorf("cannot query on redacted URNs").withCode(ErrRedactedURNs))
+			v.addError(NewQueryError(ErrRedactedURNs, "cannot query on redacted URNs"))
 		}
 
 	} else if urns.IsValidScheme(propKey) {
@@ -141,7 +141,7 @@ func (v *visitor) VisitCondition(ctx *gen.ConditionContext) interface{} {
 		valueType = assets.FieldTypeText
 
 		if v.env.RedactionPolicy() == envs.RedactionPolicyURNs && value != "" {
-			v.addError(NewQueryErrorf("cannot query on redacted URNs").withCode(ErrRedactedURNs))
+			v.addError(NewQueryError(ErrRedactedURNs, "cannot query on redacted URNs"))
 		}
 	} else {
 		field := v.resolver.ResolveField(propKey)
@@ -150,7 +150,7 @@ func (v *visitor) VisitCondition(ctx *gen.ConditionContext) interface{} {
 			valueType = field.Type()
 			reference = assets.NewFieldReference(field.Key(), field.Name())
 		} else {
-			v.addError(NewQueryErrorf("can't resolve '%s' to attribute, scheme or field", propKey).withCode(ErrUnknownProperty).withExtra("property", propKey))
+			v.addError(NewQueryError(ErrUnknownProperty, "can't resolve '%s' to attribute, scheme or field", propKey).withExtra("property", propKey))
 		}
 	}
 

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -17,7 +17,6 @@ import (
 	"github.com/nyaruka/goflow/utils/uuids"
 
 	"github.com/pkg/errors"
-	"github.com/shopspring/decimal"
 	validator "gopkg.in/go-playground/validator.v9"
 )
 
@@ -450,7 +449,7 @@ func (c *Contact) QueryProperty(env envs.Environment, key string, propType conta
 			return []interface{}{string(c.uuid)}
 		case contactql.AttributeID:
 			if c.id != 0 {
-				return []interface{}{decimal.New(int64(c.id), 0)}
+				return []interface{}{fmt.Sprintf("%d", c.id)}
 			}
 			return nil
 		case contactql.AttributeName:

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -417,16 +417,16 @@ func TestContactQuery(t *testing.T) {
 	}
 
 	doQuery := func(q string, redaction envs.RedactionPolicy) (bool, error) {
-		query, err := contactql.ParseQuery(q, redaction, "US", session.Assets())
-		if err != nil {
-			return false, err
-		}
-
 		var env envs.Environment
 		if redaction == envs.RedactionPolicyURNs {
 			env = envs.NewBuilder().WithRedactionPolicy(envs.RedactionPolicyURNs).Build()
 		} else {
 			env = session.Environment()
+		}
+
+		query, err := contactql.ParseQuery(env, q, session.Assets())
+		if err != nil {
+			return false, err
 		}
 
 		return contactql.EvaluateQuery(env, query, contact)

--- a/flows/group.go
+++ b/flows/group.go
@@ -20,7 +20,7 @@ type Group struct {
 // NewGroup returns a new group object from the given group asset
 func NewGroup(env envs.Environment, fields *FieldAssets, asset assets.Group) (*Group, error) {
 	if asset.Query() != "" {
-		query, err := contactql.ParseQuery(asset.Query(), env.RedactionPolicy(), env.DefaultCountry(), fields)
+		query, err := contactql.ParseQuery(env, asset.Query(), fields)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Catch more errors at parse time, so that mailroom's parse_query returns errors for things like unparseable dates. Also means that the contactql and engine based evaluators have less separate error handling
* Error codes for all common error cases