### PR TITLE
📇 Allow URN inequality in elastic searches

### DIFF
--- a/contactql/es/es.go
+++ b/contactql/es/es.go
@@ -301,6 +301,8 @@ func conditionToElasticQuery(env envs.Environment, resolver contactql.Resolver, 
 
 			if c.Operator() == contactql.OpEqual {
 				return elastic.NewNestedQuery("urns", elastic.NewTermQuery("urns.path.keyword", value)), nil
+			} else if c.Operator() == contactql.OpNotEqual {
+				return not(elastic.NewNestedQuery("urns", elastic.NewTermQuery("urns.path.keyword", value))), nil
 			} else if c.Operator() == contactql.OpContains {
 				return elastic.NewNestedQuery("urns", elastic.NewMatchPhraseQuery("urns.path", value)), nil
 			} else {
@@ -348,6 +350,11 @@ func conditionToElasticQuery(env envs.Environment, resolver contactql.Resolver, 
 				elastic.NewTermQuery("urns.path.keyword", value),
 				elastic.NewTermQuery("urns.scheme", key)),
 			), nil
+		} else if c.Operator() == contactql.OpNotEqual {
+			return not(elastic.NewNestedQuery("urns", elastic.NewBoolQuery().Must(
+				elastic.NewTermQuery("urns.path.keyword", value),
+				elastic.NewTermQuery("urns.scheme", key)),
+			)), nil
 		} else if c.Operator() == contactql.OpContains {
 			return elastic.NewNestedQuery("urns", elastic.NewBoolQuery().Must(
 				elastic.NewMatchPhraseQuery("urns.path", value),

--- a/contactql/es/testdata/to_query.json
+++ b/contactql/es/testdata/to_query.json
@@ -1425,7 +1425,31 @@
     {
         "description": "tel scheme inequality",
         "query": "tel!=12345",
-        "error": "unsupported scheme comparator: !="
+        "elastic": {
+            "bool": {
+                "must_not": {
+                    "nested": {
+                        "path": "urns",
+                        "query": {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "term": {
+                                            "urns.path.keyword": "12345"
+                                        }
+                                    },
+                                    {
+                                        "term": {
+                                            "urns.scheme": "tel"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
     },
     {
         "description": "tel scheme contains",
@@ -1554,7 +1578,7 @@
         }
     },
     {
-        "description": "urn equality",
+        "description": "urn attribute equality",
         "query": "urn=\"+12067799192\"",
         "elastic": {
             "nested": {
@@ -1568,12 +1592,25 @@
         }
     },
     {
-        "description": "urn inequality",
+        "description": "urn attribute inequality",
         "query": "urn!=\"+12067799192\"",
-        "error": "unsupported urn comparator: !="
+        "elastic": {
+            "bool": {
+                "must_not": {
+                    "nested": {
+                        "path": "urns",
+                        "query": {
+                            "term": {
+                                "urns.path.keyword": "+12067799192"
+                            }
+                        }
+                    }
+                }
+            }
+        }
     },
     {
-        "description": "urn contains",
+        "description": "urn attribute contains",
         "query": "urn~12345",
         "elastic": {
             "nested": {


### PR DESCRIPTION
See #950. Tested locally and works fine. AFAIK this is the last little subtle difference between the engine and elastic search implementations.