### PR TITLE
🧮 Don't parse numbers in scientific notation

### DIFF
--- a/excellent/types/number_test.go
+++ b/excellent/types/number_test.go
@@ -16,6 +16,7 @@ func TestXNumber(t *testing.T) {
 	// test creation
 	assert.Equal(t, types.RequireXNumberFromString("123"), types.NewXNumberFromInt(123))
 	assert.Equal(t, types.RequireXNumberFromString("123"), types.NewXNumberFromInt64(123))
+	assert.Panics(t, func() { types.RequireXNumberFromString("xxx") })
 
 	// test equality
 	assert.True(t, types.NewXNumberFromInt(123).Equals(types.NewXNumberFromInt(123)))
@@ -59,11 +60,14 @@ func TestToXNumberAndInteger(t *testing.T) {
 		{types.NewXErrorf("Error"), types.XNumberZero, 0, true},
 		{types.NewXNumberFromInt(123), types.NewXNumberFromInt(123), 123, false},
 		{types.NewXText("15.5"), types.RequireXNumberFromString("15.5"), 15, false},
+		{types.NewXText("  15.4  "), types.RequireXNumberFromString("15.4"), 15, false},
 		{types.NewXObject(map[string]types.XValue{
 			"__default__": types.NewXNumberFromInt(123), // should use default
 			"foo":         types.NewXNumberFromInt(234),
 		}), types.NewXNumberFromInt(123), 123, false},
 		{types.NewXText("12345678901234567890"), types.RequireXNumberFromString("12345678901234567890"), 0, true}, // out of int range
+		{types.NewXText("1E100"), types.XNumberZero, 0, true},                                                     // scientific notation not allowed
+		{types.NewXText("1e100"), types.XNumberZero, 0, true},                                                     // scientific notation not allowed
 	}
 
 	env := envs.NewBuilder().Build()


### PR DESCRIPTION
Excellent doesn't support number literals written in scientific notation so I think we should be consistent when doing runtime parsing of numbers. I also don't think scientific notation is something we need to support and when parsing does occur its  accidental like when a string happens to look like `1E3153` etc... which then also leads to problems with very big numbers e.g. https://github.com/nyaruka/goflow/issues/963