### PR TITLE
📧 Better support for non-flow emailing

### DIFF
--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -214,7 +214,7 @@ func testActionType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 		// create an engine instance
 		eng := engine.NewBuilder().
 			WithEmailServiceFactory(func(flows.Session) (flows.EmailService, error) {
-				return smtp.NewService("mail.temba.io", 25, "nyaruka", "pass123", "flows@temba.io"), nil
+				return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io")
 			}).
 			WithWebhookServiceFactory(webhooks.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-testing"}, 100000)).
 			WithClassificationServiceFactory(func(s flows.Session, c *flows.Classifier) (flows.ClassificationService, error) {

--- a/services/email/smtp/service.go
+++ b/services/email/smtp/service.go
@@ -1,72 +1,25 @@
 package smtp
 
 import (
-	"fmt"
-	"net/url"
-	"strconv"
-
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils/smtpx"
-
-	"github.com/pkg/errors"
 )
 
 type service struct {
-	host     string
-	port     int
-	username string
-	password string
-	from     string
+	smtpClient *smtpx.Client
 }
 
 // NewService creates a new SMTP email service
-func NewService(host string, port int, username, password, from string) flows.EmailService {
-	return &service{
-		host:     host,
-		port:     port,
-		username: username,
-		password: password,
-		from:     from,
-	}
-}
-
-// NewServiceFromURL creates a new SMTP email service from a URL like smtp://user:pass@host:port/?from=from@example.com
-func NewServiceFromURL(connectionURL string) (flows.EmailService, error) {
-	url, err := url.Parse(connectionURL)
+func NewService(smtpURL string) (flows.EmailService, error) {
+	c, err := smtpx.NewClientFromURL(smtpURL)
 	if err != nil {
-		return nil, errors.New("malformed connection URL")
-	}
-	if url.Scheme != "smtp" {
-		return nil, errors.New("connection URL must use SMTP scheme")
+		return nil, err
 	}
 
-	host := url.Hostname()
-
-	// parse port if provided or default to 25
-	port := 25
-	if url.Port() != "" {
-		port, err = strconv.Atoi(url.Port())
-		if err != nil || port < 0 || port > 65535 {
-			return nil, errors.Errorf("%s is not a valid port number", url.Port())
-		}
-	}
-
-	// get the credentials
-	if url.User == nil {
-		return nil, errors.New("missing credentials in connection URL")
-	}
-	username := url.User.Username()
-	password, _ := url.User.Password()
-
-	// get our from address
-	from := url.Query().Get("from")
-	if from == "" {
-		from = fmt.Sprintf("%s@%s", username, host) // default to username@host if not set
-	}
-
-	return NewService(host, port, username, password, from), nil
+	return &service{smtpClient: c}, nil
 }
 
 func (s *service) Send(session flows.Session, addresses []string, subject, body string) error {
-	return smtpx.Send(s.host, s.port, s.username, s.password, s.from, addresses, subject, body)
+	m := smtpx.NewMessage(addresses, subject, body, "")
+	return smtpx.Send(s.smtpClient, m)
 }

--- a/services/email/smtp/service.go
+++ b/services/email/smtp/service.go
@@ -1,6 +1,8 @@
 package smtp
 
 import (
+	"strings"
+
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils/smtpx"
 )
@@ -20,6 +22,11 @@ func NewService(smtpURL string) (flows.EmailService, error) {
 }
 
 func (s *service) Send(session flows.Session, addresses []string, subject, body string) error {
+	// sending blank emails is a good way to get flagged as a spammer so use placeholder if body is empty
+	if strings.TrimSpace(body) == "" {
+		body = "(empty body)"
+	}
+
 	m := smtpx.NewMessage(addresses, subject, body, "")
 	return smtpx.Send(s.smtpClient, m)
 }

--- a/services/email/smtp/service_test.go
+++ b/services/email/smtp/service_test.go
@@ -27,4 +27,10 @@ func TestService(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"HELO localhost\nMAIL FROM:<updates@temba.io>\nRCPT TO:<bob@nyaruka.com>\nRCPT TO:<jim@nyaruka.com>\nDATA\nHave a great week\n.\nQUIT\n"}, sender.Logs())
+
+	// if body is blank, we'll use a placeholder
+	err = svc.Send(nil, []string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", " ")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "HELO localhost\nMAIL FROM:<updates@temba.io>\nRCPT TO:<bob@nyaruka.com>\nRCPT TO:<jim@nyaruka.com>\nDATA\n(empty body)\n.\nQUIT\n", sender.Logs()[1])
 }

--- a/services/email/smtp/service_test.go
+++ b/services/email/smtp/service_test.go
@@ -1,11 +1,13 @@
-package smtp
+package smtp_test
 
 import (
 	"testing"
 
+	"github.com/nyaruka/goflow/services/email/smtp"
 	"github.com/nyaruka/goflow/utils/smtpx"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestService(t *testing.T) {
@@ -14,45 +16,15 @@ func TestService(t *testing.T) {
 	sender := smtpx.NewMockSender("")
 	smtpx.SetSender(sender)
 
-	svc := NewService("mail.temba.io", 255, "leah", "pass123", "updates@temba.io")
-	err := svc.Send(nil, []string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", "Have a great week")
+	// try with invalid URL
+	_, err := smtp.NewService("xyz")
+	assert.EqualError(t, err, "connection URL must use SMTP scheme")
+
+	svc, err := smtp.NewService("smtp://leah:pass123@temba.io:255?from=updates@temba.io")
+	require.NoError(t, err)
+
+	err = svc.Send(nil, []string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", "Have a great week")
 
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"HELO localhost\nMAIL FROM:<updates@temba.io>\nRCPT TO:<bob@nyaruka.com>\nRCPT TO:<jim@nyaruka.com>\nDATA\nHave a great week\n.\nQUIT\n"}, sender.Logs())
-}
-
-func TestNewServiceFromURL(t *testing.T) {
-	defer smtpx.SetSender(smtpx.DefaultSender)
-
-	sender := smtpx.NewMockSender("")
-	smtpx.SetSender(sender)
-
-	_, err := NewServiceFromURL(":")
-	assert.EqualError(t, err, "malformed connection URL")
-
-	_, err = NewServiceFromURL("http://")
-	assert.EqualError(t, err, "connection URL must use SMTP scheme")
-
-	_, err = NewServiceFromURL("smtp://temba.io:1234567890")
-	assert.EqualError(t, err, "1234567890 is not a valid port number")
-
-	_, err = NewServiceFromURL("smtp://temba.io:25")
-	assert.EqualError(t, err, "missing credentials in connection URL")
-
-	// from and port are optional
-	svc, err := NewServiceFromURL("smtp://leah:pass123@temba.io")
-	assert.NoError(t, err)
-	assert.Equal(t, "temba.io", svc.(*service).host)
-	assert.Equal(t, 25, svc.(*service).port)
-	assert.Equal(t, "leah", svc.(*service).username)
-	assert.Equal(t, "pass123", svc.(*service).password)
-	assert.Equal(t, "leah@temba.io", svc.(*service).from)
-
-	svc, err = NewServiceFromURL("smtp://leah:pass123@temba.io:255?from=updates@temba.io")
-	assert.NoError(t, err)
-	assert.Equal(t, "temba.io", svc.(*service).host)
-	assert.Equal(t, 255, svc.(*service).port)
-	assert.Equal(t, "leah", svc.(*service).username)
-	assert.Equal(t, "pass123", svc.(*service).password)
-	assert.Equal(t, "updates@temba.io", svc.(*service).from)
 }

--- a/test/runner_test.go
+++ b/test/runner_test.go
@@ -119,7 +119,7 @@ func runFlow(assetsPath string, rawTrigger json.RawMessage, rawResumes []json.Ra
 
 	eng := engine.NewBuilder().
 		WithEmailServiceFactory(func(flows.Session) (flows.EmailService, error) {
-			return smtp.NewService("mail.temba.io", 25, "nyaruka", "pass123", "flows@temba.io"), nil
+			return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io")
 		}).
 		WithWebhookServiceFactory(webhooks.NewServiceFactory(http.DefaultClient, nil, nil, map[string]string{"User-Agent": "goflow-testing"}, 100000)).
 		WithClassificationServiceFactory(func(s flows.Session, c *flows.Classifier) (flows.ClassificationService, error) {

--- a/utils/smtpx/client.go
+++ b/utils/smtpx/client.go
@@ -1,0 +1,83 @@
+package smtpx
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/go-mail/mail"
+	"github.com/pkg/errors"
+)
+
+// Client is an SMTP client
+type Client struct {
+	host     string
+	port     int
+	username string
+	password string
+	from     string
+}
+
+// NewClient creates a new client
+func NewClient(host string, port int, username, password, from string) *Client {
+	return &Client{
+		host:     host,
+		port:     port,
+		username: username,
+		password: password,
+		from:     from,
+	}
+}
+
+// NewClientFromURL creates a client from a URL like smtp://user:pass@host:port/?from=from@example.com
+func NewClientFromURL(connectionURL string) (*Client, error) {
+	url, err := url.Parse(connectionURL)
+	if err != nil {
+		return nil, errors.New("malformed connection URL")
+	}
+	if url.Scheme != "smtp" {
+		return nil, errors.New("connection URL must use SMTP scheme")
+	}
+
+	host := url.Hostname()
+
+	// parse port if provided or default to 25
+	port := 25
+	if url.Port() != "" {
+		port, err = strconv.Atoi(url.Port())
+		if err != nil || port < 0 || port > 65535 {
+			return nil, errors.Errorf("%s is not a valid port number", url.Port())
+		}
+	}
+
+	// get the credentials
+	if url.User == nil {
+		return nil, errors.New("missing credentials in connection URL")
+	}
+	username := url.User.Username()
+	password, _ := url.User.Password()
+
+	// get our from address
+	from := url.Query().Get("from")
+	if from == "" {
+		from = fmt.Sprintf("%s@%s", username, host) // default to username@host if not set
+	}
+
+	return NewClient(host, port, username, password, from), nil
+}
+
+// Send sends the given message
+func (c *Client) Send(m *Message) error {
+	// create MIME message
+	mm := mail.NewMessage()
+	mm.SetHeader("From", c.from)
+	mm.SetHeader("To", m.recipients...)
+	mm.SetHeader("Subject", m.subject)
+	mm.SetBody("text/plain", m.text)
+	if m.html != "" {
+		mm.AddAlternative("text/html", m.html)
+	}
+
+	d := mail.NewDialer(c.host, c.port, c.username, c.password)
+	return d.DialAndSend(mm)
+}

--- a/utils/smtpx/client_test.go
+++ b/utils/smtpx/client_test.go
@@ -1,0 +1,38 @@
+package smtpx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClientFromURL(t *testing.T) {
+	_, err := NewClientFromURL(":")
+	assert.EqualError(t, err, "malformed connection URL")
+
+	_, err = NewClientFromURL("http://")
+	assert.EqualError(t, err, "connection URL must use SMTP scheme")
+
+	_, err = NewClientFromURL("smtp://temba.io:1234567890")
+	assert.EqualError(t, err, "1234567890 is not a valid port number")
+
+	_, err = NewClientFromURL("smtp://temba.io:25")
+	assert.EqualError(t, err, "missing credentials in connection URL")
+
+	// from and port are optional
+	s, err := NewClientFromURL("smtp://leah:pass123@temba.io")
+	assert.NoError(t, err)
+	assert.Equal(t, "temba.io", s.host)
+	assert.Equal(t, 25, s.port)
+	assert.Equal(t, "leah", s.username)
+	assert.Equal(t, "pass123", s.password)
+	assert.Equal(t, "leah@temba.io", s.from)
+
+	s, err = NewClientFromURL("smtp://leah:pass123@temba.io:255?from=updates@temba.io")
+	assert.NoError(t, err)
+	assert.Equal(t, "temba.io", s.host)
+	assert.Equal(t, 255, s.port)
+	assert.Equal(t, "leah", s.username)
+	assert.Equal(t, "pass123", s.password)
+	assert.Equal(t, "updates@temba.io", s.from)
+}

--- a/utils/smtpx/mock.go
+++ b/utils/smtpx/mock.go
@@ -12,27 +12,29 @@ type MockSender struct {
 	logs []string
 }
 
+// NewMockSender creates a new mock sender
 func NewMockSender(err string) *MockSender {
 	return &MockSender{err: err}
 }
 
+// Logs returns the send logs
 func (s *MockSender) Logs() []string {
 	return s.logs
 }
 
-func (s *MockSender) Send(host string, port int, username, password, from string, recipients []string, subject, body string) error {
+func (s *MockSender) Send(c *Client, m *Message) error {
 	if s.err != "" {
 		return errors.New(s.err)
 	}
 
 	b := &strings.Builder{}
 	b.WriteString("HELO localhost\n")
-	b.WriteString(fmt.Sprintf("MAIL FROM:<%s>\n", from))
-	for _, r := range recipients {
+	b.WriteString(fmt.Sprintf("MAIL FROM:<%s>\n", c.from))
+	for _, r := range m.recipients {
 		b.WriteString(fmt.Sprintf("RCPT TO:<%s>\n", r))
 	}
 	b.WriteString("DATA\n")
-	b.WriteString(fmt.Sprintf("%s\n", body))
+	b.WriteString(fmt.Sprintf("%s\n", m.text))
 	b.WriteString(".\n")
 	b.WriteString("QUIT\n")
 

--- a/utils/smtpx/mock_test.go
+++ b/utils/smtpx/mock_test.go
@@ -15,9 +15,14 @@ func TestMockSender(t *testing.T) {
 	sender := smtpx.NewMockSender("")
 	smtpx.SetSender(sender)
 
-	err := smtpx.Send("mail.temba.io", 255, "leah", "pass123", "updates@temba.io", []string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", "Have a great week")
+	c := smtpx.NewClient("mail.temba.io", 255, "leah", "pass123", "updates@temba.io")
+
+	msg1 := smtpx.NewMessage([]string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", "Have a great week", "<p>Have a great week</p>")
+	msg2 := smtpx.NewMessage([]string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", "Have a great weekend", "")
+
+	err := smtpx.Send(c, msg1)
 	assert.NoError(t, err)
-	err = smtpx.Send("mail.temba.io", 255, "leah", "pass123", "updates@temba.io", []string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", "Have a great weekend")
+	err = smtpx.Send(c, msg2)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{
@@ -29,7 +34,7 @@ func TestMockSender(t *testing.T) {
 	sender = smtpx.NewMockSender("oops can't send")
 	smtpx.SetSender(sender)
 
-	err = smtpx.Send("mail.temba.io", 25, "leah", "pass123", "updates@temba.io", []string{"bob@nyaruka.com", "jim@nyaruka.com"}, "Updates", "Have a great week")
+	err = smtpx.Send(c, msg1)
 
 	assert.EqualError(t, err, "oops can't send")
 	assert.Equal(t, 0, len(sender.Logs()))

--- a/utils/smtpx/smtp.go
+++ b/utils/smtpx/smtp.go
@@ -1,32 +1,37 @@
 package smtpx
 
-import (
-	"github.com/go-mail/mail"
-)
+// Message is email message
+type Message struct {
+	recipients []string
+	subject    string
+	text       string
+	html       string
+}
+
+// NewMessage creates a new message
+func NewMessage(recipients []string, subject, text, html string) *Message {
+	return &Message{
+		recipients: recipients,
+		subject:    subject,
+		text:       text,
+		html:       html,
+	}
+}
 
 // Send an email using SMTP
-func Send(host string, port int, username, password, from string, recipients []string, subject, body string) error {
-	return currentSender.Send(host, port, username, password, from, recipients, subject, body)
+func Send(c *Client, m *Message) error {
+	return currentSender.Send(c, m)
 }
 
 // Sender is anything that can send an email
 type Sender interface {
-	Send(host string, port int, username, password, from string, recipients []string, subject, body string) error
+	Send(*Client, *Message) error
 }
 
 type defaultSender struct{}
 
-func (s defaultSender) Send(host string, port int, username, password, from string, recipients []string, subject, body string) error {
-	// create our dialer for our org
-	d := mail.NewDialer(host, port, username, password)
-
-	m := mail.NewMessage()
-	m.SetHeader("From", from)
-	m.SetHeader("To", recipients...)
-	m.SetHeader("Subject", subject)
-	m.SetBody("text/plain", body)
-
-	return d.DialAndSend(m)
+func (s defaultSender) Send(c *Client, m *Message) error {
+	return c.Send(m)
 }
 
 // DefaultSender is the default SMTP sender


### PR DESCRIPTION
Reworks the `utils/smtpx` package into something more like `httpx` so it could be used by mailroom for emails outside of flows, and addresses https://github.com/nyaruka/goflow/issues/955