### PR TITLE
URN and channel modifiers should error with invalid URNs and channels

### DIFF
--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -1,14 +1,13 @@
 package actions
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/flows/modifiers"
-
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -68,12 +67,8 @@ func (a *AddContactURNAction) Execute(run flows.FlowRun, step flows.Step, logMod
 		return nil
 	}
 
-	// if we don't have a valid URN, log error
-	urn, err := urns.NewURNFromParts(a.Scheme, evaluatedPath, "", "")
-	if err != nil {
-		logEvent(events.NewError(errors.Wrapf(err, "unable to add URN '%s:%s'", a.Scheme, evaluatedPath)))
-		return nil
-	}
+	// create URN - modifier will take care of validating it
+	urn := urns.URN(fmt.Sprintf("%s:%s", a.Scheme, evaluatedPath))
 
 	a.applyModifier(run, modifiers.NewURNs([]urns.URN{urn}, modifiers.URNsAppend), logModifier, logEvent)
 	return nil

--- a/flows/actions/set_contact_channel.go
+++ b/flows/actions/set_contact_channel.go
@@ -56,11 +56,6 @@ func (a *SetContactChannelAction) Execute(run flows.FlowRun, step flows.Step, lo
 			logEvent(events.NewDependencyError(a.Channel))
 			return nil
 		}
-
-		if !channel.HasRole(assets.ChannelRoleSend) {
-			logEvent(events.NewErrorf("can't set channel that can't send as the preferred channel"))
-			return nil
-		}
 	}
 
 	a.applyModifier(run, modifiers.NewChannel(channel), logModifier, logEvent)

--- a/flows/actions/testdata/add_contact_urn.json
+++ b/flows/actions/testdata/add_contact_urn.json
@@ -72,6 +72,23 @@
         ]
     },
     {
+        "description": "Error event if final URN is invalid",
+        "action": {
+            "type": "add_contact_urn",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "scheme": "telegram",
+            "path": "qwerty"
+        },
+        "events": [
+            {
+                "type": "error",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
+                "text": "'telegram:qwerty' is not valid URN"
+            }
+        ]
+    },
+    {
         "description": "NOOP if URN already exists on contact",
         "action": {
             "type": "add_contact_urn",

--- a/flows/modifiers/channel.go
+++ b/flows/modifiers/channel.go
@@ -34,9 +34,12 @@ func NewChannel(channel *flows.Channel) *ChannelModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *ChannelModifier) Apply(env envs.Environment, assets flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) {
-	// if URNs change in anyway, generate a URNs changed event
-	if contact.UpdatePreferredChannel(m.channel) {
+func (m *ChannelModifier) Apply(env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) {
+	if m.channel != nil && !m.channel.HasRole(assets.ChannelRoleSend) {
+		log(events.NewErrorf("can't set channel that can't send as the preferred channel"))
+
+	} else if contact.UpdatePreferredChannel(m.channel) {
+		// if URNs change in anyway, generate a URNs changed event
 		log(events.NewContactURNsChanged(contact.URNs().RawURNs()))
 	}
 }

--- a/flows/modifiers/testdata/_assets.json
+++ b/flows/modifiers/testdata/_assets.json
@@ -36,6 +36,17 @@
                 "send",
                 "receive"
             ]
+        },
+        {
+            "uuid": "eb9fee95-d762-4679-a7d5-91532e400c54",
+            "name": "Receive Only",
+            "address": "56789",
+            "schemes": [
+                "ext"
+            ],
+            "roles": [
+                "receive"
+            ]
         }
     ],
     "fields": [

--- a/flows/modifiers/testdata/channel.json
+++ b/flows/modifiers/testdata/channel.json
@@ -106,5 +106,42 @@
                 ]
             }
         ]
+    },
+    {
+        "description": "error event if channel can't send",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "urns": [
+                "tel:+12065551212?channel=3a05eaf5-cb1b-4246-bef1-f277419c83a7&id=123",
+                "twitterid:54784326227#nyaruka"
+            ],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "channel",
+            "channel": {
+                "uuid": "eb9fee95-d762-4679-a7d5-91532e400c54",
+                "name": "Receive Only"
+            }
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "created_on": "2018-06-20T11:40:30.123456789Z",
+            "urns": [
+                "tel:+12065551212?channel=3a05eaf5-cb1b-4246-bef1-f277419c83a7&id=123",
+                "twitterid:54784326227#nyaruka"
+            ]
+        },
+        "events": [
+            {
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "text": "can't set channel that can't send as the preferred channel",
+                "type": "error"
+            }
+        ]
     }
 ]

--- a/flows/modifiers/testdata/urns.json
+++ b/flows/modifiers/testdata/urns.json
@@ -220,5 +220,42 @@
             ]
         },
         "events": []
+    },
+    {
+        "description": "error event if URN invalid",
+        "contact_before": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "urns": [
+                "tel:+17010000000",
+                "tel:+17012222222"
+            ],
+            "created_on": "2018-06-20T11:40:30.123456789Z"
+        },
+        "modifier": {
+            "type": "urns",
+            "urns": [
+                "xyz:12345"
+            ],
+            "modification": "append"
+        },
+        "contact_after": {
+            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
+            "name": "Bob",
+            "status": "active",
+            "created_on": "2018-06-20T11:40:30.123456789Z",
+            "urns": [
+                "tel:+17010000000",
+                "tel:+17012222222"
+            ]
+        },
+        "events": [
+            {
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "text": "'xyz:12345' is not valid URN",
+                "type": "error"
+            }
+        ]
     }
 ]

--- a/flows/modifiers/urns.go
+++ b/flows/modifiers/urns.go
@@ -57,10 +57,14 @@ func (m *URNsModifier) Apply(env envs.Environment, assets flows.SessionAssets, c
 		// normalize the URN
 		urn := urn.Normalize(string(env.DefaultCountry()))
 
-		if m.Modification == URNsAppend || m.Modification == URNsSet {
-			modified = contact.AddURN(urn, nil)
+		if err := urn.Validate(); err != nil {
+			log(events.NewErrorf("'%s' is not valid URN", urn))
 		} else {
-			modified = contact.RemoveURN(urn)
+			if m.Modification == URNsAppend || m.Modification == URNsSet {
+				modified = contact.AddURN(urn, nil)
+			} else {
+				modified = contact.RemoveURN(urn)
+			}
 		}
 	}
 


### PR DESCRIPTION
Pushes error checking down from the action to the modifier so that when we use modifiers without actions in mailroom, we still get error events