### PR TITLE
🧮 Add workaround for exponent expressions with non-integer exponents

### DIFF
--- a/excellent/operators/builtin_test.go
+++ b/excellent/operators/builtin_test.go
@@ -72,6 +72,9 @@ func TestBinaryOperators(t *testing.T) {
 
 		{operators.Exponent, xi(3), xi(2), xi(9)},
 		{operators.Exponent, xs("3"), xs("2"), xi(9)},
+		{operators.Exponent, xn("2"), xn("32.000"), xn("4294967296")},
+		{operators.Exponent, xn("9"), xn("0.5"), xn("3")},
+		{operators.Exponent, xn("4"), xn("2.5"), xn("32")},
 		{operators.Exponent, ERROR, xi(1), ERROR},
 		{operators.Exponent, xi(1), ERROR, ERROR},
 


### PR DESCRIPTION
`float64` workaround for #984