### PR TITLE
📏 Log error event and skip when attachment is longer than 2048 limit

### DIFF
--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -23,6 +23,9 @@ import (
 // max number of bytes to be saved to extra on a result
 const resultExtraMaxBytes = 10000
 
+// max length of a message attachment (type:url)
+const maxAttachmentLength = 2048
+
 // common category names
 const (
 	CategorySuccess = "Success"
@@ -94,6 +97,10 @@ func (a *baseAction) evaluateMessage(run flows.FlowRun, languages []envs.Languag
 		}
 		if evaluatedAttachment == "" {
 			logEvent(events.NewErrorf("attachment text evaluated to empty string, skipping"))
+			continue
+		}
+		if len(evaluatedAttachment) > maxAttachmentLength {
+			logEvent(events.NewErrorf("evaluated attachment is longer than %d limit, skipping", maxAttachmentLength))
 			continue
 		}
 		evaluatedAttachments = append(evaluatedAttachments, utils.Attachment(evaluatedAttachment))

--- a/flows/actions/testdata/send_msg.json
+++ b/flows/actions/testdata/send_msg.json
@@ -190,6 +190,43 @@
         ]
     },
     {
+        "description": "Attachments skipped if they evaluate to something too long",
+        "action": {
+            "type": "send_msg",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "text": "Hi there",
+            "attachments": [
+                "@(json(run) & json(run) & json(run))",
+                "image/jpeg:http://exacmple.com/test.jpg"
+            ]
+        },
+        "events": [
+            {
+                "type": "error",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
+                "text": "evaluated attachment is longer than 2048 limit, skipping"
+            },
+            {
+                "type": "msg_created",
+                "created_on": "2018-10-18T14:20:30.000123456Z",
+                "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
+                "msg": {
+                    "uuid": "9688d21d-95aa-4bed-afc7-f31b35731a3d",
+                    "urn": "tel:+12065551212?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=123",
+                    "channel": {
+                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
+                        "name": "My Android Phone"
+                    },
+                    "text": "Hi there",
+                    "attachments": [
+                        "image/jpeg:http://exacmple.com/test.jpg"
+                    ]
+                }
+            }
+        ]
+    },
+    {
         "description": "Msg text that includes globals",
         "action": {
             "type": "send_msg",


### PR DESCRIPTION
Does #1000 and stops us from blowing up when mailroom tries to save the message