### PR TITLE
Ticket tweaks

### DIFF
--- a/flows/contact.go
+++ b/flows/contact.go
@@ -313,6 +313,7 @@ func (c *Contact) Format(env envs.Environment) string {
 //   groups:[]group -> the groups the contact belongs to
 //   fields:fields -> the custom field values of the contact
 //   channel:channel -> the preferred channel of the contact
+//   tickets:[]ticket -> the open tickets of the contact
 //
 // @context contact
 func (c *Contact) Context(env envs.Environment) map[string]types.XValue {

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -128,7 +128,7 @@ func TestContact(t *testing.T) {
 
 	assert.Equal(t, 0, contact.Tickets().Count())
 
-	ticket := flows.NewTicket(sa.Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5"), "New ticket", "I have issues", "654321")
+	ticket := flows.NewTicket(sa.Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5"), "New ticket", "I have issues")
 	contact.Tickets().Add(ticket)
 
 	assert.Equal(t, 1, contact.Tickets().Count())

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -42,6 +42,8 @@ func TestEventMarshaling(t *testing.T) {
 	timeout := 500
 	gender := session.Assets().Fields().Get("gender")
 	mailgun := session.Assets().Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5")
+	ticket := flows.NewTicket(mailgun, "Need help", "Where are my cookies?")
+	ticket.ExternalID = "1243252"
 
 	eventTests := []struct {
 		event     flows.Event
@@ -413,7 +415,7 @@ func TestEventMarshaling(t *testing.T) {
 					},
 					"text": "Hi there",
 					"urn": "tel:+12345678900",
-					"uuid": "20cc4181-48cf-4344-9751-99419796decd"
+					"uuid": "04e910a5-d2e3-448b-958a-630e35c62431"
 				},
 				"type": "ivr_created"
 			}`,
@@ -502,19 +504,12 @@ func TestEventMarshaling(t *testing.T) {
 			}`,
 		},
 		{
-			events.NewTicketOpened(
-				flows.NewTicket(
-					mailgun,
-					"Need help",
-					"Where are my cookies?",
-					"1243252",
-				),
-			),
+			events.NewTicketOpened(ticket),
 			`{
 				"type": "ticket_opened",
 				"created_on": "2018-10-18T14:20:30.000123456Z",
 				"ticket": {
-					"uuid": "04e910a5-d2e3-448b-958a-630e35c62431",
+					"uuid": "20cc4181-48cf-4344-9751-99419796decd",
 					"ticketer": {
 						"uuid": "19dc6346-9623-4fe4-be80-538d493ecdf5",
 						"name": "Support Tickets"

--- a/flows/tickets.go
+++ b/flows/tickets.go
@@ -17,21 +17,34 @@ type baseTicket struct {
 	ExternalID string     `json:"external_id,omitempty"`
 }
 
-// Ticket is a ticket in a ticketing system
-type Ticket struct {
-	Ticketer *Ticketer
-	baseTicket
-}
-
 // TicketReference is a ticket with a reference to the ticketer
 type TicketReference struct {
 	Ticketer *assets.TicketerReference `json:"ticketer"`
 	baseTicket
 }
 
-// NewTicket creates a new ticket
-func NewTicket(ticketer *Ticketer, subject, body, externalID string) *Ticket {
-	return newTicket(TicketUUID(uuids.New()), ticketer, subject, body, externalID)
+// NewTicketReference creates a new ticket with a reference to the ticketer
+func NewTicketReference(uuid TicketUUID, ticketer *assets.TicketerReference, subject, body, externalID string) *TicketReference {
+	return &TicketReference{
+		baseTicket: baseTicket{
+			UUID:       uuid,
+			Subject:    subject,
+			Body:       body,
+			ExternalID: externalID,
+		},
+		Ticketer: ticketer,
+	}
+}
+
+// Ticket is a ticket in a ticketing system
+type Ticket struct {
+	Ticketer *Ticketer
+	baseTicket
+}
+
+// NewTicket creates a new ticket. Used by ticketing services to open a new ticket.
+func NewTicket(ticketer *Ticketer, subject, body string) *Ticket {
+	return newTicket(TicketUUID(uuids.New()), ticketer, subject, body, "")
 }
 
 // creates a new ticket

--- a/test/engine.go
+++ b/test/engine.go
@@ -120,7 +120,9 @@ func (s *ticketService) Open(session flows.Session, subject, body string, logHTT
 		ElapsedMS: 1,
 	})
 
-	return flows.NewTicket(s.ticketer, subject, body, "123456"), nil
+	ticket := flows.NewTicket(s.ticketer, subject, body)
+	ticket.ExternalID = "123456"
+	return ticket, nil
 }
 
 // implementation of an airtime service for testing which uses a fixed currency


### PR DESCRIPTION
 * Remove externalID as arg to `flows.NewTicket` since it's never used that way
 * Add way to create new ticket reference instances
 * Add contact tickets to editor autocompletion