### PR TITLE
Get rid of ticket references

### DIFF
--- a/flows/actions/open_ticket.go
+++ b/flows/actions/open_ticket.go
@@ -65,7 +65,7 @@ func (a *OpenTicketAction) Execute(run flows.FlowRun, step flows.Step, logModifi
 
 	ticket := a.open(run, step, ticketer, evaluatedSubject, evaluatedBody, logEvent)
 	if ticket != nil {
-		a.saveResult(run, step, a.ResultName, string(ticket.UUID), CategorySuccess, "", "", nil, logEvent)
+		a.saveResult(run, step, a.ResultName, string(ticket.UUID()), CategorySuccess, "", "", nil, logEvent)
 	} else {
 		a.saveResult(run, step, a.ResultName, "", CategoryFailure, "", "", nil, logEvent)
 	}

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -128,7 +128,7 @@ func TestContact(t *testing.T) {
 
 	assert.Equal(t, 0, contact.Tickets().Count())
 
-	ticket := flows.NewTicket(sa.Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5"), "New ticket", "I have issues")
+	ticket := flows.OpenTicket(sa.Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5"), "New ticket", "I have issues")
 	contact.Tickets().Add(ticket)
 
 	assert.Equal(t, 1, contact.Tickets().Count())

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -2,6 +2,7 @@ package flows_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -33,6 +34,13 @@ func TestContact(t *testing.T) {
 				"schemes": ["tel"],
 				"roles": ["send", "receive"],
 				"country": "US"
+			}
+		],
+		"ticketers": [
+			{
+				"uuid": "d605bb96-258d-4097-ad0a-080937db2212",
+				"name": "Support Tickets",
+				"type": "mailgun"
 			}
 		]
 	}`))
@@ -128,7 +136,7 @@ func TestContact(t *testing.T) {
 
 	assert.Equal(t, 0, contact.Tickets().Count())
 
-	ticket := flows.OpenTicket(sa.Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5"), "New ticket", "I have issues")
+	ticket := flows.OpenTicket(sa.Ticketers().Get("d605bb96-258d-4097-ad0a-080937db2212"), "New ticket", "I have issues")
 	contact.Tickets().Add(ticket)
 
 	assert.Equal(t, 1, contact.Tickets().Count())
@@ -166,6 +174,16 @@ func TestContact(t *testing.T) {
 	assert.True(t, contact.ClearURNs()) // did have URNs
 	assert.False(t, contact.ClearURNs())
 	assert.Equal(t, flows.URNList{}, contact.URNs())
+
+	marshaled, err := jsonx.Marshal(contact)
+	require.NoError(t, err)
+
+	fmt.Println(string(marshaled))
+
+	unmarshaled, err := flows.ReadContact(sa, marshaled, assets.PanicOnMissing)
+	require.NoError(t, err)
+
+	assert.True(t, contact.Equal(unmarshaled))
 }
 
 func TestReadContact(t *testing.T) {

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -42,8 +42,7 @@ func TestEventMarshaling(t *testing.T) {
 	timeout := 500
 	gender := session.Assets().Fields().Get("gender")
 	mailgun := session.Assets().Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5")
-	ticket := flows.NewTicket(mailgun, "Need help", "Where are my cookies?")
-	ticket.ExternalID = "1243252"
+	ticket := flows.NewTicket("7481888c-07dd-47dc-bf22-ef7448696ffe", mailgun, "Need help", "Where are my cookies?", "1243252")
 
 	eventTests := []struct {
 		event     flows.Event
@@ -424,7 +423,7 @@ func TestEventMarshaling(t *testing.T) {
 					},
 					"text": "Hi there",
 					"urn": "tel:+12345678900",
-					"uuid": "04e910a5-d2e3-448b-958a-630e35c62431"
+					"uuid": "20cc4181-48cf-4344-9751-99419796decd"
 				},
 				"type": "ivr_created"
 			}`,
@@ -518,7 +517,7 @@ func TestEventMarshaling(t *testing.T) {
 				"type": "ticket_opened",
 				"created_on": "2018-10-18T14:20:30.000123456Z",
 				"ticket": {
-					"uuid": "20cc4181-48cf-4344-9751-99419796decd",
+					"uuid": "7481888c-07dd-47dc-bf22-ef7448696ffe",
 					"ticketer": {
 						"uuid": "19dc6346-9623-4fe4-be80-538d493ecdf5",
 						"name": "Support Tickets"

--- a/flows/events/ticket_opened.go
+++ b/flows/events/ticket_opened.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 )
 
@@ -10,6 +11,14 @@ func init() {
 
 // TypeTicketOpened is the type for our ticket opened events
 const TypeTicketOpened string = "ticket_opened"
+
+type Ticket struct {
+	UUID       flows.TicketUUID          `json:"uuid"                   validate:"required,uuid4"`
+	Ticketer   *assets.TicketerReference `json:"ticketer"               validate:"required,dive"`
+	Subject    string                    `json:"subject"`
+	Body       string                    `json:"body"`
+	ExternalID string                    `json:"external_id,omitempty"`
+}
 
 // TicketOpenedEvent events are created when a new ticket is opened.
 //
@@ -32,13 +41,19 @@ const TypeTicketOpened string = "ticket_opened"
 type TicketOpenedEvent struct {
 	baseEvent
 
-	Ticket *flows.TicketReference `json:"ticket"`
+	Ticket *Ticket `json:"ticket"`
 }
 
 // NewTicketOpened returns a new ticket opened event
 func NewTicketOpened(ticket *flows.Ticket) *TicketOpenedEvent {
 	return &TicketOpenedEvent{
 		baseEvent: newBaseEvent(TypeTicketOpened),
-		Ticket:    ticket.Reference(),
+		Ticket: &Ticket{
+			UUID:       ticket.UUID(),
+			Ticketer:   ticket.Ticketer().Reference(),
+			Subject:    ticket.Subject(),
+			Body:       ticket.Body(),
+			ExternalID: ticket.ExternalID(),
+		},
 	}
 }

--- a/flows/tickets.go
+++ b/flows/tickets.go
@@ -1,72 +1,49 @@
 package flows
 
 import (
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
+	"github.com/nyaruka/goflow/utils"
+	"github.com/pkg/errors"
 )
 
 // TicketUUID is the UUID of a ticket
 type TicketUUID uuids.UUID
 
-type baseTicket struct {
-	UUID       TicketUUID `json:"uuid"`
-	Subject    string     `json:"subject"`
-	Body       string     `json:"body"`
-	ExternalID string     `json:"external_id,omitempty"`
-}
-
-// TicketReference is a ticket with a reference to the ticketer
-type TicketReference struct {
-	Ticketer *assets.TicketerReference `json:"ticketer"`
-	baseTicket
-}
-
-// NewTicketReference creates a new ticket with a reference to the ticketer
-func NewTicketReference(uuid TicketUUID, ticketer *assets.TicketerReference, subject, body, externalID string) *TicketReference {
-	return &TicketReference{
-		baseTicket: baseTicket{
-			UUID:       uuid,
-			Subject:    subject,
-			Body:       body,
-			ExternalID: externalID,
-		},
-		Ticketer: ticketer,
-	}
-}
-
 // Ticket is a ticket in a ticketing system
 type Ticket struct {
-	Ticketer *Ticketer
-	baseTicket
+	uuid       TicketUUID `json:"uuid"`
+	ticketer   *Ticketer
+	subject    string `json:"subject"`
+	body       string `json:"body"`
+	externalID string `json:"external_id,omitempty"`
 }
 
-// NewTicket creates a new ticket. Used by ticketing services to open a new ticket.
-func NewTicket(ticketer *Ticketer, subject, body string) *Ticket {
-	return newTicket(TicketUUID(uuids.New()), ticketer, subject, body, "")
-}
-
-// creates a new ticket
-func newTicket(uuid TicketUUID, ticketer *Ticketer, subject, body, externalID string) *Ticket {
+// NewTicketcreates a new ticket with a reference to the ticketer
+func NewTicket(uuid TicketUUID, ticketer *Ticketer, subject, body, externalID string) *Ticket {
 	return &Ticket{
-		baseTicket: baseTicket{
-			UUID:       uuid,
-			Subject:    subject,
-			Body:       body,
-			ExternalID: externalID,
-		},
-		Ticketer: ticketer,
+		uuid:       uuid,
+		ticketer:   ticketer,
+		subject:    subject,
+		body:       body,
+		externalID: externalID,
 	}
 }
 
-// Reference converts this ticket to a ticket reference suitable for marshaling
-func (t *Ticket) Reference() *TicketReference {
-	return &TicketReference{
-		baseTicket: t.baseTicket,
-		Ticketer:   t.Ticketer.Reference(),
-	}
+// OpenTicket creates a new ticket. Used by ticketing services to open a new ticket.
+func OpenTicket(ticketer *Ticketer, subject, body string) *Ticket {
+	return NewTicket(TicketUUID(uuids.New()), ticketer, subject, body, "")
 }
+
+func (t *Ticket) UUID() TicketUUID        { return t.uuid }
+func (t *Ticket) Ticketer() *Ticketer     { return t.ticketer }
+func (t *Ticket) Subject() string         { return t.subject }
+func (t *Ticket) Body() string            { return t.body }
+func (t *Ticket) ExternalID() string      { return t.externalID }
+func (t *Ticket) SetExternalID(id string) { t.externalID = id }
 
 // Context returns the properties available in expressions
 //
@@ -77,10 +54,61 @@ func (t *Ticket) Reference() *TicketReference {
 // @context ticket
 func (t *Ticket) Context(env envs.Environment) map[string]types.XValue {
 	return map[string]types.XValue{
-		"uuid":    types.NewXText(string(t.UUID)),
-		"subject": types.NewXText(t.Subject),
-		"body":    types.NewXText(t.Body),
+		"uuid":    types.NewXText(string(t.uuid)),
+		"subject": types.NewXText(t.subject),
+		"body":    types.NewXText(t.body),
 	}
+}
+
+//------------------------------------------------------------------------------------------
+// JSON Encoding / Decoding
+//------------------------------------------------------------------------------------------
+
+type ticketEnvelope struct {
+	UUID       TicketUUID                `json:"uuid"                   validate:"required,uuid4"`
+	Ticketer   *assets.TicketerReference `json:"ticketer"               validate:"required,dive"`
+	Subject    string                    `json:"subject"`
+	Body       string                    `json:"body"`
+	ExternalID string                    `json:"external_id,omitempty"`
+}
+
+// ReadTicket ecodes a contact from the passed in JSON. If the ticketer can't be found in the assets,
+// we return report the missing asset and return ticket with nil ticketer.
+func ReadTicket(sa SessionAssets, data []byte, missing assets.MissingCallback) (*Ticket, error) {
+	e := &ticketEnvelope{}
+
+	if err := utils.UnmarshalAndValidate(data, e); err != nil {
+		return nil, errors.Wrap(err, "unable to read ticket")
+	}
+
+	ticketer := sa.Ticketers().Get(e.Ticketer.UUID)
+	if ticketer == nil {
+		missing(e.Ticketer, nil)
+	}
+
+	return &Ticket{
+		uuid:       e.UUID,
+		ticketer:   ticketer,
+		subject:    e.Subject,
+		body:       e.Body,
+		externalID: e.ExternalID,
+	}, nil
+}
+
+// MarshalJSON marshals this ticket into JSON
+func (t *Ticket) MarshalJSON() ([]byte, error) {
+	var ticketerRef *assets.TicketerReference
+	if t.ticketer != nil {
+		ticketerRef = t.ticketer.Reference()
+	}
+
+	return jsonx.Marshal(&ticketEnvelope{
+		UUID:       t.uuid,
+		Ticketer:   ticketerRef,
+		Subject:    t.subject,
+		Body:       t.body,
+		ExternalID: t.externalID,
+	})
 }
 
 // TicketList defines a contact's list of tickets
@@ -88,24 +116,8 @@ type TicketList struct {
 	tickets []*Ticket
 }
 
-// NewTicketFromReference creates a new ticket from a ticket reference
-func NewTicketFromReference(sa SessionAssets, ref *TicketReference) *Ticket {
-	ticketer := sa.Ticketers().Get(ref.Ticketer.UUID)
-	return newTicket(ref.UUID, ticketer, ref.Subject, ref.Body, ref.ExternalID)
-}
-
 // NewTicketList creates a new ticket list
-func NewTicketList(sa SessionAssets, refs []*TicketReference, missing assets.MissingCallback) *TicketList {
-	tickets := make([]*Ticket, 0, len(refs))
-
-	for _, ref := range refs {
-		ticket := NewTicketFromReference(sa, ref)
-		if ticket.Ticketer != nil {
-			tickets = append(tickets, ticket)
-		} else {
-			missing(ref.Ticketer, nil)
-		}
-	}
+func NewTicketList(tickets []*Ticket) *TicketList {
 	return &TicketList{tickets: tickets}
 }
 
@@ -114,15 +126,6 @@ func (l *TicketList) clone() *TicketList {
 	tickets := make([]*Ticket, len(l.tickets))
 	copy(tickets, l.tickets)
 	return &TicketList{tickets: tickets}
-}
-
-// returns this ticket list as a slice of ticket references
-func (l *TicketList) references() []*TicketReference {
-	refs := make([]*TicketReference, len(l.tickets))
-	for i, ticket := range l.tickets {
-		refs[i] = ticket.Reference()
-	}
-	return refs
 }
 
 // Adds adds the given ticket to this ticket list

--- a/flows/tickets.go
+++ b/flows/tickets.go
@@ -7,7 +7,6 @@ import (
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
-	"github.com/pkg/errors"
 )
 
 // TicketUUID is the UUID of a ticket
@@ -66,7 +65,7 @@ func (t *Ticket) Context(env envs.Environment) map[string]types.XValue {
 
 type ticketEnvelope struct {
 	UUID       TicketUUID                `json:"uuid"                   validate:"required,uuid4"`
-	Ticketer   *assets.TicketerReference `json:"ticketer"               validate:"required,dive"`
+	Ticketer   *assets.TicketerReference `json:"ticketer"               validate:"omitempty,dive"`
 	Subject    string                    `json:"subject"`
 	Body       string                    `json:"body"`
 	ExternalID string                    `json:"external_id,omitempty"`
@@ -78,7 +77,7 @@ func ReadTicket(sa SessionAssets, data []byte, missing assets.MissingCallback) (
 	e := &ticketEnvelope{}
 
 	if err := utils.UnmarshalAndValidate(data, e); err != nil {
-		return nil, errors.Wrap(err, "unable to read ticket")
+		return nil, err
 	}
 
 	ticketer := sa.Ticketers().Get(e.Ticketer.UUID)

--- a/flows/tickets_test.go
+++ b/flows/tickets_test.go
@@ -50,6 +50,9 @@ func TestTickets(t *testing.T) {
 		missingRefs = append(missingRefs, ref)
 	}
 
+	_, err = flows.ReadTicket(sa, []byte(`{}`), missing)
+	assert.EqualError(t, err, "field 'uuid' is required")
+
 	ticket1, err := flows.ReadTicket(sa, []byte(`{
 		"uuid": "349c851f-3f8e-4353-8bf2-8e90b6d73530", 
 		"ticketer": {"uuid": "0a0b5ce4-35c9-47b7-b124-40258f0a5b53", "name": "Deleted"},

--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -177,8 +177,8 @@ func TestTriggerMarshaling(t *testing.T) {
 
 	flow := assets.NewFlowReference("7c37d7e5-6468-4b31-8109-ced2ef8b5ddc", "Registration")
 	channel := assets.NewChannelReference("3a05eaf5-cb1b-4246-bef1-f277419c83a7", "Nexmo")
-	ticketer := assets.NewTicketerReference("19dc6346-9623-4fe4-be80-538d493ecdf5", "Support Tickets")
-	ticket := flows.NewTicketReference("276c2e43-d6f9-4c36-8e54-b5af5039acf6", ticketer, "Problem", "Where are my shoes?", "123456")
+	ticketer := sa.Ticketers().Get("19dc6346-9623-4fe4-be80-538d493ecdf5")
+	ticket := flows.NewTicket("276c2e43-d6f9-4c36-8e54-b5af5039acf6", ticketer, "Problem", "Where are my shoes?", "123456")
 
 	contact := flows.NewEmptyContact(sa, "Bob", envs.Language("eng"), nil)
 	contact.AddURN(urns.URN("tel:+12065551212"), nil)

--- a/flows/triggers/testdata/TestTriggerMarshaling_ticket_closed.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_ticket_closed.snap
@@ -29,11 +29,11 @@
     "event": {
         "type": "closed",
         "ticket": {
+            "uuid": "276c2e43-d6f9-4c36-8e54-b5af5039acf6",
             "ticketer": {
                 "uuid": "19dc6346-9623-4fe4-be80-538d493ecdf5",
                 "name": "Support Tickets"
             },
-            "uuid": "276c2e43-d6f9-4c36-8e54-b5af5039acf6",
             "subject": "Problem",
             "body": "Where are my shoes?",
             "external_id": "123456"

--- a/flows/triggers/testdata/ticket.json
+++ b/flows/triggers/testdata/ticket.json
@@ -15,7 +15,7 @@
             },
             "triggered_on": "2000-01-01T00:00:00Z"
         },
-        "read_error": "field 'event' is required"
+        "read_error": "field 'event.type' is required, field 'event.ticket' is required"
     },
     {
         "description": "with all required fields",

--- a/test/engine.go
+++ b/test/engine.go
@@ -120,8 +120,8 @@ func (s *ticketService) Open(session flows.Session, subject, body string, logHTT
 		ElapsedMS: 1,
 	})
 
-	ticket := flows.NewTicket(s.ticketer, subject, body)
-	ticket.ExternalID = "123456"
+	ticket := flows.OpenTicket(s.ticketer, subject, body)
+	ticket.SetExternalID("123456")
 	return ticket, nil
 }
 


### PR DESCRIPTION
They were a workaround to have a ticket-like struct that marshals/unmarshals