### PR TITLE
🌐 Remove default_language from environments 

### DIFF
--- a/envs/environment.go
+++ b/envs/environment.go
@@ -31,13 +31,13 @@ type Environment interface {
 	DateFormat() DateFormat
 	TimeFormat() TimeFormat
 	Timezone() *time.Location
-	DefaultLanguage() Language
 	AllowedLanguages() []Language
 	DefaultCountry() Country
 	NumberFormat() *NumberFormat
 	RedactionPolicy() RedactionPolicy
 	MaxValueLength() int
 
+	DefaultLanguage() Language
 	DefaultLocale() Locale
 
 	LocationResolver() LocationResolver
@@ -52,7 +52,6 @@ type environment struct {
 	dateFormat       DateFormat
 	timeFormat       TimeFormat
 	timezone         *time.Location
-	defaultLanguage  Language
 	allowedLanguages []Language
 	defaultCountry   Country
 	numberFormat     *NumberFormat
@@ -63,12 +62,19 @@ type environment struct {
 func (e *environment) DateFormat() DateFormat           { return e.dateFormat }
 func (e *environment) TimeFormat() TimeFormat           { return e.timeFormat }
 func (e *environment) Timezone() *time.Location         { return e.timezone }
-func (e *environment) DefaultLanguage() Language        { return e.defaultLanguage }
 func (e *environment) AllowedLanguages() []Language     { return e.allowedLanguages }
 func (e *environment) DefaultCountry() Country          { return e.defaultCountry }
 func (e *environment) NumberFormat() *NumberFormat      { return e.numberFormat }
 func (e *environment) RedactionPolicy() RedactionPolicy { return e.redactionPolicy }
 func (e *environment) MaxValueLength() int              { return e.maxValueLength }
+
+// DefaultLanguage is the first allowed language
+func (e *environment) DefaultLanguage() Language {
+	if len(e.allowedLanguages) > 0 {
+		return e.allowedLanguages[0]
+	}
+	return NilLanguage
+}
 
 // DefaultLocale combines the default languages and countries into a locale
 func (e *environment) DefaultLocale() Locale {
@@ -95,7 +101,6 @@ type envEnvelope struct {
 	DateFormat       DateFormat      `json:"date_format" validate:"date_format"`
 	TimeFormat       TimeFormat      `json:"time_format" validate:"time_format"`
 	Timezone         string          `json:"timezone"`
-	DefaultLanguage  Language        `json:"default_language,omitempty" validate:"omitempty,language"`
 	AllowedLanguages []Language      `json:"allowed_languages,omitempty" validate:"omitempty,dive,language"`
 	NumberFormat     *NumberFormat   `json:"number_format,omitempty"`
 	DefaultCountry   Country         `json:"default_country,omitempty" validate:"omitempty,country"`
@@ -115,7 +120,6 @@ func ReadEnvironment(data json.RawMessage) (Environment, error) {
 
 	env.dateFormat = envelope.DateFormat
 	env.timeFormat = envelope.TimeFormat
-	env.defaultLanguage = envelope.DefaultLanguage
 	env.allowedLanguages = envelope.AllowedLanguages
 	env.defaultCountry = envelope.DefaultCountry
 	env.numberFormat = envelope.NumberFormat
@@ -136,7 +140,6 @@ func (e *environment) toEnvelope() *envEnvelope {
 		DateFormat:       e.dateFormat,
 		TimeFormat:       e.timeFormat,
 		Timezone:         e.timezone.String(),
-		DefaultLanguage:  e.defaultLanguage,
 		AllowedLanguages: e.allowedLanguages,
 		DefaultCountry:   e.defaultCountry,
 		NumberFormat:     e.numberFormat,
@@ -166,7 +169,6 @@ func NewBuilder() *EnvironmentBuilder {
 			dateFormat:       DateFormatYearMonthDay,
 			timeFormat:       TimeFormatHourMinute,
 			timezone:         time.UTC,
-			defaultLanguage:  NilLanguage,
 			allowedLanguages: nil,
 			defaultCountry:   NilCountry,
 			numberFormat:     DefaultNumberFormat,
@@ -190,11 +192,6 @@ func (b *EnvironmentBuilder) WithTimeFormat(timeFormat TimeFormat) *EnvironmentB
 
 func (b *EnvironmentBuilder) WithTimezone(timezone *time.Location) *EnvironmentBuilder {
 	b.env.timezone = timezone
-	return b
-}
-
-func (b *EnvironmentBuilder) WithDefaultLanguage(defaultLanguage Language) *EnvironmentBuilder {
-	b.env.defaultLanguage = defaultLanguage
 	return b
 }
 

--- a/envs/environment_test.go
+++ b/envs/environment_test.go
@@ -17,31 +17,34 @@ func TestEnvironmentMarshaling(t *testing.T) {
 	require.NoError(t, err)
 
 	// can't create with invalid date format
-	env, err := envs.ReadEnvironment(json.RawMessage(`{"date_format": "YYYYYYYYYYY", "time_format": "tt:mm:ss", "timezone": "Africa/Kigali"}`))
+	_, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "YYYYYYYYYYY", "time_format": "tt:mm:ss", "timezone": "Africa/Kigali"}`))
 	assert.Error(t, err)
 
 	// can't create with invalid time format
-	env, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "timezone": "Africa/Kigali"}`))
+	_, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "timezone": "Africa/Kigali"}`))
 	assert.Error(t, err)
 
 	// can't create with invalid language
-	env, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "default_language": "elvish"}`))
+	_, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "allowed_languages": ["elvish"]}`))
 	assert.Error(t, err)
 
 	// can't create with invalid country
-	env, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "default_country": "Narnia"}`))
+	_, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "default_country": "Narnia"}`))
 	assert.Error(t, err)
 
 	// can't create with invalid timzeone
-	env, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "timezone": "Cuenca"}`))
+	_, err = envs.ReadEnvironment(json.RawMessage(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "timezone": "Cuenca"}`))
 	assert.Error(t, err)
 
 	// empty environment uses all defaults
-	env, err = envs.ReadEnvironment(json.RawMessage(`{}`))
+	env, err := envs.ReadEnvironment(json.RawMessage(`{}`))
 	assert.NoError(t, err)
 	assert.Equal(t, envs.DateFormatYearMonthDay, env.DateFormat())
 	assert.Equal(t, envs.TimeFormatHourMinute, env.TimeFormat())
 	assert.Equal(t, envs.DefaultNumberFormat, env.NumberFormat())
+	assert.Equal(t, envs.NilLanguage, env.DefaultLanguage())
+	assert.Nil(t, env.AllowedLanguages())
+	assert.Equal(t, envs.NilCountry, env.DefaultCountry())
 	assert.Equal(t, 640, env.MaxValueLength())
 	assert.Nil(t, env.LocationResolver())
 
@@ -49,7 +52,6 @@ func TestEnvironmentMarshaling(t *testing.T) {
 	env, err = envs.ReadEnvironment(json.RawMessage(`{
 		"date_format": "DD-MM-YYYY", 
 		"time_format": "tt:mm:ss", 
-		"default_language": "eng", 
 		"allowed_languages": ["eng", "fra"], 
 		"default_country": "RW", 
 		"timezone": "Africa/Kigali"
@@ -66,7 +68,7 @@ func TestEnvironmentMarshaling(t *testing.T) {
 
 	data, err := jsonx.Marshal(env)
 	require.NoError(t, err)
-	assert.Equal(t, string(data), `{"date_format":"DD-MM-YYYY","time_format":"tt:mm:ss","timezone":"Africa/Kigali","default_language":"eng","allowed_languages":["eng","fra"],"number_format":{"decimal_symbol":".","digit_grouping_symbol":","},"default_country":"RW","redaction_policy":"none","max_value_length":640}`)
+	assert.Equal(t, string(data), `{"date_format":"DD-MM-YYYY","time_format":"tt:mm:ss","timezone":"Africa/Kigali","allowed_languages":["eng","fra"],"number_format":{"decimal_symbol":".","digit_grouping_symbol":","},"default_country":"RW","redaction_policy":"none","max_value_length":640}`)
 }
 
 func TestEnvironmentEqual(t *testing.T) {
@@ -100,7 +102,6 @@ func TestEnvironmentBuilder(t *testing.T) {
 		WithDateFormat(envs.DateFormatDayMonthYear).
 		WithTimeFormat(envs.TimeFormatHourMinuteSecond).
 		WithTimezone(kgl).
-		WithDefaultLanguage(envs.Language("fra")).
 		WithAllowedLanguages([]envs.Language{envs.Language("fra"), envs.Language("eng")}).
 		WithDefaultCountry(envs.Country("RW")).
 		WithNumberFormat(&envs.NumberFormat{DecimalSymbol: "'"}).
@@ -111,7 +112,6 @@ func TestEnvironmentBuilder(t *testing.T) {
 	assert.Equal(t, envs.DateFormatDayMonthYear, env.DateFormat())
 	assert.Equal(t, envs.TimeFormatHourMinuteSecond, env.TimeFormat())
 	assert.Equal(t, kgl, env.Timezone())
-	assert.Equal(t, envs.Language("fra"), env.DefaultLanguage())
 	assert.Equal(t, []envs.Language{envs.Language("fra"), envs.Language("eng")}, env.AllowedLanguages())
 	assert.Equal(t, envs.Country("RW"), env.DefaultCountry())
 	assert.Equal(t, &envs.NumberFormat{DecimalSymbol: "'"}, env.NumberFormat())

--- a/excellent/types/date_test.go
+++ b/excellent/types/date_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestXDate(t *testing.T) {
 	env := envs.NewBuilder().WithDateFormat(envs.DateFormatDayMonthYear).Build()
-	env2 := envs.NewBuilder().WithDateFormat(envs.DateFormatYearMonthDay).WithDefaultLanguage("spa").Build()
+	env2 := envs.NewBuilder().WithDateFormat(envs.DateFormatYearMonthDay).WithAllowedLanguages([]envs.Language{"spa"}).Build()
 
 	d1 := types.NewXDate(dates.NewDate(2019, 2, 20))
 	assert.Equal(t, `date`, d1.Describe())

--- a/excellent/types/datetime_test.go
+++ b/excellent/types/datetime_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestXDateTime(t *testing.T) {
 	env := envs.NewBuilder().WithDateFormat(envs.DateFormatDayMonthYear).Build()
-	env2 := envs.NewBuilder().WithDateFormat(envs.DateFormatYearMonthDay).WithDefaultLanguage("spa").Build()
+	env2 := envs.NewBuilder().WithDateFormat(envs.DateFormatYearMonthDay).WithAllowedLanguages([]envs.Language{"spa"}).Build()
 
 	assert.True(t, types.NewXDateTime(time.Date(2018, 4, 9, 17, 1, 30, 123456789, time.UTC)).Truthy())
 

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -179,7 +179,6 @@ func testActionType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 		}
 
 		envBuilder := envs.NewBuilder().
-			WithDefaultLanguage("eng").
 			WithAllowedLanguages([]envs.Language{"eng", "spa"}).
 			WithDefaultCountry("RW")
 

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -311,7 +311,6 @@ func TestReevaluateQueryBasedGroups(t *testing.T) {
 
 	for _, tc := range tests {
 		envBuilder := envs.NewBuilder().
-			WithDefaultLanguage("eng").
 			WithAllowedLanguages([]envs.Language{"eng", "spa"}).
 			WithDefaultCountry("RW")
 

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -365,7 +365,6 @@ func TestEventMarshaling(t *testing.T) {
 					],
 					"date_format": "DD-MM-YYYY",
 					"default_country": "US",
-					"default_language": "eng",
 					"max_value_length": 640,
 					"number_format": {
 						"decimal_symbol": ".",

--- a/flows/events/environment_refreshed.go
+++ b/flows/events/environment_refreshed.go
@@ -24,7 +24,6 @@ const TypeEnvironmentRefreshed string = "environment_refreshed"
 //       "date_format": "YYYY-MM-DD",
 //       "time_format": "hh:mm",
 //       "timezone": "Africa/Kigali",
-//       "default_language": "eng",
 //       "allowed_languages": ["eng", "fra"]
 //     }
 //   }

--- a/flows/runs/environment_test.go
+++ b/flows/runs/environment_test.go
@@ -85,7 +85,6 @@ func TestRunEnvironment(t *testing.T) {
 	tzUK, _ := time.LoadLocation("Europe/London")
 
 	env := envs.NewBuilder().
-		WithDefaultLanguage("eng").
 		WithAllowedLanguages([]envs.Language{"eng", "fra", "kin"}).
 		WithDefaultCountry("RW").
 		WithTimezone(tzRW).

--- a/flows/runs/run_test.go
+++ b/flows/runs/run_test.go
@@ -97,7 +97,6 @@ var sessionTrigger = `{
     },
     "environment": {
         "date_format": "YYYY-MM-DD",
-        "default_language": "eng",
         "allowed_languages": [
             "eng", 
             "spa"

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -47,7 +47,7 @@ type Environment struct {
 }
 
 // NewEnvironment creates a new environment.
-func NewEnvironment(dateFormat string, timeFormat string, timezone string, defaultLanguage string, allowedLanguages *StringSlice, defaultCountry string, redactionPolicy string) (*Environment, error) {
+func NewEnvironment(dateFormat string, timeFormat string, timezone string, allowedLanguages *StringSlice, defaultCountry string, redactionPolicy string) (*Environment, error) {
 	tz, err := time.LoadLocation(timezone)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,6 @@ func NewEnvironment(dateFormat string, timeFormat string, timezone string, defau
 			WithDateFormat(envs.DateFormat(dateFormat)).
 			WithTimeFormat(envs.TimeFormat(timeFormat)).
 			WithTimezone(tz).
-			WithDefaultLanguage(envs.Language(defaultLanguage)).
 			WithAllowedLanguages(langs).
 			WithDefaultCountry(envs.Country(defaultCountry)).
 			WithRedactionPolicy(envs.RedactionPolicy(redactionPolicy)).

--- a/mobile/bindings_test.go
+++ b/mobile/bindings_test.go
@@ -38,7 +38,7 @@ func TestMobileBindings(t *testing.T) {
 	langs := mobile.NewStringSlice(2)
 	langs.Add("eng")
 	langs.Add("fra")
-	environment, err := mobile.NewEnvironment("DD-MM-YYYY", "tt:mm", "Africa/Kigali", "eng", langs, "RW", "none")
+	environment, err := mobile.NewEnvironment("DD-MM-YYYY", "tt:mm", "Africa/Kigali", langs, "RW", "none")
 	require.NoError(t, err)
 
 	// and create a new session assets

--- a/test/session.go
+++ b/test/session.go
@@ -363,7 +363,6 @@ var sessionTrigger = `{
     },
     "environment": {
         "date_format": "DD-MM-YYYY",
-        "default_language": "eng",
         "allowed_languages": [
             "eng", 
             "spa"
@@ -476,7 +475,6 @@ var voiceSessionTrigger = `{
     },
     "environment": {
         "date_format": "DD-MM-YYYY",
-        "default_language": "eng",
         "allowed_languages": [
             "eng", 
             "spa"

--- a/test/testdata/runner/airtime.test_successful_transfer.json
+++ b/test/testdata/runner/airtime.test_successful_transfer.json
@@ -191,7 +191,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -298,7 +297,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -341,7 +339,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/all_actions.test.json
+++ b/test/testdata/runner/all_actions.test.json
@@ -457,7 +457,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -954,7 +953,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -1026,7 +1024,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/brochure.test.json
+++ b/test/testdata/runner/brochure.test.json
@@ -51,7 +51,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -139,7 +138,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -256,7 +254,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -426,7 +423,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -491,7 +487,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/date_parse.test.json
+++ b/test/testdata/runner/date_parse.test.json
@@ -51,7 +51,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -133,7 +132,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -244,7 +242,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -404,7 +401,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -470,7 +466,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "h:mm aa",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/legacy_favorites.test.json
+++ b/test/testdata/runner/legacy_favorites.test.json
@@ -36,7 +36,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -109,7 +108,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -193,7 +191,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -332,7 +329,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -411,7 +407,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -597,7 +592,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -666,7 +660,6 @@
                 "fra"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/legacy_timeout.test.json
+++ b/test/testdata/runner/legacy_timeout.test.json
@@ -43,7 +43,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -123,7 +122,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -198,7 +196,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -324,7 +321,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -377,7 +373,6 @@
                 "fra"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/legacy_webhook.test.json
+++ b/test/testdata/runner/legacy_webhook.test.json
@@ -62,7 +62,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -167,7 +166,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -209,7 +207,6 @@
                 "fra"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/node_loop.test.json
+++ b/test/testdata/runner/node_loop.test.json
@@ -1438,7 +1438,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -3502,7 +3501,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -3554,7 +3552,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/redact_urns.test.json
+++ b/test/testdata/runner/redact_urns.test.json
@@ -65,7 +65,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -154,7 +153,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -206,7 +204,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "redaction_policy": "urns",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"

--- a/test/testdata/runner/router_tests.test.json
+++ b/test/testdata/runner/router_tests.test.json
@@ -94,7 +94,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -258,7 +257,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -313,7 +311,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/subflow.test.json
+++ b/test/testdata/runner/subflow.test.json
@@ -76,7 +76,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -205,7 +204,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -313,7 +311,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -528,7 +525,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -594,7 +590,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/subflow.test_resume_with_expiration.json
+++ b/test/testdata/runner/subflow.test_resume_with_expiration.json
@@ -76,7 +76,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -205,7 +204,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -281,7 +279,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -437,7 +434,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -494,7 +490,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/subflow_other.test.json
+++ b/test/testdata/runner/subflow_other.test.json
@@ -76,7 +76,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -217,7 +216,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -316,7 +314,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -532,7 +529,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -645,7 +641,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -936,7 +931,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -1035,7 +1029,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -1390,7 +1383,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -1484,7 +1476,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -1883,7 +1874,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -1988,7 +1978,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/triggered.test.json
+++ b/test/testdata/runner/triggered.test.json
@@ -46,7 +46,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -124,7 +123,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -203,7 +201,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/two_questions.test.json
+++ b/test/testdata/runner/two_questions.test.json
@@ -61,7 +61,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -145,7 +144,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -180,7 +178,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -301,7 +298,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -358,7 +354,6 @@
                                         "fra"
                                     ],
                                     "date_format": "YYYY-MM-DD",
-                                    "default_language": "eng",
                                     "max_value_length": 640,
                                     "number_format": {
                                         "decimal_symbol": ".",
@@ -509,7 +504,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -616,7 +610,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -673,7 +666,6 @@
                                         "fra"
                                     ],
                                     "date_format": "YYYY-MM-DD",
-                                    "default_language": "eng",
                                     "max_value_length": 640,
                                     "number_format": {
                                         "decimal_symbol": ".",
@@ -889,7 +881,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -942,7 +933,6 @@
                     "fra"
                 ],
                 "date_format": "YYYY-MM-DD",
-                "default_language": "eng",
                 "time_format": "hh:mm",
                 "timezone": "America/New_York"
             },
@@ -998,7 +988,6 @@
                 "fra"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },

--- a/test/testdata/runner/two_questions.test_resume_with_expiration.json
+++ b/test/testdata/runner/two_questions.test_resume_with_expiration.json
@@ -53,7 +53,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -137,7 +136,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -197,7 +195,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "default_language": "eng",
                     "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
@@ -287,7 +284,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "default_language": "eng",
                         "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
@@ -341,7 +337,6 @@
                 "fra"
             ],
             "date_format": "YYYY-MM-DD",
-            "default_language": "eng",
             "time_format": "hh:mm",
             "timezone": "America/Los_Angeles"
         },


### PR DESCRIPTION
We now expect `allowed_languages` to be ordered (at least the first item) and that's what we use as the default. Having to repeat `default_language` in `allowed_languages` always felt a bit redundant and enables a weird state of what does it mean if your `default_language` is not an `allowed_language`..