### PR TITLE
🔪 Fix `remove_first_word`

### DIFF
--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -480,12 +480,13 @@ func TestFunctions(t *testing.T) {
 
 		{"remove_first_word", dmy, []types.XValue{xs("hello World")}, xs("World")},
 		{"remove_first_word", dmy, []types.XValue{xs("hello")}, xs("")},
-		{"remove_first_word", dmy, []types.XValue{xs(`"hello"`)}, xs(`"`)},   // " ignored when extracting words, thus first word is hello
+		{"remove_first_word", dmy, []types.XValue{xs(`"hello"`)}, xs("")},    // " ignored when extracting words
 		{"remove_first_word", dmy, []types.XValue{xs(`don't go`)}, xs(`go`)}, // ' included when extracting words
 		{"remove_first_word", dmy, []types.XValue{xs(`'start' this`)}, xs(`this`)},
 		{"remove_first_word", dmy, []types.XValue{xs(` ‘start’ this`)}, xs(`this`)},
 		{"remove_first_word", dmy, []types.XValue{xs("     hello World")}, xs("World")},
 		{"remove_first_word", dmy, []types.XValue{xs("😁 hello")}, xs("hello")},
+		{"remove_first_word", dmy, []types.XValue{xs("“SIGN ABCDEF”")}, xs("ABCDEF”")},
 		{"remove_first_word", dmy, []types.XValue{xs("Hi there. I'm a flow!")}, xs("there. I'm a flow!")},
 		{"remove_first_word", dmy, []types.XValue{xs("ጥሩ ፍሰቶች")}, xs("ፍሰቶች")},
 		{"remove_first_word", dmy, []types.XValue{xs("")}, xs("")},
@@ -670,6 +671,7 @@ func TestFunctions(t *testing.T) {
 		{"word", dmy, []types.XValue{xs(""), xi(0)}, ERROR},
 		{"word", dmy, []types.XValue{xs("cat dog bee"), xi(-1)}, xs("bee")},
 		{"word", dmy, []types.XValue{xs("😁 hello World"), xi(0)}, xs("😁")},
+		{"word", dmy, []types.XValue{xs("“SIGN ABCDEF”"), xi(0)}, xs("SIGN")},
 		{"word", dmy, []types.XValue{xs("bee.*cat,dog"), xi(1), xs(".*=|")}, xs("cat,dog")},
 		{"word", dmy, []types.XValue{xs("bee.*cat,dog"), xi(1), ERROR}, ERROR}, // delimiters is error
 		{"word", dmy, []types.XValue{xs(" hello World"), xi(2)}, ERROR},        // out of range
@@ -695,6 +697,7 @@ func TestFunctions(t *testing.T) {
 		{"word_count", dmy, []types.XValue{xs("hello")}, xi(1)},
 		{"word_count", dmy, []types.XValue{xs("")}, xi(0)},
 		{"word_count", dmy, []types.XValue{xs("😁😁")}, xi(2)},
+		{"word_count", dmy, []types.XValue{xs("“SIGN ABCDEF”")}, xi(2)},
 		{"word_count", dmy, []types.XValue{xs("bee.*cat,dog"), xs(".*=|")}, xi(2)},
 		{"word_count", dmy, []types.XValue{xs("bee.*cat,dog"), ERROR}, ERROR},
 		{"word_count", dmy, []types.XValue{}, ERROR},

--- a/excellent/functions/utils.go
+++ b/excellent/functions/utils.go
@@ -1,0 +1,11 @@
+package functions
+
+import "github.com/nyaruka/goflow/utils"
+
+func extractWords(text string, delimiters string) []string {
+	if delimiters != "" {
+		return utils.TokenizeStringByChars(text, delimiters)
+	} else {
+		return utils.TokenizeString(text)
+	}
+}

--- a/excellent/functions/utils_test.go
+++ b/excellent/functions/utils_test.go
@@ -1,0 +1,18 @@
+package functions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractWords(t *testing.T) {
+	assert.Equal(t, []string(nil), extractWords("", ""))
+	assert.Equal(t, []string{"foo"}, extractWords("foo", ""))
+	assert.Equal(t, []string{"foo", "bar"}, extractWords("foo  bar  ", ""))
+	assert.Equal(t, []string{"foo", "foo"}, extractWords("foo foo", ""))
+	assert.Equal(t, []string{"foo.bar", "zed | doh"}, extractWords("foo.bar$zed | doh", "$"))
+	assert.Equal(t, []string{"foo.bar", "zed ", " doh"}, extractWords("foo.bar$zed | doh", "$|"))
+	assert.Equal(t, []string{"foo", "bar", "zed", "doh"}, extractWords("foo.bar$zed | doh", "$| ."))
+	assert.Equal(t, []string{"😁", "😃"}, extractWords("😁🎟️😃", "🎟️"))
+}


### PR DESCRIPTION
when input contains non-ASCII and tweak contract to be that the result is starts with the second valid word