### PR TITLE
👮 Strip invalid UTF-8 from webhook responses

### DIFF
--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -141,7 +141,7 @@ func (a *baseAction) saveWebhookResult(run flows.FlowRun, step flows.Step, name 
 	if call.Response != nil {
 		value = strconv.Itoa(call.Response.StatusCode)
 
-		if len(call.ResponseBody) < resultExtraMaxBytes && call.ValidJSON {
+		if len(call.ResponseJSON) > 0 && len(call.ResponseJSON) < resultExtraMaxBytes {
 			extra = call.ResponseBody
 		}
 	}

--- a/flows/events/webhook_called.go
+++ b/flows/events/webhook_called.go
@@ -62,6 +62,6 @@ func NewWebhookCalled(call *flows.WebhookCall, status flows.CallStatus, resthook
 		ElapsedMS:   int((call.EndTime.Sub(call.StartTime)) / time.Millisecond),
 		Resthook:    resthook,
 		StatusCode:  statusCode,
-		BodyIgnored: len(call.ResponseBody) > 0 && !call.ValidJSON,
+		BodyIgnored: len(call.ResponseBody) > 0 && len(call.ResponseJSON) == 0,
 	}
 }

--- a/flows/services.go
+++ b/flows/services.go
@@ -46,7 +46,7 @@ const (
 // WebhookCall is the result of a webhook call
 type WebhookCall struct {
 	*httpx.Trace
-	ValidJSON bool
+	ResponseJSON []byte
 }
 
 // WebhookService provides webhook functionality to the engine

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -1,9 +1,9 @@
 package webhooks
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
-	"unicode/utf8"
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/goflow/flows"
@@ -60,7 +60,13 @@ func (s *service) Call(session flows.Session, request *http.Request) (*flows.Web
 			return call, nil
 		}
 
-		call.ValidJSON = len(trace.ResponseBody) > 0 && json.Valid(trace.ResponseBody) && utf8.Valid(trace.ResponseBody)
+		if len(call.ResponseBody) > 0 {
+			// strip out any invalid UTF-8
+			bodyUTF8 := bytes.ToValidUTF8(call.ResponseBody, nil)
+			if json.Valid(bodyUTF8) {
+				call.ResponseJSON = bodyUTF8
+			}
+		}
 
 		return call, err
 	}

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -3,6 +3,7 @@ package webhooks
 import (
 	"encoding/json"
 	"net/http"
+	"unicode/utf8"
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/goflow/flows"
@@ -59,7 +60,7 @@ func (s *service) Call(session flows.Session, request *http.Request) (*flows.Web
 			return call, nil
 		}
 
-		call.ValidJSON = len(trace.ResponseBody) > 0 && json.Valid(trace.ResponseBody)
+		call.ValidJSON = len(trace.ResponseBody) > 0 && json.Valid(trace.ResponseBody) && utf8.Valid(trace.ResponseBody)
 
 		return call, err
 	}

--- a/services/webhooks/service_test.go
+++ b/services/webhooks/service_test.go
@@ -26,10 +26,10 @@ type call struct {
 func (c *call) String() string { return c.method + " " + c.url }
 
 type webhook struct {
-	request   string
-	response  string
-	body      string
-	validJSON bool
+	request  string
+	response string
+	body     string
+	bodyJSON string
 }
 
 func TestWebhookParsing(t *testing.T) {
@@ -48,73 +48,73 @@ func TestWebhookParsing(t *testing.T) {
 			// successful GET
 			call: call{"GET", "http://127.0.0.1:49994/?cmd=success", ""},
 			webhook: webhook{
-				request:   "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `{ "ok": "true" }`,
-				validJSON: true,
+				request:  "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `{ "ok": "true" }`,
+				bodyJSON: `{ "ok": "true" }`,
 			},
 		}, {
 			// successful GET with valid JSON response body
 			call: call{"GET", "http://127.0.0.1:49994/?cmd=textjs", ""},
 			webhook: webhook{
-				request:   "GET /?cmd=textjs HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/javascript; charset=iso-8859-1\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `{ "ok": "true" }`,
-				validJSON: true,
+				request:  "GET /?cmd=textjs HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/javascript; charset=iso-8859-1\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `{ "ok": "true" }`,
+				bodyJSON: `{ "ok": "true" }`,
 			},
 		}, {
 			// successful POST without request body and valid JSON response body
 			call: call{"POST", "http://127.0.0.1:49994/?cmd=success", ""},
 			webhook: webhook{
-				request:   "POST /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `{ "ok": "true" }`,
-				validJSON: true,
+				request:  "POST /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `{ "ok": "true" }`,
+				bodyJSON: `{ "ok": "true" }`,
 			},
 		}, {
 			// successful POST with request body and valid JSON response body
 			call: call{"POST", "http://127.0.0.1:49994/?cmd=success", `{"contact": "Bob"}`},
 			webhook: webhook{
-				request:   "POST /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 18\r\nAccept-Encoding: gzip\r\n\r\n{\"contact\": \"Bob\"}",
-				response:  "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `{ "ok": "true" }`,
-				validJSON: true,
+				request:  "POST /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 18\r\nAccept-Encoding: gzip\r\n\r\n{\"contact\": \"Bob\"}",
+				response: "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `{ "ok": "true" }`,
+				bodyJSON: `{ "ok": "true" }`,
 			},
 		}, {
 			// successful POST with non-UTF8 response body
 			call: call{"POST", "http://127.0.0.1:49994/?cmd=badutf8", ""},
 			webhook: webhook{
-				request:   "POST /?cmd=badutf8 HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Length: 15\r\nContent-Type: text/plain\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      "{ \"bad\": \"\x80\x81\" }",
-				validJSON: false,
+				request:  "POST /?cmd=badutf8 HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Length: 15\r\nContent-Type: text/plain\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     "{ \"bad\": \"\x80\x81\" }",
+				bodyJSON: `{ "bad": "" }`,
 			},
 		}, {
 			// successful POST receiving gzipped non-JSON body
 			call: call{"POST", "http://127.0.0.1:49994/?cmd=gzipped&content=Hello", ``},
 			webhook: webhook{
-				request:   "POST /?cmd=gzipped&content=Hello HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Type: application/x-gzip\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `Hello`,
-				validJSON: false,
+				request:  "POST /?cmd=gzipped&content=Hello HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Type: application/x-gzip\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `Hello`,
+				bodyJSON: ``,
 			},
 		}, {
 			// successful POST receiving gzipped JSON body
 			call: call{"POST", "http://127.0.0.1:49994/?cmd=gzipped&content=%7B%22contact%22%3A%20%22Bob%22%7D", ``},
 			webhook: webhook{
-				request:   "POST /?cmd=gzipped&content=%7B%22contact%22%3A%20%22Bob%22%7D HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Type: application/x-gzip\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `{"contact": "Bob"}`,
-				validJSON: true,
+				request:  "POST /?cmd=gzipped&content=%7B%22contact%22%3A%20%22Bob%22%7D HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Type: application/x-gzip\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `{"contact": "Bob"}`,
+				bodyJSON: `{"contact": "Bob"}`,
 			},
 		}, {
 			// POST returning 503
 			call: call{"POST", "http://127.0.0.1:49994/?cmd=unavailable", ""},
 			webhook: webhook{
-				request:   "POST /?cmd=unavailable HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 37\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `{ "errors": ["service unavailable"] }`,
-				validJSON: true,
+				request:  "POST /?cmd=unavailable HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 37\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `{ "errors": ["service unavailable"] }`,
+				bodyJSON: `{ "errors": ["service unavailable"] }`,
 			},
 		}, {
 			// GET returning text body larger than allowed
@@ -124,28 +124,28 @@ func TestWebhookParsing(t *testing.T) {
 			// GET returning non-JSON body
 			call: call{"GET", "http://127.0.0.1:49994/?cmd=typeless&content=kthxbai", ""},
 			webhook: webhook{
-				request:   "GET /?cmd=typeless&content=kthxbai HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nContent-Type: \r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      "kthxbai",
-				validJSON: false,
+				request:  "GET /?cmd=typeless&content=kthxbai HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nContent-Type: \r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     "kthxbai",
+				bodyJSON: ``,
 			},
 		}, {
 			// GET returning JSON body but an empty content-type header
 			call: call{"GET", "http://127.0.0.1:49994/?cmd=typeless&content=%7B%22msg%22%3A%20%22I%27m%20JSON%22%7D", ""},
 			webhook: webhook{
-				request:   "GET /?cmd=typeless&content=%7B%22msg%22%3A%20%22I%27m%20JSON%22%7D HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "HTTP/1.1 200 OK\r\nContent-Length: 19\r\nContent-Type: \r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
-				body:      `{"msg": "I'm JSON"}`,
-				validJSON: true,
+				request:  "GET /?cmd=typeless&content=%7B%22msg%22%3A%20%22I%27m%20JSON%22%7D HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "HTTP/1.1 200 OK\r\nContent-Length: 19\r\nContent-Type: \r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:     `{"msg": "I'm JSON"}`,
+				bodyJSON: `{"msg": "I'm JSON"}`,
 			},
 		}, {
 			// connection error
 			call: call{"POST", "http://127.0.0.1:55555/", ""},
 			webhook: webhook{
-				request:   "POST / HTTP/1.1\r\nHost: 127.0.0.1:55555\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
-				response:  "",
-				body:      "",
-				validJSON: false,
+				request:  "POST / HTTP/1.1\r\nHost: 127.0.0.1:55555\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
+				response: "",
+				body:     "",
+				bodyJSON: ``,
 			},
 		},
 	}
@@ -167,7 +167,7 @@ func TestWebhookParsing(t *testing.T) {
 			assert.Equal(t, tc.webhook.request, string(c.RequestTrace), "request trace mismatch for call %s", tc.call)
 			assert.Equal(t, tc.webhook.response, string(c.ResponseTrace), "response mismatch for call %s", tc.call)
 			assert.Equal(t, tc.webhook.body, string(c.ResponseBody), "body mismatch for call %s", tc.call)
-			assert.Equal(t, tc.webhook.validJSON, c.ValidJSON, "validJSON mismatch for call %s", tc.call)
+			assert.Equal(t, tc.webhook.bodyJSON, string(c.ResponseJSON), "body JSON mismatch for call %s", tc.call)
 		}
 	}
 }
@@ -179,7 +179,7 @@ func TestRetries(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
 	mocks := httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"http://temba.io/": []httpx.MockResponse{
+		"http://temba.io/": {
 			httpx.NewMockResponse(502, nil, "a"),
 			httpx.NewMockResponse(200, nil, "b"),
 		},

--- a/services/webhooks/service_test.go
+++ b/services/webhooks/service_test.go
@@ -81,6 +81,15 @@ func TestWebhookParsing(t *testing.T) {
 				validJSON: true,
 			},
 		}, {
+			// successful POST with non-UTF8 response body
+			call: call{"POST", "http://127.0.0.1:49994/?cmd=badutf8", ""},
+			webhook: webhook{
+				request:   "POST /?cmd=badutf8 HTTP/1.1\r\nHost: 127.0.0.1:49994\r\nUser-Agent: goflow-testing\r\nContent-Length: 0\r\nAccept-Encoding: gzip\r\n\r\n",
+				response:  "HTTP/1.1 200 OK\r\nContent-Length: 15\r\nContent-Type: text/plain\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n",
+				body:      "{ \"bad\": \"\x80\x81\" }",
+				validJSON: false,
+			},
+		}, {
 			// successful POST receiving gzipped non-JSON body
 			call: call{"POST", "http://127.0.0.1:49994/?cmd=gzipped&content=Hello", ``},
 			webhook: webhook{

--- a/test/http.go
+++ b/test/http.go
@@ -57,6 +57,9 @@ func testHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	case "textjs":
 		contentType = "text/javascript; charset=iso-8859-1"
 		data = []byte(`{ "ok": "true" }`)
+	case "badutf8":
+		contentType = "text/plain"
+		data = []byte("{ \"bad\": \"\x80\x81\" }")
 	case "typeless":
 		w.Header().Set("Content-Type", "")
 	case "unavailable":


### PR DESCRIPTION
`json.Valid` seems to only check structure even tho JSON "must" be valid UTF8 according to the [RFC](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)

https://play.golang.org/p/pXRiYg5sEPZ 

Had my suspicions that webhook responses were one place that invalid UTF-8 can get into the session state and sure enough it looks like https://sentry.io/organizations/nyaruka/issues/2483695525/events/5374e6c59d1d44f49fcc337469302de0/?project=1281372 is caused by a webhook result that includes `"id_number":"01\u00006\u00002"`.. NULL chars.

Initially was thinking we should reject invalid UTF-8 but seem like we can afford to be a bit more forgiving and strip out the invalid UTF-8.