### PR TITLE
🔌 Allow `msg` type triggers to have connections

### DIFF
--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -271,6 +271,7 @@ func TestTriggerMarshaling(t *testing.T) {
 			triggers.NewBuilder(env, flow, contact).
 				Msg(flows.NewMsgIn(flows.MsgUUID("c8005ee3-4628-4d76-be66-906352cb1935"), urns.URN("tel:+1234567890"), channel, "Hi there", nil)).
 				WithMatch(triggers.NewKeywordMatch(triggers.KeywordMatchTypeFirstWord, "hi")).
+				WithConnection(channel, "tel:+12065551212").
 				Build(),
 			"msg",
 		},

--- a/flows/triggers/msg.go
+++ b/flows/triggers/msg.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
@@ -115,6 +116,12 @@ func (b *Builder) Msg(msg *flows.MsgIn) *MsgBuilder {
 // WithMatch sets the keyword match for the trigger
 func (b *MsgBuilder) WithMatch(match *KeywordMatch) *MsgBuilder {
 	b.t.match = match
+	return b
+}
+
+// WithConnection sets the channel connection for the trigger
+func (b *MsgBuilder) WithConnection(channel *assets.ChannelReference, urn urns.URN) *MsgBuilder {
+	b.t.connection = flows.NewConnection(channel, urn)
 	return b
 }
 

--- a/flows/triggers/testdata/TestTriggerMarshaling_msg.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_msg.snap
@@ -25,6 +25,13 @@
             "tel:+12065551212"
         ]
     },
+    "connection": {
+        "channel": {
+            "uuid": "3a05eaf5-cb1b-4246-bef1-f277419c83a7",
+            "name": "Nexmo"
+        },
+        "urn": "tel:+12065551212"
+    },
     "triggered_on": "2018-10-20T09:49:31.23456789Z",
     "msg": {
         "uuid": "c8005ee3-4628-4d76-be66-906352cb1935",


### PR DESCRIPTION
Messages can trigger IVR flows but IVR flows can be run without a connection. 

Usually this isn't a problem because if a message triggers an IVR flow, that becomes a flow start which eventually is started in the engine with a manual trigger. We forget that it came from a message.

But in the simulator, if a message matches a keyword trigger and we want to simulate switching to that flow, we use a Msg type trigger... but we don't set connection.. so if that flow is IVR, we blow up, e.g. https://sentry.io/organizations/nyaruka/issues/2506463195/?project=1281372

