### PR TITLE
🔎 Simplify parsing contact queries

### DIFF
--- a/contactql/es/query_test.go
+++ b/contactql/es/query_test.go
@@ -63,15 +63,12 @@ func TestElasticQuery(t *testing.T) {
 		}
 		env := envs.NewBuilder().WithTimezone(ny).WithRedactionPolicy(redactionPolicy).Build()
 
-		parsed, err := contactql.ParseQuery(env, tc.Query)
+		parsed, err := contactql.ParseQuery(env, tc.Query, resolver)
 
 		var query elastic.Query
 		if err == nil {
-			err = parsed.Validate(env, resolver)
-			if err == nil {
-				query, err = es.ToElasticQuery(env, resolver, parsed)
-				require.NoError(t, err)
-			}
+			query, err = es.ToElasticQuery(env, resolver, parsed)
+			require.NoError(t, err)
 		}
 
 		if tc.Error != "" {

--- a/contactql/evaluator_test.go
+++ b/contactql/evaluator_test.go
@@ -43,98 +43,98 @@ func TestEvaluateQuery(t *testing.T) {
 		result bool
 	}{
 		// UUID condition
-		{`uuid = "C7D9BECE-6bbd-4b3b-8a86-eb0cf1ac9d05"`, true},
-		{`uuid = "xyz"`, false},
+		{query: `uuid = "C7D9BECE-6bbd-4b3b-8a86-eb0cf1ac9d05"`, result: true},
+		{query: `uuid = "xyz"`, result: false},
 
 		// ID condition
-		{`id = 12345`, true},
-		{`id = 76543`, false},
+		{query: `id = 12345`, result: true},
+		{query: `id = 76543`, result: false},
 
 		// name condition
-		{`name = "BOB smithwick"`, true},
-		{`name = "Bob"`, false},
-		{`name ~ "Bob"`, true},
-		{`name ~ "Bobby"`, false},
-		{`name ~ "Sm"`, true},
-		{`name ~ "Smithwicke"`, true}, // only compare up to 8 chars
-		{`name ~ "Smithx"`, false},
+		{query: `name = "BOB smithwick"`, result: true},
+		{query: `name = "Bob"`, result: false},
+		{query: `name ~ "Bob"`, result: true},
+		{query: `name ~ "Bobby"`, result: false},
+		{query: `name ~ "Sm"`, result: true},
+		{query: `name ~ "Smithwicke"`, result: true}, // only compare up to 8 chars
+		{query: `name ~ "Smithx"`, result: false},
 
 		// URN condition
-		{`tel = +59313145145`, true},
-		{`tel = +59313140000`, false},
-		{`tel:+59313145145`, true},
-		{`tel:+59313140000`, false},
-		{`tel has 45145`, true},
-		{`tel ~ 33333`, false},
-		{`TWITTER IS bob_smith`, true},
-		{`twitter:bob_smith`, true},
-		{`twitter = jim_smith`, false},
-		{`twitter:jim_smith`, false},
-		{`twitter ~ smith`, true},
-		{`whatsapp = 4533343`, false},
+		{query: `tel = +59313145145`, result: true},
+		{query: `tel = +59313140000`, result: false},
+		{query: `tel:+59313145145`, result: true},
+		{query: `tel:+59313140000`, result: false},
+		{query: `tel has 45145`, result: true},
+		{query: `tel ~ 33333`, result: false},
+		{query: `TWITTER IS bob_smith`, result: true},
+		{query: `twitter:bob_smith`, result: true},
+		{query: `twitter = jim_smith`, result: false},
+		{query: `twitter:jim_smith`, result: false},
+		{query: `twitter ~ smith`, result: true},
+		{query: `whatsapp = 4533343`, result: false},
 
 		// text field condition
-		{`Gender = male`, true},
-		{`Gender is MALE`, true},
-		{`gender = "female"`, false},
-		{`gender != "female"`, true},
-		{`gender != "male"`, false},
-		{`empty != "male"`, true}, // this is true because "" is not "male"
-		{`gender != ""`, true},
+		{query: `Gender = male`, result: true},
+		{query: `Gender is MALE`, result: true},
+		{query: `gender = "female"`, result: false},
+		{query: `gender != "female"`, result: true},
+		{query: `gender != "male"`, result: false},
+		{query: `empty != "male"`, result: true}, // this is true because "" is not "male"
+		{query: `gender != ""`, result: true},
 
 		// number field condition
-		{`age = 36`, true},
-		{`age = 35`, false},
-		{`age is 35`, false},
-		{`age != 36`, false},
-		{`age != 35`, true},
-		{`age > 36`, false},
-		{`age > 35`, true},
-		{`age >= 36`, true},
-		{`age < 36`, false},
-		{`age < 37`, true},
-		{`age <= 36`, true},
+		{query: `age = 36`, result: true},
+		{query: `age = 35`, result: false},
+		{query: `age is 35`, result: false},
+		{query: `age != 36`, result: false},
+		{query: `age != 35`, result: true},
+		{query: `age > 36`, result: false},
+		{query: `age > 35`, result: true},
+		{query: `age >= 36`, result: true},
+		{query: `age < 36`, result: false},
+		{query: `age < 37`, result: true},
+		{query: `age <= 36`, result: true},
 
 		// datetime field condition
-		{`dob = 1981/05/28`, true},
-		{`dob = 1981/05/29`, false},
-		{`dob != 1981/05/28`, false},
-		{`dob != 1981/05/29`, true},
-		{`dob > 1981/05/28`, false},
-		{`dob > 1981/05/27`, true},
-		{`dob >= 1981/05/28`, true},
-		{`dob >= 1981/05/29`, false},
-		{`dob < 1981/05/28`, false},
-		{`dob < 1981/05/29`, true},
-		{`dob <= 1981/05/28`, true},
-		{`dob <= 1981/05/27`, false},
+		{query: `dob = 1981/05/28`, result: true},
+		{query: `dob = 1981/05/29`, result: false},
+		{query: `dob != 1981/05/28`, result: false},
+		{query: `dob != 1981/05/29`, result: true},
+		{query: `dob > 1981/05/28`, result: false},
+		{query: `dob > 1981/05/27`, result: true},
+		{query: `dob >= 1981/05/28`, result: true},
+		{query: `dob >= 1981/05/29`, result: false},
+		{query: `dob < 1981/05/28`, result: false},
+		{query: `dob < 1981/05/29`, result: true},
+		{query: `dob <= 1981/05/28`, result: true},
+		{query: `dob <= 1981/05/27`, result: false},
 
 		// location field condition
-		{`state = kigali`, true},
-		{`state = "kigali"`, true},
-		{`state = "NYC"`, false},
-		{`district = "GASABO"`, true},
-		{`district = "Brooklyn"`, false},
-		{`ward = ndera`, true},
-		{`ward = solano`, false},
-		{`ward != ndera`, false},
-		{`ward != solano`, true},
+		{query: `state = kigali`, result: true},
+		{query: `state = "kigali"`, result: true},
+		{query: `state = "NYC"`, result: false},
+		{query: `district = "GASABO"`, result: true},
+		{query: `district = "Brooklyn"`, result: false},
+		{query: `ward = ndera`, result: true},
+		{query: `ward = solano`, result: false},
+		{query: `ward != ndera`, result: false},
+		{query: `ward != solano`, result: true},
 
 		// existence
-		{`age = ""`, false},
-		{`age != ""`, true},
-		{`xyz = ""`, true},
-		{`xyz != ""`, false},
-		{`age != "" AND xyz != ""`, false},
-		{`age != "" OR xyz != ""`, true},
+		{query: `age = ""`, result: false},
+		{query: `age != ""`, result: true},
+		{query: `xyz = ""`, result: true},
+		{query: `xyz != ""`, result: false},
+		{query: `age != "" AND xyz != ""`, result: false},
+		{query: `age != "" OR xyz != ""`, result: true},
 
 		// boolean combinations
-		{`age = 36 AND gender = male`, true},
-		{`(age = 36) AND (gender = male)`, true},
-		{`age = 36 AND gender = female`, false},
-		{`age = 36 OR gender = female`, true},
-		{`age = 35 OR gender = female`, false},
-		{`(age = 36 OR gender = female) AND age > 35`, true},
+		{query: `age = 36 AND gender = male`, result: true},
+		{query: `(age = 36) AND (gender = male)`, result: true},
+		{query: `age = 36 AND gender = female`, result: false},
+		{query: `age = 36 OR gender = female`, result: true},
+		{query: `age = 35 OR gender = female`, result: false},
+		{query: `(age = 36 OR gender = female) AND age > 35`, result: true},
 	}
 
 	resolver := contactql.NewMockResolver(map[string]assets.Field{
@@ -149,14 +149,10 @@ func TestEvaluateQuery(t *testing.T) {
 	}, map[string]assets.Group{})
 
 	for _, test := range tests {
-		parsed, err := contactql.ParseQuery(env, test.query)
+		parsed, err := contactql.ParseQuery(env, test.query, resolver)
 		assert.NoError(t, err, "unexpected error parsing '%s'", test.query)
 
-		err = parsed.Validate(env, resolver)
-		assert.NoError(t, err, "unexpected error validating '%s'", test.query)
-
-		actualResult, err := contactql.EvaluateQuery(env, resolver, parsed, testObj)
-		assert.NoError(t, err, "unexpected error evaluating '%s'", test.query)
+		actualResult := contactql.EvaluateQuery(env, parsed, testObj)
 		assert.Equal(t, test.result, actualResult, "unexpected result for '%s'", test.query)
 	}
 }

--- a/contactql/inspect.go
+++ b/contactql/inspect.go
@@ -18,9 +18,15 @@ type Inspection struct {
 func Inspect(query *ContactQuery) *Inspection {
 	attributes := make(map[string]bool)
 	schemes := make(map[string]bool)
-	fieldRefs := make([]*assets.FieldReference, 0)
-	groupRefs := make([]*assets.GroupReference, 0)
+	refs := make([]assets.Reference, 0)
 	refsSeen := make(map[string]bool)
+
+	addRef := func(ref assets.Reference) {
+		if !refsSeen[ref.String()] {
+			refs = append(refs, ref)
+			refsSeen[ref.String()] = true
+		}
+	}
 
 	walk(query.Root(), func(c *Condition) {
 		switch c.propType {
@@ -28,22 +34,36 @@ func Inspect(query *ContactQuery) *Inspection {
 			attributes[c.propKey] = true
 
 			if c.propKey == AttributeGroup {
-				ref := assets.NewVariableGroupReference(c.value)
-				if !refsSeen[ref.String()] {
-					groupRefs = append(groupRefs, ref)
-					refsSeen[ref.String()] = true
+				if query.resolver != nil {
+					group := query.resolver.ResolveGroup(c.value)
+					addRef(assets.NewGroupReference(group.UUID(), group.Name()))
+				} else {
+					addRef(assets.NewVariableGroupReference(c.value))
 				}
 			}
 		case PropertyTypeScheme:
 			schemes[c.propKey] = true
 		case PropertyTypeField:
-			ref := assets.NewFieldReference(c.propKey, "")
-			if !refsSeen[ref.String()] {
-				fieldRefs = append(fieldRefs, ref)
-				refsSeen[ref.String()] = true
+			if query.resolver != nil {
+				field := query.resolver.ResolveField(c.propKey)
+				addRef(assets.NewFieldReference(field.Key(), field.Name()))
+			} else {
+				addRef(assets.NewFieldReference(c.propKey, ""))
 			}
+
 		}
 	})
+
+	fieldRefs := make([]*assets.FieldReference, 0)
+	groupRefs := make([]*assets.GroupReference, 0)
+	for _, ref := range refs {
+		switch typed := ref.(type) {
+		case *assets.FieldReference:
+			fieldRefs = append(fieldRefs, typed)
+		case *assets.GroupReference:
+			groupRefs = append(groupRefs, typed)
+		}
+	}
 
 	allowAsGroup := !(attributes[AttributeID] || attributes[AttributeGroup])
 

--- a/contactql/inspect_test.go
+++ b/contactql/inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/assets/static/types"
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/goflow/envs"
 
@@ -12,12 +13,23 @@ import (
 )
 
 func TestInspect(t *testing.T) {
+	env := envs.NewBuilder().Build()
+	resolver := contactql.NewMockResolver(map[string]assets.Field{
+		"age":    types.NewField(assets.FieldUUID("f1b5aea6-6586-41c7-9020-1a6326cc6565"), "age", "Age", assets.FieldTypeNumber),
+		"dob":    types.NewField(assets.FieldUUID("3810a485-3fda-4011-a589-7320c0b8dbef"), "dob", "DOB", assets.FieldTypeDatetime),
+		"gender": types.NewField(assets.FieldUUID("d66a7823-eada-40e5-9a3a-57239d4690bf"), "gender", "Gender", assets.FieldTypeText),
+	}, map[string]assets.Group{
+		"u-reporters": types.NewGroup(assets.GroupUUID("4eeca453-f474-4767-bdd0-434b180223db"), "U-Reporters", ""),
+	})
+
 	tests := []struct {
 		query      string
+		resolver   contactql.Resolver
 		inspection *contactql.Inspection
 	}{
 		{
-			query: "bob",
+			query:    "bob",
+			resolver: resolver,
 			inspection: &contactql.Inspection{
 				Attributes:   []string{"name"},
 				Schemes:      []string{},
@@ -39,7 +51,21 @@ func TestInspect(t *testing.T) {
 			},
 		},
 		{
-			query: "id = 123",
+			query:    "AGE > 18 AND name != \"\" OR twitter = bobby OR tel ~1234",
+			resolver: resolver,
+			inspection: &contactql.Inspection{
+				Attributes: []string{"name"},
+				Schemes:    []string{"tel", "twitter"},
+				Fields: []*assets.FieldReference{
+					assets.NewFieldReference("age", "Age"),
+				},
+				Groups:       []*assets.GroupReference{},
+				AllowAsGroup: true,
+			},
+		},
+		{
+			query:    "id = 123",
+			resolver: resolver,
 			inspection: &contactql.Inspection{
 				Attributes:   []string{"id"},
 				Schemes:      []string{},
@@ -49,7 +75,7 @@ func TestInspect(t *testing.T) {
 			},
 		},
 		{
-			query: "group = U-reporters",
+			query: "group = U-reporters", // group condition parsed without resolver
 			inspection: &contactql.Inspection{
 				Attributes: []string{"group"},
 				Schemes:    []string{},
@@ -60,12 +86,23 @@ func TestInspect(t *testing.T) {
 				AllowAsGroup: false,
 			},
 		},
+		{
+			query:    "group = U-reporters", // group condition parsed with resolver
+			resolver: resolver,
+			inspection: &contactql.Inspection{
+				Attributes: []string{"group"},
+				Schemes:    []string{},
+				Fields:     []*assets.FieldReference{},
+				Groups: []*assets.GroupReference{
+					assets.NewGroupReference("4eeca453-f474-4767-bdd0-434b180223db", "U-Reporters"),
+				},
+				AllowAsGroup: false,
+			},
+		},
 	}
 
-	env := envs.NewBuilder().Build()
-
 	for _, tc := range tests {
-		query, err := contactql.ParseQuery(env, tc.query)
+		query, err := contactql.ParseQuery(env, tc.query, tc.resolver)
 		require.NoError(t, err, "error parsing %s", tc.query)
 
 		assert.Equal(t, tc.inspection, contactql.Inspect(query), "inspect mismatch for query %s", tc.query)

--- a/contactql/parser_test.go
+++ b/contactql/parser_test.go
@@ -11,192 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseAndValidateQuery(t *testing.T) {
-	tests := []struct {
-		text   string
-		parsed string
-		err    string
-		redact envs.RedactionPolicy
-	}{
-		// implicit conditions
-		{`"will"`, `name ~ "will"`, "", envs.RedactionPolicyNone},
-		{`Will`, `name ~ "Will"`, "", envs.RedactionPolicyNone},
-		{`wil`, `name ~ "wil"`, "", envs.RedactionPolicyNone},
-		{`wi`, `name ~ "wi"`, "", envs.RedactionPolicyNone},
-		{`w`, `name = "w"`, "", envs.RedactionPolicyNone}, // don't have at least 1 token of >= 2 chars
-		{`w me`, `name = "w" AND name ~ "me"`, "", envs.RedactionPolicyNone},
-		{`w m`, `name = "w" AND name = "m"`, "", envs.RedactionPolicyNone},
-		{`tel:+0123456566`, `tel = "+0123456566"`, "", envs.RedactionPolicyNone}, // whole query is a URN
-		{`twitter:bobby`, `twitter = "bobby"`, "", envs.RedactionPolicyNone},
-		{`(202) 456-1111`, `tel = "+12024561111"`, "", envs.RedactionPolicyNone}, // whole query looks like a phone number
-		{`+12024561111`, `tel = "+12024561111"`, "", envs.RedactionPolicyNone},
-		{` 202.456.1111 `, `tel = "+12024561111"`, "", envs.RedactionPolicyNone},
-		{`"+12024561111"`, `tel ~ "+12024561111"`, "", envs.RedactionPolicyNone},
-		{`566`, `name ~ 566`, "", envs.RedactionPolicyNone}, // too short to be a phone number
-
-		// implicit conditions with URN redaction
-		{`will`, `name ~ "will"`, "", envs.RedactionPolicyURNs},
-		{`tel:+0123456566`, `name ~ "tel:+0123456566"`, "", envs.RedactionPolicyURNs},
-		{`twitter:bobby`, `name ~ "twitter:bobby"`, "", envs.RedactionPolicyURNs},
-		{`0123456566`, `id = 123456566`, "", envs.RedactionPolicyURNs},
-		{`+0123456566`, `id = 123456566`, "", envs.RedactionPolicyURNs},
-		{`0123-456-566`, `name ~ "0123-456-566"`, "", envs.RedactionPolicyURNs},
-
-		// explicit conditions on name
-		{`Name=will`, `name = "will"`, "", envs.RedactionPolicyNone},
-		{`Name=O'Shea`, `name = "O'Shea"`, "", envs.RedactionPolicyNone},
-		{`Name ~ "felix"`, `name ~ "felix"`, "", envs.RedactionPolicyNone},
-		{`Name HAS "Felix"`, `name ~ "Felix"`, "", envs.RedactionPolicyNone},
-		{`name is ""`, `name = ""`, "", envs.RedactionPolicyNone},            // is not set
-		{`name != ""`, `name != ""`, "", envs.RedactionPolicyNone},           // is set
-		{`name != "felix"`, `name != "felix"`, "", envs.RedactionPolicyNone}, // is not equal to value
-		{`Name ~ ""`, ``, "contains operator on name requires token of minimum length 2", envs.RedactionPolicyNone},
-
-		// explicit attribute conditions
-		{`language = spa`, `language = "spa"`, "", envs.RedactionPolicyNone},
-		{`Group IS U-Reporters`, `group = "U-Reporters"`, "", envs.RedactionPolicyNone},
-		{`CREATED_ON>27-01-2020`, `created_on > "27-01-2020"`, "", envs.RedactionPolicyNone},
-
-		// explicit conditions on URN
-		{`tel=""`, `tel = ""`, "", envs.RedactionPolicyNone},
-		{`tel!=""`, `tel != ""`, "", envs.RedactionPolicyNone},
-		{`tel IS 233`, `tel = 233`, "", envs.RedactionPolicyNone},
-		{`tel HAS 233`, `tel ~ 233`, "", envs.RedactionPolicyNone},
-		{`tel ~ 23`, ``, "contains operator on URN requires value of minimum length 3", envs.RedactionPolicyNone},
-		{`mailto = user@example.com`, `mailto = "user@example.com"`, "", envs.RedactionPolicyNone},
-		{`MAILTO ~ user@example.com`, `mailto ~ "user@example.com"`, "", envs.RedactionPolicyNone},
-		{`URN=ewok`, `urn = "ewok"`, "", envs.RedactionPolicyNone},
-
-		// explicit conditions on URN with URN redaction
-		{`tel=""`, `tel = ""`, "", envs.RedactionPolicyURNs},
-		{`tel!=""`, `tel != ""`, "", envs.RedactionPolicyURNs},
-		{`mailto=""`, `mailto = ""`, "", envs.RedactionPolicyURNs},
-		{`mailto!=""`, `mailto != ""`, "", envs.RedactionPolicyURNs},
-		{`urn=""`, `urn = ""`, "", envs.RedactionPolicyURNs},
-		{`urn!=""`, `urn != ""`, "", envs.RedactionPolicyURNs},
-		{`tel = 233`, ``, "cannot query on redacted URNs", envs.RedactionPolicyURNs},
-		{`tel ~ 233`, ``, "cannot query on redacted URNs", envs.RedactionPolicyURNs},
-		{`mailto = user@example.com`, ``, "cannot query on redacted URNs", envs.RedactionPolicyURNs},
-		{`MAILTO ~ user@example.com`, ``, "cannot query on redacted URNs", envs.RedactionPolicyURNs},
-		{`URN=ewok`, ``, "cannot query on redacted URNs", envs.RedactionPolicyURNs},
-
-		// field conditions
-		{`Age IS 18`, `age = 18`, "", envs.RedactionPolicyNone},
-		{`AGE != ""`, `age != ""`, "", envs.RedactionPolicyNone},
-		{`age ~ 34`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`gender ~ M`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-
-		// lt/lte/gt/gte comparisons
-		{`Age > "18"`, `age > 18`, "", envs.RedactionPolicyNone},
-		{`Age >= 18`, `age >= 18`, "", envs.RedactionPolicyNone},
-		{`Age < 18`, `age < 18`, "", envs.RedactionPolicyNone},
-		{`Age <= 18`, `age <= 18`, "", envs.RedactionPolicyNone},
-		{`DOB > "27-01-2020"`, `dob > "27-01-2020"`, "", envs.RedactionPolicyNone},
-		{`DOB >= 27-01-2020`, `dob >= "27-01-2020"`, "", envs.RedactionPolicyNone},
-		{`DOB < 27/01/2020`, `dob < "27/01/2020"`, "", envs.RedactionPolicyNone},
-		{`DOB <= 27.01.2020`, `dob <= "27.01.2020"`, "", envs.RedactionPolicyNone},
-		{`name > Will`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`tel < 23425`, ``, "comparisons with < can only be used with date and number fields", envs.RedactionPolicyNone},
-
-		// implicit combinations
-		{`will felix`, `name ~ "will" AND name ~ "felix"`, "", envs.RedactionPolicyNone},
-		{`will +123456566`, `name ~ "will" AND tel ~ "+123456566"`, "", envs.RedactionPolicyNone},
-
-		// explicit combinations...
-		{`will and felix`, `name ~ "will" AND name ~ "felix"`, "", envs.RedactionPolicyNone}, // explicit AND
-		{`will or felix or matt`, `(name ~ "will" OR name ~ "felix") OR name ~ "matt"`, "", envs.RedactionPolicyNone},
-		{`name=will or Name ~ "felix"`, `name = "will" OR name ~ "felix"`, "", envs.RedactionPolicyNone},
-		{`Name is will or Name has felix`, `name = "will" OR name ~ "felix"`, "", envs.RedactionPolicyNone}, // operator aliases
-		{`will or Name ~ "felix"`, `name ~ "will" OR name ~ "felix"`, "", envs.RedactionPolicyNone},
-
-		// boolean operator precedence is AND before OR, even when AND is implicit
-		{`will and felix or matt amber`, `(name ~ "will" AND name ~ "felix") OR (name ~ "matt" AND name ~ "amber")`, "", envs.RedactionPolicyNone},
-
-		// boolean combinations can themselves be combined
-		{
-			`(Age < 18 and Gender = "male") or (Age > 18 and Gender = "female")`,
-			`(age < 18 AND gender = "male") OR (age > 18 AND gender = "female")`,
-			"",
-			envs.RedactionPolicyNone,
-		},
-
-		{`xyz != ""`, ``, "can't resolve 'xyz' to attribute, scheme or field", envs.RedactionPolicyNone},
-		{`group != "Gamers"`, ``, "'Gamers' is not a valid group name", envs.RedactionPolicyNone},
-		{`language = "xxxx"`, ``, "'xxxx' is not a valid language code", envs.RedactionPolicyNone},
-
-		{`name = "O\"Leary"`, `name = "O\"Leary"`, "", envs.RedactionPolicyNone}, // string unquoting
-
-		// = supported for everything
-		{`uuid = f81d1eb5-215d-4ae8-90fa-38b3f2d6e328`, `uuid = "f81d1eb5-215d-4ae8-90fa-38b3f2d6e328"`, "", envs.RedactionPolicyNone},
-		{`id = 02352`, `id = 02352`, "", envs.RedactionPolicyNone},
-		{`name = felix`, `name = "felix"`, "", envs.RedactionPolicyNone},
-		{`language = eng`, `language = "eng"`, "", envs.RedactionPolicyNone},
-		{`group = u-reporters`, `group = "u-reporters"`, "", envs.RedactionPolicyNone},
-		{`created_on = 20-02-2020`, `created_on = "20-02-2020"`, "", envs.RedactionPolicyNone},
-		{`tel = 02352`, `tel = 02352`, "", envs.RedactionPolicyNone},
-		{`urn = 02352`, `urn = 02352`, "", envs.RedactionPolicyNone},
-		{`age = 18`, `age = 18`, "", envs.RedactionPolicyNone},
-		{`gender = male`, `gender = "male"`, "", envs.RedactionPolicyNone},
-		{`dob = 20-02-2020`, `dob = "20-02-2020"`, "", envs.RedactionPolicyNone},
-		{`state = Pichincha`, `state = "Pichincha"`, "", envs.RedactionPolicyNone},
-
-		// != supported for everything
-		{`uuid != f81d1eb5-215d-4ae8-90fa-38b3f2d6e328`, `uuid != "f81d1eb5-215d-4ae8-90fa-38b3f2d6e328"`, "", envs.RedactionPolicyNone},
-		{`id != 02352`, `id != 02352`, "", envs.RedactionPolicyNone},
-		{`name != felix`, `name != "felix"`, "", envs.RedactionPolicyNone},
-		{`language != eng`, `language != "eng"`, "", envs.RedactionPolicyNone},
-		{`group != u-reporters`, `group != "u-reporters"`, "", envs.RedactionPolicyNone},
-		{`created_on != 20-02-2020`, `created_on != "20-02-2020"`, "", envs.RedactionPolicyNone},
-		{`tel != 02352`, `tel != 02352`, "", envs.RedactionPolicyNone},
-		{`urn != 02352`, `urn != 02352`, "", envs.RedactionPolicyNone},
-		{`age != 18`, `age != 18`, "", envs.RedactionPolicyNone},
-		{`gender != male`, `gender != "male"`, "", envs.RedactionPolicyNone},
-		{`dob != 20-02-2020`, `dob != "20-02-2020"`, "", envs.RedactionPolicyNone},
-		{`state != Pichincha`, `state != "Pichincha"`, "", envs.RedactionPolicyNone},
-
-		// = "" supported for name, language, fields and urns
-		{`uuid = ""`, ``, "can't check whether 'uuid' is set or not set", envs.RedactionPolicyNone},
-		{`id = ""`, ``, "can't check whether 'id' is set or not set", envs.RedactionPolicyNone},
-		{`name = ""`, `name = ""`, "", envs.RedactionPolicyNone},
-		{`language = ""`, `language = ""`, "", envs.RedactionPolicyNone},
-		{`group = ""`, ``, "can't check whether 'group' is set or not set", envs.RedactionPolicyNone},
-		{`created_on = ""`, ``, "can't check whether 'created_on' is set or not set", envs.RedactionPolicyNone},
-		{`tel = ""`, `tel = ""`, "", envs.RedactionPolicyNone},
-		{`urn = ""`, `urn = ""`, "", envs.RedactionPolicyNone},
-		{`age = ""`, `age = ""`, "", envs.RedactionPolicyNone},
-		{`gender = ""`, `gender = ""`, "", envs.RedactionPolicyNone},
-		{`dob = ""`, `dob = ""`, "", envs.RedactionPolicyNone},
-		{`state = ""`, `state = ""`, "", envs.RedactionPolicyNone},
-
-		// ~ only supported for name and URNs
-		{`uuid ~ 02352`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`id ~ 02352`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`name ~ felix`, `name ~ "felix"`, "", envs.RedactionPolicyNone},
-		{`language ~ eng`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`group ~ porters`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`created_on ~ 2018`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`tel ~ 02352`, `tel ~ 02352`, "", envs.RedactionPolicyNone},
-		{`urn ~ 02352`, `urn ~ 02352`, "", envs.RedactionPolicyNone},
-		{`age ~ 18`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`gender ~ mal`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`dob ~ 20-02-2020`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-		{`state ~ Pichincha`, ``, "contains conditions can only be used with name or URN values", envs.RedactionPolicyNone},
-
-		// > >= < <= only supported for numeric or date fields
-		{`uuid > 02352`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`id > 02352`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`name > felix`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`language > eng`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`group > reporters`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`created_on > 20-02-2020`, `created_on > "20-02-2020"`, "", envs.RedactionPolicyNone},
-		{`tel > 02352`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`urn > 02352`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`age > 18`, `age > 18`, "", envs.RedactionPolicyNone},
-		{`gender > male`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-		{`dob > 20-02-2020`, `dob > "20-02-2020"`, "", envs.RedactionPolicyNone},
-		{`state > Pichincha`, ``, "comparisons with > can only be used with date and number fields", envs.RedactionPolicyNone},
-	}
-
+func TestParseQuery(t *testing.T) {
 	resolver := contactql.NewMockResolver(map[string]assets.Field{
 		"age":    types.NewField(assets.FieldUUID("f1b5aea6-6586-41c7-9020-1a6326cc6565"), "age", "Age", assets.FieldTypeNumber),
 		"gender": types.NewField(assets.FieldUUID("d66a7823-eada-40e5-9a3a-57239d4690bf"), "gender", "Gender", assets.FieldTypeText),
@@ -206,13 +21,206 @@ func TestParseAndValidateQuery(t *testing.T) {
 		"u-reporters": types.NewGroup(assets.GroupUUID(""), "U-Reporters", ""),
 	})
 
-	for _, tc := range tests {
-		env := envs.NewBuilder().WithDateFormat(envs.DateFormatDayMonthYear).WithDefaultCountry("US").WithRedactionPolicy(tc.redact).Build()
+	tests := []struct {
+		text       string
+		parsed     string
+		err        string
+		redactURNs bool
+		resolver   contactql.Resolver
+	}{
+		// implicit conditions
+		{text: `"will"`, parsed: `name ~ "will"`, resolver: resolver},
+		{text: `Will`, parsed: `name ~ "Will"`, resolver: resolver},
+		{text: `wil`, parsed: `name ~ "wil"`, resolver: resolver},
+		{text: `wi`, parsed: `name ~ "wi"`, resolver: resolver},
+		{text: `w`, parsed: `name = "w"`, resolver: resolver}, // don't have at least 1 token of >= 2 chars
+		{text: `w me`, parsed: `name = "w" AND name ~ "me"`, resolver: resolver},
+		{text: `w m`, parsed: `name = "w" AND name = "m"`, resolver: resolver},
+		{text: `tel:+0123456566`, parsed: `tel = "+0123456566"`, resolver: resolver}, // whole query is a URN
+		{text: `twitter:bobby`, parsed: `twitter = "bobby"`, resolver: resolver},
+		{text: `(202) 456-1111`, parsed: `tel = "+12024561111"`, resolver: resolver}, // whole query looks like a phone number
+		{text: `+12024561111`, parsed: `tel = "+12024561111"`, resolver: resolver},
+		{text: ` 202.456.1111 `, parsed: `tel = "+12024561111"`, resolver: resolver},
+		{text: `"+12024561111"`, parsed: `tel ~ "+12024561111"`, resolver: resolver},
+		{text: `566`, parsed: `name ~ 566`, resolver: resolver}, // too short to be a phone number
 
-		parsed, err := contactql.ParseQuery(env, tc.text)
-		if parsed != nil {
-			err = parsed.Validate(env, resolver)
+		// implicit conditions with URN redaction
+		{text: `will`, parsed: `name ~ "will"`, redactURNs: true, resolver: resolver},
+		{text: `tel:+0123456566`, parsed: `name ~ "tel:+0123456566"`, redactURNs: true, resolver: resolver},
+		{text: `twitter:bobby`, parsed: `name ~ "twitter:bobby"`, redactURNs: true, resolver: resolver},
+		{text: `0123456566`, parsed: `id = 123456566`, redactURNs: true, resolver: resolver},
+		{text: `+0123456566`, parsed: `id = 123456566`, redactURNs: true, resolver: resolver},
+		{text: `0123-456-566`, parsed: `name ~ "0123-456-566"`, redactURNs: true, resolver: resolver},
+
+		// explicit conditions on name
+		{text: `Name=will`, parsed: `name = "will"`, resolver: resolver},
+		{text: `Name=O'Shea`, parsed: `name = "O'Shea"`, resolver: resolver},
+		{text: `Name ~ "felix"`, parsed: `name ~ "felix"`, resolver: resolver},
+		{text: `Name HAS "Felix"`, parsed: `name ~ "Felix"`, resolver: resolver},
+		{text: `name is ""`, parsed: `name = ""`, resolver: resolver},            // is not set
+		{text: `name != ""`, parsed: `name != ""`, resolver: resolver},           // is set
+		{text: `name != "felix"`, parsed: `name != "felix"`, resolver: resolver}, // is not equal to value
+		{text: `Name ~ ""`, err: "contains operator on name requires token of minimum length 2", resolver: resolver},
+
+		// explicit attribute conditions
+		{text: `language = spa`, parsed: `language = "spa"`, resolver: resolver},
+		{text: `Group IS U-Reporters`, parsed: `group = "U-Reporters"`, resolver: resolver},
+		{text: `CREATED_ON>27-01-2020`, parsed: `created_on > "27-01-2020"`, resolver: resolver},
+
+		// explicit conditions on URN
+		{text: `tel=""`, parsed: `tel = ""`, resolver: resolver},
+		{text: `tel!=""`, parsed: `tel != ""`, resolver: resolver},
+		{text: `tel IS 233`, parsed: `tel = 233`, resolver: resolver},
+		{text: `tel HAS 233`, parsed: `tel ~ 233`, resolver: resolver},
+		{text: `tel ~ 23`, err: "contains operator on URN requires value of minimum length 3", resolver: resolver},
+		{text: `mailto = user@example.com`, parsed: `mailto = "user@example.com"`, resolver: resolver},
+		{text: `MAILTO ~ user@example.com`, parsed: `mailto ~ "user@example.com"`, resolver: resolver},
+		{text: `URN=ewok`, parsed: `urn = "ewok"`, resolver: resolver},
+
+		// explicit conditions on URN with URN redaction
+		{text: `tel=""`, parsed: `tel = ""`, redactURNs: true, resolver: resolver},
+		{text: `tel!=""`, parsed: `tel != ""`, redactURNs: true, resolver: resolver},
+		{text: `mailto=""`, parsed: `mailto = ""`, redactURNs: true, resolver: resolver},
+		{text: `mailto!=""`, parsed: `mailto != ""`, redactURNs: true, resolver: resolver},
+		{text: `urn=""`, parsed: `urn = ""`, redactURNs: true, resolver: resolver},
+		{text: `urn!=""`, parsed: `urn != ""`, redactURNs: true, resolver: resolver},
+		{text: `tel = 233`, err: "cannot query on redacted URNs", redactURNs: true, resolver: resolver},
+		{text: `tel ~ 233`, err: "cannot query on redacted URNs", redactURNs: true, resolver: resolver},
+		{text: `mailto = user@example.com`, err: "cannot query on redacted URNs", redactURNs: true, resolver: resolver},
+		{text: `MAILTO ~ user@example.com`, err: "cannot query on redacted URNs", redactURNs: true, resolver: resolver},
+		{text: `URN=ewok`, err: "cannot query on redacted URNs", redactURNs: true, resolver: resolver},
+
+		// field conditions
+		{text: `Age IS 18`, parsed: `age = 18`, resolver: resolver},
+		{text: `AGE != ""`, parsed: `age != ""`, resolver: resolver},
+		{text: `age ~ 34`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `gender ~ M`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+
+		// lt/lte/gt/gte comparisons
+		{text: `Age > "18"`, parsed: `age > 18`, resolver: resolver},
+		{text: `Age >= 18`, parsed: `age >= 18`, resolver: resolver},
+		{text: `Age < 18`, parsed: `age < 18`, resolver: resolver},
+		{text: `Age <= 18`, parsed: `age <= 18`, resolver: resolver},
+		{text: `DOB > "27-01-2020"`, parsed: `dob > "27-01-2020"`, resolver: resolver},
+		{text: `DOB >= 27-01-2020`, parsed: `dob >= "27-01-2020"`, resolver: resolver},
+		{text: `DOB < 27/01/2020`, parsed: `dob < "27/01/2020"`, resolver: resolver},
+		{text: `DOB <= 27.01.2020`, parsed: `dob <= "27.01.2020"`, resolver: resolver},
+		{text: `name > Will`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `tel < 23425`, err: "comparisons with < can only be used with date and number fields", resolver: resolver},
+
+		// implicit combinations
+		{text: `will felix`, parsed: `name ~ "will" AND name ~ "felix"`, resolver: resolver},
+		{text: `will +123456566`, parsed: `name ~ "will" AND tel ~ "+123456566"`, resolver: resolver},
+
+		// explicit combinations...
+		{text: `will and felix`, parsed: `name ~ "will" AND name ~ "felix"`, resolver: resolver}, // explicit AND
+		{text: `will or felix or matt`, parsed: `(name ~ "will" OR name ~ "felix") OR name ~ "matt"`, resolver: resolver},
+		{text: `name=will or Name ~ "felix"`, parsed: `name = "will" OR name ~ "felix"`, resolver: resolver},
+		{text: `Name is will or Name has felix`, parsed: `name = "will" OR name ~ "felix"`, resolver: resolver}, // operator aliases
+		{text: `will or Name ~ "felix"`, parsed: `name ~ "will" OR name ~ "felix"`, resolver: resolver},
+
+		// boolean operator precedence is AND before OR, even when AND is implicit
+		{text: `will and felix or matt amber`, parsed: `(name ~ "will" AND name ~ "felix") OR (name ~ "matt" AND name ~ "amber")`, resolver: resolver},
+
+		// boolean combinations can themselves be combined
+		{
+			text:     `(Age < 18 and Gender = "male") or (Age > 18 and Gender = "female")`,
+			parsed:   `(age < 18 AND gender = "male") OR (age > 18 AND gender = "female")`,
+			resolver: resolver,
+		},
+
+		{text: `xyz != ""`, err: "can't resolve 'xyz' to attribute, scheme or field", resolver: resolver},
+		{text: `group != "Gamers"`, err: "'Gamers' is not a valid group name", resolver: resolver},
+		{text: `language = "xxxx"`, err: "'xxxx' is not a valid language code", resolver: resolver},
+
+		{text: `name = "O\"Leary"`, parsed: `name = "O\"Leary"`, resolver: resolver}, // string unquoting
+
+		// = supported for everything
+		{text: `uuid = f81d1eb5-215d-4ae8-90fa-38b3f2d6e328`, parsed: `uuid = "f81d1eb5-215d-4ae8-90fa-38b3f2d6e328"`, resolver: resolver},
+		{text: `id = 02352`, parsed: `id = 02352`, resolver: resolver},
+		{text: `name = felix`, parsed: `name = "felix"`, resolver: resolver},
+		{text: `language = eng`, parsed: `language = "eng"`, resolver: resolver},
+		{text: `group = u-reporters`, parsed: `group = "u-reporters"`, resolver: resolver},
+		{text: `created_on = 20-02-2020`, parsed: `created_on = "20-02-2020"`, resolver: resolver},
+		{text: `tel = 02352`, parsed: `tel = 02352`, resolver: resolver},
+		{text: `urn = 02352`, parsed: `urn = 02352`, resolver: resolver},
+		{text: `age = 18`, parsed: `age = 18`, resolver: resolver},
+		{text: `gender = male`, parsed: `gender = "male"`, resolver: resolver},
+		{text: `dob = 20-02-2020`, parsed: `dob = "20-02-2020"`, resolver: resolver},
+		{text: `state = Pichincha`, parsed: `state = "Pichincha"`, resolver: resolver},
+
+		// != supported for everything
+		{text: `uuid != f81d1eb5-215d-4ae8-90fa-38b3f2d6e328`, parsed: `uuid != "f81d1eb5-215d-4ae8-90fa-38b3f2d6e328"`, resolver: resolver},
+		{text: `id != 02352`, parsed: `id != 02352`, resolver: resolver},
+		{text: `name != felix`, parsed: `name != "felix"`, resolver: resolver},
+		{text: `language != eng`, parsed: `language != "eng"`, resolver: resolver},
+		{text: `group != u-reporters`, parsed: `group != "u-reporters"`, resolver: resolver},
+		{text: `created_on != 20-02-2020`, parsed: `created_on != "20-02-2020"`, resolver: resolver},
+		{text: `tel != 02352`, parsed: `tel != 02352`, resolver: resolver},
+		{text: `urn != 02352`, parsed: `urn != 02352`, resolver: resolver},
+		{text: `age != 18`, parsed: `age != 18`, resolver: resolver},
+		{text: `gender != male`, parsed: `gender != "male"`, resolver: resolver},
+		{text: `dob != 20-02-2020`, parsed: `dob != "20-02-2020"`, resolver: resolver},
+		{text: `state != Pichincha`, parsed: `state != "Pichincha"`, resolver: resolver},
+
+		// = "" supported for name, language, fields and urns
+		{text: `uuid = ""`, err: "can't check whether 'uuid' is set or not set", resolver: resolver},
+		{text: `id = ""`, err: "can't check whether 'id' is set or not set", resolver: resolver},
+		{text: `name = ""`, parsed: `name = ""`, resolver: resolver},
+		{text: `language = ""`, parsed: `language = ""`, resolver: resolver},
+		{text: `group = ""`, err: "can't check whether 'group' is set or not set", resolver: resolver},
+		{text: `created_on = ""`, err: "can't check whether 'created_on' is set or not set", resolver: resolver},
+		{text: `tel = ""`, parsed: `tel = ""`, resolver: resolver},
+		{text: `urn = ""`, parsed: `urn = ""`, resolver: resolver},
+		{text: `age = ""`, parsed: `age = ""`, resolver: resolver},
+		{text: `gender = ""`, parsed: `gender = ""`, resolver: resolver},
+		{text: `dob = ""`, parsed: `dob = ""`, resolver: resolver},
+		{text: `state = ""`, parsed: `state = ""`, resolver: resolver},
+
+		// ~ only supported for name and URNs
+		{text: `uuid ~ 02352`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `id ~ 02352`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `name ~ felix`, parsed: `name ~ "felix"`, resolver: resolver},
+		{text: `language ~ eng`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `group ~ porters`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `created_on ~ 2018`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `tel ~ 02352`, parsed: `tel ~ 02352`, resolver: resolver},
+		{text: `urn ~ 02352`, parsed: `urn ~ 02352`, resolver: resolver},
+		{text: `age ~ 18`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `gender ~ mal`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `dob ~ 20-02-2020`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+		{text: `state ~ Pichincha`, err: "contains conditions can only be used with name or URN values", resolver: resolver},
+
+		// > >= < <= only supported for numeric or date fields
+		{text: `uuid > 02352`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `id > 02352`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `name > felix`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `language > eng`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `group > reporters`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `created_on > 20-02-2020`, parsed: `created_on > "20-02-2020"`, resolver: resolver},
+		{text: `tel > 02352`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `urn > 02352`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `age > 18`, parsed: `age > 18`, resolver: resolver},
+		{text: `gender > male`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+		{text: `dob > 20-02-2020`, parsed: `dob > "20-02-2020"`, resolver: resolver},
+		{text: `state > Pichincha`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
+
+		// however if we don't provide a resolver, we don't know the field type, so allowed for all
+		{text: `age > 18`, parsed: `age > 18`},
+		{text: `gender > male`, parsed: `gender > "male"`},
+		{text: `dob > 20-02-2020`, parsed: `dob > "20-02-2020"`},
+		{text: `state > Pichincha`, parsed: `state > "Pichincha"`},
+	}
+
+	for _, tc := range tests {
+		redact := envs.RedactionPolicyNone
+		if tc.redactURNs {
+			redact = envs.RedactionPolicyURNs
 		}
+
+		env := envs.NewBuilder().WithDateFormat(envs.DateFormatDayMonthYear).WithDefaultCountry("US").WithRedactionPolicy(redact).Build()
+
+		parsed, err := contactql.ParseQuery(env, tc.text, tc.resolver)
 
 		if tc.err != "" {
 			assert.EqualError(t, err, tc.err, "error mismatch for '%s'", tc.text)
@@ -330,10 +338,7 @@ func TestParsingErrors(t *testing.T) {
 	}, map[string]assets.Group{})
 
 	for _, tc := range tests {
-		parsed, err := contactql.ParseQuery(env, tc.query)
-		if parsed != nil {
-			err = parsed.Validate(env, resolver)
-		}
+		_, err := contactql.ParseQuery(env, tc.query, resolver)
 
 		assert.EqualError(t, err, tc.errMsg, "error mismatch for '%s'", tc.query)
 

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -440,20 +440,16 @@ func (c *Contact) UpdatePreferredChannel(channel *Channel) bool {
 }
 
 // ReevaluateQueryBasedGroups reevaluates membership of all query based groups for this contact
-func (c *Contact) ReevaluateQueryBasedGroups(env envs.Environment) ([]*Group, []*Group, []error) {
+func (c *Contact) ReevaluateQueryBasedGroups(env envs.Environment) ([]*Group, []*Group) {
 	added := make([]*Group, 0)
 	removed := make([]*Group, 0)
-	errs := make([]error, 0)
 
 	for _, group := range c.assets.Groups().All() {
 		if !group.UsesQuery() {
 			continue
 		}
 
-		qualifies, err := group.CheckQueryBasedMembership(env, c)
-		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "unable to re-evaluate membership of group '%s'", group.Name()))
-		}
+		qualifies := group.CheckQueryBasedMembership(env, c)
 
 		if qualifies {
 			if c.groups.Add(group) {
@@ -466,7 +462,7 @@ func (c *Contact) ReevaluateQueryBasedGroups(env envs.Environment) ([]*Group, []
 		}
 	}
 
-	return added, removed, errs
+	return added, removed
 }
 
 // QueryProperty resolves a contact query search key for this contact

--- a/flows/contact_test.go
+++ b/flows/contact_test.go
@@ -507,16 +507,12 @@ func TestContactQuery(t *testing.T) {
 			env = session.Environment()
 		}
 
-		parsed, err := contactql.ParseQuery(env, q)
-		if err != nil {
-			return false, err
-		}
-		err = parsed.Validate(env, session.Assets())
+		parsed, err := contactql.ParseQuery(env, q, session.Assets())
 		if err != nil {
 			return false, err
 		}
 
-		return contactql.EvaluateQuery(env, session.Assets(), parsed, contact)
+		return contactql.EvaluateQuery(env, parsed, contact), nil
 	}
 
 	for _, tc := range testCases {

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -502,12 +502,7 @@ func (s *session) ensureQueryBasedGroups(logEvent flows.EventCallback) {
 		return
 	}
 
-	added, removed, errors := s.contact.ReevaluateQueryBasedGroups(s.Environment())
-
-	// add error event for each group we couldn't re-evaluate
-	for _, err := range errors {
-		logEvent(events.NewError(err))
-	}
+	added, removed := s.contact.ReevaluateQueryBasedGroups(s.Environment())
 
 	// add groups changed event for the groups we were added/removed to/from
 	if len(added) > 0 || len(removed) > 0 {

--- a/flows/group.go
+++ b/flows/group.go
@@ -20,11 +20,8 @@ type Group struct {
 // NewGroup returns a new group object from the given group asset
 func NewGroup(env envs.Environment, fields *FieldAssets, asset assets.Group) (*Group, error) {
 	if asset.Query() != "" {
-		query, err := contactql.ParseQuery(env, asset.Query())
+		query, err := contactql.ParseQuery(env, asset.Query(), fields)
 		if err != nil {
-			return nil, err
-		}
-		if err := query.Validate(env, fields); err != nil {
 			return nil, err
 		}
 
@@ -41,16 +38,16 @@ func (g *Group) Asset() assets.Group { return g.Group }
 func (g *Group) UsesQuery() bool { return g.Query() != "" }
 
 // CheckQueryBasedMembership returns whether the given contact belongs in a query based group
-func (g *Group) CheckQueryBasedMembership(env envs.Environment, contact *Contact) (bool, error) {
+func (g *Group) CheckQueryBasedMembership(env envs.Environment, contact *Contact) bool {
 	if !g.UsesQuery() {
 		panic("can't check membership on a non-query based group")
 	}
 
 	if contact.Status() != ContactStatusActive {
-		return false, nil
+		return false
 	}
 
-	return contactql.EvaluateQuery(env, g.resolver, g.parsedQuery, contact)
+	return contactql.EvaluateQuery(env, g.parsedQuery, contact)
 }
 
 // Reference returns a reference to this group

--- a/flows/modifiers/base.go
+++ b/flows/modifiers/base.go
@@ -40,12 +40,7 @@ func (m *baseModifier) Type() string { return m.Type_ }
 
 // helper to re-evaluate groups and log any changes to membership
 func (m *baseModifier) reevaluateGroups(env envs.Environment, assets flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) {
-	added, removed, errors := contact.ReevaluateQueryBasedGroups(env)
-
-	// add error event for each group we couldn't re-evaluate
-	for _, err := range errors {
-		log(events.NewError(err))
-	}
+	added, removed := contact.ReevaluateQueryBasedGroups(env)
 
 	// make sure from all static groups are removed for non-active contacts
 	if contact.Status() != flows.ContactStatusActive {


### PR DESCRIPTION
* Queries can be parsed with or without a resolver
* Only queries parsed with a resolver can be evaluated
* Inspection optionally uses resolver