### PR TITLE
Add engine property for maximum resumes per session

### DIFF
--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -10,9 +10,10 @@ import (
 
 // an instance of the engine
 type engine struct {
-	services          *services
-	maxStepsPerSprint int
-	maxTemplateChars  int
+	services             *services
+	maxStepsPerSprint    int
+	maxResumesPerSession int
+	maxTemplateChars     int
 }
 
 // NewSession creates a new session
@@ -37,9 +38,10 @@ func (e *engine) ReadSession(sa flows.SessionAssets, data json.RawMessage, missi
 	return readSession(e, sa, data, missing)
 }
 
-func (e *engine) Services() flows.Services { return e.services }
-func (e *engine) MaxStepsPerSprint() int   { return e.maxStepsPerSprint }
-func (e *engine) MaxTemplateChars() int    { return e.maxTemplateChars }
+func (e *engine) Services() flows.Services  { return e.services }
+func (e *engine) MaxStepsPerSprint() int    { return e.maxStepsPerSprint }
+func (e *engine) MaxResumesPerSession() int { return e.maxResumesPerSession }
+func (e *engine) MaxTemplateChars() int     { return e.maxTemplateChars }
 
 var _ flows.Engine = (*engine)(nil)
 
@@ -56,9 +58,10 @@ type Builder struct {
 func NewBuilder() *Builder {
 	return &Builder{
 		eng: &engine{
-			services:          newEmptyServices(),
-			maxStepsPerSprint: 100,
-			maxTemplateChars:  10000,
+			services:             newEmptyServices(),
+			maxStepsPerSprint:    100,
+			maxResumesPerSession: 500,
+			maxTemplateChars:     10000,
 		},
 	}
 }
@@ -96,6 +99,12 @@ func (b *Builder) WithAirtimeServiceFactory(f AirtimeServiceFactory) *Builder {
 // WithMaxStepsPerSprint sets the maximum number of steps allowed in a single sprint
 func (b *Builder) WithMaxStepsPerSprint(max int) *Builder {
 	b.eng.maxStepsPerSprint = max
+	return b
+}
+
+// WithMaxResumesPerSession sets the maximum number of resumes allowed in a single session
+func (b *Builder) WithMaxResumesPerSession(max int) *Builder {
+	b.eng.maxResumesPerSession = max
 	return b
 }
 

--- a/flows/engine/engine_test.go
+++ b/flows/engine/engine_test.go
@@ -13,9 +13,10 @@ import (
 
 func TestBuilder(t *testing.T) {
 	// create engine with no services
-	eng := engine.NewBuilder().WithMaxStepsPerSprint(123).Build()
+	eng := engine.NewBuilder().WithMaxStepsPerSprint(123).WithMaxResumesPerSession(567).Build()
 
 	assert.Equal(t, 123, eng.MaxStepsPerSprint())
+	assert.Equal(t, 567, eng.MaxResumesPerSession())
 
 	_, err := eng.Services().Email(nil)
 	assert.EqualError(t, err, "no email service factory configured")

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -387,6 +387,31 @@ func TestSessionHistory(t *testing.T) {
 	}, session2.History())
 }
 
+func TestMaxResumesPerSession(t *testing.T) {
+	assetsJSON, err := os.ReadFile("../../test/testdata/runner/two_questions.json")
+	require.NoError(t, err)
+
+	session, _, err := test.CreateSession(assetsJSON, "615b8a0f-588c-4d20-a05f-363b0b4ce6f4")
+	require.NoError(t, err)
+	require.Equal(t, flows.SessionStatusWaiting, session.Status())
+
+	numResumes := 0
+	for {
+		msg := flows.NewMsgIn(flows.MsgUUID(uuids.New()), "tel:+593979123456", nil, "Teal", nil)
+		resume := resumes.NewMsg(nil, nil, msg)
+		numResumes++
+
+		_, err := session.Resume(resume)
+		require.NoError(t, err)
+
+		if session.Status() == flows.SessionStatusFailed {
+			break
+		}
+	}
+
+	assert.Equal(t, 500, numResumes)
+}
+
 func TestFindStep(t *testing.T) {
 	session, evts, err := test.CreateTestSession("", envs.RedactionPolicyNone)
 	require.NoError(t, err)

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -327,6 +327,7 @@ type Engine interface {
 
 	Services() Services
 	MaxStepsPerSprint() int
+	MaxResumesPerSession() int
 	MaxTemplateChars() int
 }
 

--- a/test/testdata/runner/node_loop.test.json
+++ b/test/testdata/runner/node_loop.test.json
@@ -1405,7 +1405,7 @@
                 {
                     "created_on": "2018-07-06T12:35:03.123456789Z",
                     "step_uuid": "d67c1713-db75-4403-a020-37bccfcdf0e7",
-                    "text": "step limit exceeded, stopping execution before entering '32bc60ad-5c86-465e-a6b8-049c44ecce49'",
+                    "text": "reached maximum number of steps per sprint (100)",
                     "type": "failure"
                 }
             ],
@@ -2854,7 +2854,7 @@
                             {
                                 "created_on": "2018-07-06T12:35:03.123456789Z",
                                 "step_uuid": "d67c1713-db75-4403-a020-37bccfcdf0e7",
-                                "text": "step limit exceeded, stopping execution before entering '32bc60ad-5c86-465e-a6b8-049c44ecce49'",
+                                "text": "reached maximum number of steps per sprint (100)",
                                 "type": "failure"
                             }
                         ],


### PR DESCRIPTION
Perhaps part of the fix for https://github.com/rapidpro/rapidpro/issues/1575