### PR TITLE
Support contact queries on flow history

### DIFF
--- a/contactql/es/query.go
+++ b/contactql/es/query.go
@@ -315,10 +315,15 @@ func attributeConditionToElastic(env envs.Environment, resolver contactql.Resolv
 		default:
 			panic(fmt.Sprintf("unsupported group attribute operator: %s", c.Operator()))
 		}
-	case contactql.AttributeFlow:
+	case contactql.AttributeFlow, contactql.AttributeHistory:
+		fieldName := "flow_id"
+		if c.PropertyKey() == contactql.AttributeHistory {
+			fieldName = "flow_history_ids"
+		}
+
 		// special case for set/unset
 		if (c.Operator() == contactql.OpEqual || c.Operator() == contactql.OpNotEqual) && value == "" {
-			query = elastic.NewExistsQuery("flow_id")
+			query = elastic.NewExistsQuery(fieldName)
 			if c.Operator() == contactql.OpEqual {
 				query = not(query)
 			}
@@ -329,9 +334,9 @@ func attributeConditionToElastic(env envs.Environment, resolver contactql.Resolv
 
 		switch c.Operator() {
 		case contactql.OpEqual:
-			return elastic.NewTermQuery("flow_id", mapper.Flow(flow))
+			return elastic.NewTermQuery(fieldName, mapper.Flow(flow))
 		case contactql.OpNotEqual:
-			return not(elastic.NewTermQuery("flow_id", mapper.Flow(flow)))
+			return not(elastic.NewTermQuery(fieldName, mapper.Flow(flow)))
 		default:
 			panic(fmt.Sprintf("unsupported flow attribute operator: %s", c.Operator()))
 		}

--- a/contactql/es/testdata/to_query.json
+++ b/contactql/es/testdata/to_query.json
@@ -1736,6 +1736,50 @@
         }
     },
     {
+        "description": "history equality",
+        "query": "history = \"registration\"",
+        "elastic": {
+            "term": {
+                "flow_history_ids": 234
+            }
+        }
+    },
+    {
+        "description": "flow inequality",
+        "query": "history != \"registration\"",
+        "elastic": {
+            "bool": {
+                "must_not": {
+                    "term": {
+                        "flow_history_ids": 234
+                    }
+                }
+            }
+        }
+    },
+    {
+        "description": "history is set",
+        "query": "history != \"\"",
+        "elastic": {
+            "exists": {
+                "field": "flow_history_ids"
+            }
+        }
+    },
+    {
+        "description": "history is not set",
+        "query": "history = \"\"",
+        "elastic": {
+            "bool": {
+                "must_not": {
+                    "exists": {
+                        "field": "flow_history_ids"
+                    }
+                }
+            }
+        }
+    },
+    {
         "description": "bool and",
         "query": "color=red and age>10",
         "elastic": {

--- a/contactql/inspect.go
+++ b/contactql/inspect.go
@@ -66,7 +66,7 @@ func Inspect(query *ContactQuery) *Inspection {
 	}
 
 	// can't turn a query into a group if it uses id, group or flow
-	allowAsGroup := !(attributes[AttributeID] || attributes[AttributeGroup] || attributes[AttributeFlow])
+	allowAsGroup := !(attributes[AttributeID] || attributes[AttributeGroup] || attributes[AttributeFlow] || attributes[AttributeHistory])
 
 	return &Inspection{
 		Attributes:   utils.StringSetKeys(attributes),

--- a/contactql/parser.go
+++ b/contactql/parser.go
@@ -190,7 +190,7 @@ func (c *Condition) validate(env envs.Environment, resolver Resolver) error {
 			if group == nil {
 				return NewQueryError(ErrInvalidGroup, "'%s' is not a valid group name", c.value).withExtra("value", c.value)
 			}
-		} else if c.propKey == AttributeFlow && resolver != nil {
+		} else if (c.propKey == AttributeFlow || c.propKey == AttributeHistory) && resolver != nil {
 			flow := c.ValueAsFlow(resolver)
 			if flow == nil {
 				return NewQueryError(ErrInvalidFlow, "'%s' is not a valid flow name", c.value).withExtra("value", c.value)

--- a/contactql/visitor.go
+++ b/contactql/visitor.go
@@ -32,6 +32,7 @@ const (
 	AttributeURN        = "urn"
 	AttributeGroup      = "group"
 	AttributeFlow       = "flow"
+	AttributeHistory    = "history"
 	AttributeTickets    = "tickets"
 	AttributeCreatedOn  = "created_on"
 	AttributeLastSeenOn = "last_seen_on"
@@ -45,6 +46,7 @@ var attributes = map[string]assets.FieldType{
 	AttributeURN:        assets.FieldTypeText,
 	AttributeGroup:      assets.FieldTypeText,
 	AttributeFlow:       assets.FieldTypeText,
+	AttributeHistory:    assets.FieldTypeText,
 	AttributeTickets:    assets.FieldTypeNumber,
 	AttributeCreatedOn:  assets.FieldTypeDatetime,
 	AttributeLastSeenOn: assets.FieldTypeDatetime,


### PR DESCRIPTION
As `history = "Name of flow"`.. tho to be reliable for flow starts we're going to need to make flow names unique or let it work against UUIDs as well as names, i.e. if the text is the format of a UUID, treat is as one.