### PR TITLE
Add support to get object keys

### DIFF
--- a/cmd/docgen/docs/base_test.go
+++ b/cmd/docgen/docs/base_test.go
@@ -43,7 +43,7 @@ func TestGenerateDocs(t *testing.T) {
 	context := completion["context"].(map[string]interface{})
 	functions := completion["functions"].([]interface{})
 
-	assert.Equal(t, 85, len(functions))
+	assert.Equal(t, 86, len(functions))
 
 	types := context["types"].([]interface{})
 	assert.Equal(t, 18, len(types))

--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -136,6 +136,8 @@ func init() {
 		"extract_object": MinArgsCheck(2, ExtractObject),
 		"foreach":        MinArgsCheck(2, ForEach),
 		"foreach_value":  MinArgsCheck(2, ForEachValue),
+
+		"keys": OneArgFunction(Keys),
 	}
 
 	for name, fn := range builtin {
@@ -2099,6 +2101,32 @@ func ExtractObject(env envs.Environment, args ...types.XValue) types.XValue {
 	}
 
 	return types.NewXObject(result)
+}
+
+// Keys takes an object and returns its properties
+//
+//	@(keys(object("a", 123, "b", "hello", "c", "world"))) -> [a, b, c]
+//	@(keys(null)) -> []
+//	@(keys("string")) -> ERROR
+//	@(keys(10)) -> ERROR
+//
+// @function keys(object)
+func Keys(env envs.Environment, arg types.XValue) types.XValue {
+
+	// if utils.IsNil(arg) {
+	// 	return types.NewXErrorf("requires a not nil object as its argument")
+	// }
+
+	object, xerr := types.ToXObject(env, arg)
+	if xerr != nil {
+		return xerr
+	}
+	keys := object.Properties()
+	items := make([]types.XValue, 0)
+	for _, prop := range keys {
+		items = append(items, types.NewXText(prop))
+	}
+	return types.NewXArray(items...)
 }
 
 // ForEach creates a new array by applying `func` to each value in `values`.

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -26,6 +26,7 @@ var xdt = types.NewXDateTime
 var xd = types.NewXDate
 var xt = types.NewXTime
 var xa = types.NewXArray
+var xo = types.NewXObject
 var xf = functions.Lookup
 var ERROR = types.NewXErrorf("any error")
 
@@ -266,6 +267,20 @@ func TestFunctions(t *testing.T) {
 		{"foreach", dmy, []types.XValue{ERROR, xf("upper")}, ERROR},
 		{"foreach", dmy, []types.XValue{xa(xs("a"), xs("b"), xs("c")), ERROR}, ERROR},
 		{"foreach", dmy, []types.XValue{xa(xs("a"), xs("b"), xs("c")), xf("abs")}, ERROR},
+
+		{"keys", dmy, []types.XValue{xo(map[string]types.XValue{"a": xs("x"), "b": xs("y"), "c": xs("z")})}, xa(xs("a"), xs("b"), xs("c"))},
+		{
+			"keys",
+			dmy,
+			[]types.XValue{xo(map[string]types.XValue{"foo": xs("x"), "bar": nil, "sub": xo(map[string]types.XValue{"x": xi(3)})})},
+			xa(xs("bar"), xs("foo"), xs("sub")),
+		},
+		{"keys", dmy, []types.XValue{nil}, xa()},
+		{"keys", dmy, []types.XValue{xa(xs("a"), xs("b"), xs("c"))}, ERROR},
+		{"keys", dmy, []types.XValue{ERROR}, ERROR},
+		{"keys", dmy, []types.XValue{types.NewXObject(map[string]types.XValue{"a": xs("x"), "b": xs("y")}), xf("abs")}, ERROR},
+		{"keys", dmy, []types.XValue{xs("a")}, ERROR},
+		{"keys", dmy, []types.XValue{xi(10)}, ERROR},
 
 		{
 			"foreach_value",


### PR DESCRIPTION
Same as https://github.com/nyaruka/goflow/pull/1127 except the name of the function is `keys`