### PR TITLE
Make `utils.Attachment` smarter about parsing raw URLs

### DIFF
--- a/utils/attachment.go
+++ b/utils/attachment.go
@@ -1,21 +1,29 @@
 package utils
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // Attachment is a media attachment on a message in the format <content-type>:<url>. Content type may be a full
 // media type or may omit the subtype when it is unknown.
 //
 // Examples:
-//  - image/jpeg:http://s3.amazon.com/bucket/test.jpg
-//  - image:http://s3.amazon.com/bucket/test.jpg
-//
+//   - image/jpeg:http://s3.amazon.com/bucket/test.jpg
+//   - image:http://s3.amazon.com/bucket/test.jpg
 type Attachment string
+
+// we allow outgoing attachments to have types like "image"
+var contentTypeRegex = regexp.MustCompile(`^(image|audio|video|application|(\w+/[-+.\w]+))$`)
 
 // ToParts splits an attachment string into content-type and URL
 func (a Attachment) ToParts() (string, string) {
 	offset := strings.Index(string(a), ":")
 	if offset >= 0 {
-		return string(a[:offset]), string(a[offset+1:])
+		t, u := strings.ToLower(string(a[:offset])), string(a[offset+1:])
+		if contentTypeRegex.MatchString(t) {
+			return t, u
+		}
 	}
 	return "", string(a)
 }

--- a/utils/attachment_test.go
+++ b/utils/attachment_test.go
@@ -14,7 +14,21 @@ func TestAttachment(t *testing.T) {
 	assert.Equal(t, "image/jpeg", attachment.ContentType())
 	assert.Equal(t, "https://example.com/test.jpg", attachment.URL())
 
+	assertParse := func(a string, expectedType, expectedURL string) {
+		actualType, actualURL := utils.Attachment(a).ToParts()
+		assert.Equal(t, expectedType, actualType, "content type mismatch for attachment '%s'", a)
+		assert.Equal(t, expectedURL, actualURL, "content type mismatch for attachment '%s'", a)
+	}
+
+	assertParse("audio:http://test.m4a", "audio", "http://test.m4a")
+	assertParse("audio/mp4:http://test.m4a", "audio/mp4", "http://test.m4a")
+	assertParse("audio:/file/path", "audio", "/file/path")
+	assertParse("application:http://test.pdf", "application", "http://test.pdf")
+	assertParse("application/pdf:http://test.pdf", "application/pdf", "http://test.pdf")
+
 	// be lenient with invalid attachments
-	assert.Equal(t, "", utils.Attachment("foo").ContentType())
-	assert.Equal(t, "foo", utils.Attachment("foo").URL())
+	assertParse("foo", "", "foo")
+	assertParse("http://test.jpg", "", "http://test.jpg")
+	assertParse("https://test.jpg", "", "https://test.jpg")
+	assertParse("HTTPS://test.jpg", "", "HTTPS://test.jpg")
 }


### PR DESCRIPTION
Gonna use this in mailroom to know if courier has already fetched attachments