### PR TITLE
Locale for template assets

### DIFF
--- a/assets/static/template.go
+++ b/assets/static/template.go
@@ -1,94 +1,72 @@
 package static
 
 import (
-	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
 )
 
 // Template is a JSON serializable implementation of a template asset
 type Template struct {
-	t struct {
-		UUID         assets.TemplateUUID    `json:"uuid"         validate:"required,uuid"`
-		Name         string                 `json:"name"`
-		Translations []*TemplateTranslation `json:"translations"`
-	}
+	UUID_         assets.TemplateUUID    `json:"uuid"         validate:"required,uuid"`
+	Name_         string                 `json:"name"`
+	Translations_ []*TemplateTranslation `json:"translations"`
 }
 
 // NewTemplate creates a new template
 func NewTemplate(uuid assets.TemplateUUID, name string, translations []*TemplateTranslation) *Template {
-	t := &Template{}
-	t.t.UUID = uuid
-	t.t.Name = name
-	t.t.Translations = translations
-	return t
+	return &Template{
+		UUID_:         uuid,
+		Name_:         name,
+		Translations_: translations,
+	}
 }
 
 // UUID returns the UUID of this template
-func (t *Template) UUID() assets.TemplateUUID { return t.t.UUID }
+func (t *Template) UUID() assets.TemplateUUID { return t.UUID_ }
 
 // Name returns the name of this template
-func (t *Template) Name() string { return t.t.Name }
+func (t *Template) Name() string { return t.Name_ }
 
 // Translations returns the translations for this template
 func (t *Template) Translations() []assets.TemplateTranslation {
-	trs := make([]assets.TemplateTranslation, len(t.t.Translations))
-	for i := range t.t.Translations {
-		trs[i] = t.t.Translations[i]
+	trs := make([]assets.TemplateTranslation, len(t.Translations_))
+	for i := range t.Translations_ {
+		trs[i] = t.Translations_[i]
 	}
 	return trs
 }
 
-// UnmarshalJSON is our unmarshaller for json data
-func (t *Template) UnmarshalJSON(data []byte) error { return jsonx.Unmarshal(data, &t.t) }
-
-// MarshalJSON is our marshaller for json data
-func (t *Template) MarshalJSON() ([]byte, error) { return jsonx.Marshal(t.t) }
-
 // TemplateTranslation represents a single template translation
 type TemplateTranslation struct {
-	t struct {
-		Channel       assets.ChannelReference `json:"channel"         validate:"required"`
-		Content       string                  `json:"content"         validate:"required"`
-		Language      envs.Language           `json:"language"        validate:"required"`
-		Namespace     string                  `json:"namespace"`
-		Country       envs.Country            `json:"country,omitempty"`
-		VariableCount int                     `json:"variable_count"`
-	}
+	Channel_       assets.ChannelReference `json:"channel"         validate:"required"`
+	Content_       string                  `json:"content"         validate:"required"`
+	Locale_        envs.Locale             `json:"locale"          validate:"required"`
+	Namespace_     string                  `json:"namespace"`
+	VariableCount_ int                     `json:"variable_count"`
 }
 
 // NewTemplateTranslation creates a new template translation
-func NewTemplateTranslation(channel assets.ChannelReference, language envs.Language, country envs.Country, content string, variableCount int, namespace string) *TemplateTranslation {
-	t := &TemplateTranslation{}
-	t.t.Channel = channel
-	t.t.Content = content
-	t.t.Namespace = namespace
-	t.t.Language = language
-	t.t.Country = country
-	t.t.VariableCount = variableCount
-	return t
+func NewTemplateTranslation(channel assets.ChannelReference, locale envs.Locale, content string, variableCount int, namespace string) *TemplateTranslation {
+	return &TemplateTranslation{
+		Channel_:       channel,
+		Content_:       content,
+		Namespace_:     namespace,
+		Locale_:        locale,
+		VariableCount_: variableCount,
+	}
 }
 
 // Content returns the translated content for this template
-func (t *TemplateTranslation) Content() string { return t.t.Content }
+func (t *TemplateTranslation) Content() string { return t.Content_ }
 
 // Namespace returns the namespace for this template
-func (t *TemplateTranslation) Namespace() string { return t.t.Namespace }
+func (t *TemplateTranslation) Namespace() string { return t.Namespace_ }
 
-// Language returns the language this translation is in
-func (t *TemplateTranslation) Language() envs.Language { return t.t.Language }
-
-// Country returns the country this translation is for if any
-func (t *TemplateTranslation) Country() envs.Country { return t.t.Country }
+// Language returns the locale this translation is in
+func (t *TemplateTranslation) Locale() envs.Locale { return t.Locale_ }
 
 // VariableCount returns the number of variables in this template
-func (t *TemplateTranslation) VariableCount() int { return t.t.VariableCount }
+func (t *TemplateTranslation) VariableCount() int { return t.VariableCount_ }
 
 // Channel returns the channel this template translation is for
-func (t *TemplateTranslation) Channel() assets.ChannelReference { return t.t.Channel }
-
-// UnmarshalJSON is our unmarshaller for json data
-func (t *TemplateTranslation) UnmarshalJSON(data []byte) error { return jsonx.Unmarshal(data, &t.t) }
-
-// MarshalJSON is our marshaller for json data
-func (t *TemplateTranslation) MarshalJSON() ([]byte, error) { return jsonx.Marshal(t.t) }
+func (t *TemplateTranslation) Channel() assets.ChannelReference { return t.Channel_ }

--- a/assets/static/template_test.go
+++ b/assets/static/template_test.go
@@ -16,10 +16,9 @@ func TestTemplate(t *testing.T) {
 		UUID: assets.ChannelUUID("ffffffff-9b24-92e1-ffff-ffffb207cdb4"),
 	}
 
-	translation := NewTemplateTranslation(channel, envs.Language("eng"), envs.Country("US"), "Hello {{1}}", 1, "0162a7f4_dfe4_4c96_be07_854d5dba3b2b")
+	translation := NewTemplateTranslation(channel, envs.Locale("eng-US"), "Hello {{1}}", 1, "0162a7f4_dfe4_4c96_be07_854d5dba3b2b")
 	assert.Equal(t, channel, translation.Channel())
-	assert.Equal(t, envs.Language("eng"), translation.Language())
-	assert.Equal(t, envs.Country("US"), translation.Country())
+	assert.Equal(t, envs.Locale("eng-US"), translation.Locale())
 	assert.Equal(t, "Hello {{1}}", translation.Content())
 	assert.Equal(t, 1, translation.VariableCount())
 	assert.Equal(t, "0162a7f4_dfe4_4c96_be07_854d5dba3b2b", translation.Namespace())

--- a/assets/template.go
+++ b/assets/template.go
@@ -17,7 +17,7 @@ type TemplateUUID uuids.UUID
 //	  "uuid": "14782905-81a6-4910-bc9f-93ad287b23c3",
 //	  "translations": [
 //	    {
-//	       "language": "eng",
+//	       "locale": "eng-US",
 //	       "content": "Hi {{1}}, are you still experiencing your issue?",
 //	       "channel": {
 //	         "uuid": "cf26be4c-875f-4094-9e08-162c3c9dcb5b",
@@ -25,7 +25,7 @@ type TemplateUUID uuids.UUID
 //	       }
 //	    },
 //	    {
-//	       "language": "fra",
+//	       "locale": "fra",
 //	       "content": "Bonjour {{1}}",
 //	       "channel": {
 //	         "uuid": "cf26be4c-875f-4094-9e08-162c3c9dcb5b",
@@ -45,8 +45,7 @@ type Template interface {
 // TemplateTranslation represents a single translation for a specific template and channel
 type TemplateTranslation interface {
 	Content() string
-	Language() envs.Language
-	Country() envs.Country
+	Locale() envs.Locale
 	Namespace() string
 	VariableCount() int
 	Channel() ChannelReference

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -122,7 +122,8 @@ func (a *SendMsgAction) Execute(run flows.Run, step flows.Step, logModifier flow
 				}
 
 				evaluatedText = translation.Substitute(evaluatedVariables)
-				templating = flows.NewMsgTemplating(a.Templating.Template, translation.Language(), translation.Country(), evaluatedVariables, translation.Namespace())
+				templating = flows.NewMsgTemplating(a.Templating.Template, evaluatedVariables, translation.Namespace())
+				locale = translation.Locale()
 			}
 		}
 

--- a/flows/actions/testdata/_assets.json
+++ b/flows/actions/testdata/_assets.json
@@ -235,8 +235,7 @@
                         "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
                         "name": "My Android Phone"
                     },
-                    "language": "eng",
-                    "country": "US",
+                    "locale": "eng-US",
                     "content": "Hi {{1}}, who's an excellent {{2}}?"
                 },
                 {
@@ -244,7 +243,7 @@
                         "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
                         "name": "My Android Phone"
                     },
-                    "language": "spa",
+                    "locale": "spa",
                     "content": "Hola {{1}}, quien es un {{2}} excelente?"
                 }
             ]
@@ -258,7 +257,7 @@
                         "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
                         "name": "My Android Phone"
                     },
-                    "language": "eng",
+                    "locale": "eng",
                     "content": "Hi there, it's time to get up!"
                 }
             ]

--- a/flows/actions/testdata/send_msg.json
+++ b/flows/actions/testdata/send_msg.json
@@ -450,8 +450,6 @@
                             "uuid": "5722e1fd-fe32-4e74-ac78-3cf41a6adb7e",
                             "name": "affirmation"
                         },
-                        "language": "eng",
-                        "country": "US",
                         "variables": [
                             "Ryan Lewis",
                             "boy"
@@ -533,15 +531,13 @@
                             "uuid": "5722e1fd-fe32-4e74-ac78-3cf41a6adb7e",
                             "name": "affirmation"
                         },
-                        "language": "spa",
-                        "country": "",
                         "variables": [
                             "Ryan Lewis",
                             "niño"
                         ],
                         "namespace": ""
                     },
-                    "locale": "eng-US"
+                    "locale": "spa"
                 }
             }
         ],
@@ -604,11 +600,9 @@
                             "uuid": "2edc8dfd-aef0-41cf-a900-8a71bdb00900",
                             "name": "wakeup"
                         },
-                        "language": "eng",
-                        "country": "",
                         "namespace": ""
                     },
-                    "locale": "eng-US"
+                    "locale": "eng"
                 }
             }
         ],
@@ -674,11 +668,9 @@
                             "uuid": "2edc8dfd-aef0-41cf-a900-8a71bdb00900",
                             "name": "wakeup"
                         },
-                        "language": "eng",
-                        "country": "",
                         "namespace": ""
                     },
-                    "locale": "spa-US"
+                    "locale": "eng"
                 }
             }
         ],

--- a/flows/msg.go
+++ b/flows/msg.go
@@ -167,20 +167,12 @@ func (m *MsgOut) UnsendableReason() UnsendableReason { return m.UnsendableReason
 // MsgTemplating represents any substituted message template that should be applied when sending this message
 type MsgTemplating struct {
 	Template_  *assets.TemplateReference `json:"template"`
-	Language_  envs.Language             `json:"language"`
-	Country_   envs.Country              `json:"country"`
 	Variables_ []string                  `json:"variables,omitempty"`
 	Namespace_ string                    `json:"namespace"`
 }
 
 // Template returns the template this msg template is for
 func (t MsgTemplating) Template() *assets.TemplateReference { return t.Template_ }
-
-// Language returns the language that should be used for the template
-func (t MsgTemplating) Language() envs.Language { return t.Language_ }
-
-// Country returns the country that should be used for the template
-func (t MsgTemplating) Country() envs.Country { return t.Country_ }
 
 // Variables returns the variables that should be substituted in the template
 func (t MsgTemplating) Variables() []string { return t.Variables_ }
@@ -189,11 +181,9 @@ func (t MsgTemplating) Variables() []string { return t.Variables_ }
 func (t MsgTemplating) Namespace() string { return t.Namespace_ }
 
 // NewMsgTemplating creates and returns a new msg template
-func NewMsgTemplating(template *assets.TemplateReference, language envs.Language, country envs.Country, variables []string, namespace string) *MsgTemplating {
+func NewMsgTemplating(template *assets.TemplateReference, variables []string, namespace string) *MsgTemplating {
 	return &MsgTemplating{
 		Template_:  template,
-		Language_:  language,
-		Country_:   country,
 		Variables_: variables,
 		Namespace_: namespace,
 	}

--- a/flows/template.go
+++ b/flows/template.go
@@ -38,8 +38,10 @@ func (t *Template) FindTranslation(channel assets.ChannelUUID, locales []envs.Lo
 	for _, tr := range t.Template.Translations() {
 		if tr.Channel().UUID == channel {
 			tt := NewTemplateTranslation(tr)
+			lang, _ := tt.Locale().ToParts()
+
 			candidatesByLocale[tt.Locale()] = tt
-			candidatesByLang[tt.Language()] = tt
+			candidatesByLang[lang] = tt
 		}
 	}
 
@@ -72,9 +74,6 @@ type TemplateTranslation struct {
 func NewTemplateTranslation(t assets.TemplateTranslation) *TemplateTranslation {
 	return &TemplateTranslation{TemplateTranslation: t}
 }
-
-// Locale returns the locale
-func (t *TemplateTranslation) Locale() envs.Locale { return envs.NewLocale(t.Language(), t.Country()) }
 
 // Asset returns the underlying asset
 func (t *TemplateTranslation) Asset() assets.TemplateTranslation { return t.TemplateTranslation }

--- a/flows/template_test.go
+++ b/flows/template_test.go
@@ -23,7 +23,7 @@ func TestTemplateTranslation(t *testing.T) {
 	channel := assets.NewChannelReference("0bce5fd3-c215-45a0-bcb8-2386eb194175", "Test Channel")
 
 	for i, tc := range tcs {
-		tt := NewTemplateTranslation(static.NewTemplateTranslation(*channel, envs.Language("eng"), envs.Country("US"), tc.Content, len(tc.Variables), "a6a8863e_7879_4487_ad24_5e2ea429027c"))
+		tt := NewTemplateTranslation(static.NewTemplateTranslation(*channel, envs.Locale("eng-US"), tc.Content, len(tc.Variables), "a6a8863e_7879_4487_ad24_5e2ea429027c"))
 		result := tt.Substitute(tc.Variables)
 		assert.Equal(t, tc.Expected, result, "%d: unexpected template substitution", i)
 	}
@@ -31,9 +31,9 @@ func TestTemplateTranslation(t *testing.T) {
 
 func TestTemplates(t *testing.T) {
 	channel1 := assets.NewChannelReference("0bce5fd3-c215-45a0-bcb8-2386eb194175", "Test Channel")
-	tt1 := static.NewTemplateTranslation(*channel1, envs.Language("eng"), envs.NilCountry, "Hello {{1}}", 1, "")
-	tt2 := static.NewTemplateTranslation(*channel1, envs.Language("spa"), envs.Country("EC"), "Que tal {{1}}", 1, "")
-	tt3 := static.NewTemplateTranslation(*channel1, envs.Language("spa"), envs.Country("ES"), "Hola {{1}}", 1, "")
+	tt1 := static.NewTemplateTranslation(*channel1, envs.Locale("eng"), "Hello {{1}}", 1, "")
+	tt2 := static.NewTemplateTranslation(*channel1, envs.Locale("spa-EC"), "Que tal {{1}}", 1, "")
+	tt3 := static.NewTemplateTranslation(*channel1, envs.Locale("spa-ES"), "Hola {{1}}", 1, "")
 	template := NewTemplate(static.NewTemplate("c520cbda-e118-440f-aaf6-c0485088384f", "greeting", []*static.TemplateTranslation{tt1, tt2, tt3}))
 
 	tas := NewTemplateAssets([]assets.Template{template})


### PR DESCRIPTION
Replace `TemplateTranslation.language` and `country` fields with single `locale` field and also don't duplicate locale on `MsgTemplating` since it's now on the message itself