### PR TITLE
Replace max_value_length on env with new engine options for max field and result chars

### DIFF
--- a/envs/environment.go
+++ b/envs/environment.go
@@ -35,7 +35,6 @@ type Environment interface {
 	DefaultCountry() Country
 	NumberFormat() *NumberFormat
 	RedactionPolicy() RedactionPolicy
-	MaxValueLength() int
 
 	DefaultLanguage() Language
 	DefaultLocale() Locale
@@ -56,7 +55,6 @@ type environment struct {
 	defaultCountry   Country
 	numberFormat     *NumberFormat
 	redactionPolicy  RedactionPolicy
-	maxValueLength   int
 }
 
 func (e *environment) DateFormat() DateFormat           { return e.dateFormat }
@@ -66,7 +64,6 @@ func (e *environment) AllowedLanguages() []Language     { return e.allowedLangua
 func (e *environment) DefaultCountry() Country          { return e.defaultCountry }
 func (e *environment) NumberFormat() *NumberFormat      { return e.numberFormat }
 func (e *environment) RedactionPolicy() RedactionPolicy { return e.redactionPolicy }
-func (e *environment) MaxValueLength() int              { return e.maxValueLength }
 
 // DefaultLanguage is the first allowed language
 func (e *environment) DefaultLanguage() Language {
@@ -105,7 +102,6 @@ type envEnvelope struct {
 	NumberFormat     *NumberFormat   `json:"number_format,omitempty"`
 	DefaultCountry   Country         `json:"default_country,omitempty" validate:"omitempty,country"`
 	RedactionPolicy  RedactionPolicy `json:"redaction_policy" validate:"omitempty,eq=none|eq=urns"`
-	MaxValuelength   int             `json:"max_value_length"`
 }
 
 // ReadEnvironment reads an environment from the given JSON
@@ -124,7 +120,6 @@ func ReadEnvironment(data json.RawMessage) (Environment, error) {
 	env.defaultCountry = envelope.DefaultCountry
 	env.numberFormat = envelope.NumberFormat
 	env.redactionPolicy = envelope.RedactionPolicy
-	env.maxValueLength = envelope.MaxValuelength
 
 	tz, err := time.LoadLocation(envelope.Timezone)
 	if err != nil {
@@ -144,7 +139,6 @@ func (e *environment) toEnvelope() *envEnvelope {
 		DefaultCountry:   e.defaultCountry,
 		NumberFormat:     e.numberFormat,
 		RedactionPolicy:  e.redactionPolicy,
-		MaxValuelength:   e.maxValueLength,
 	}
 }
 
@@ -172,7 +166,6 @@ func NewBuilder() *EnvironmentBuilder {
 			allowedLanguages: nil,
 			defaultCountry:   NilCountry,
 			numberFormat:     DefaultNumberFormat,
-			maxValueLength:   640,
 			redactionPolicy:  RedactionPolicyNone,
 		},
 	}
@@ -212,11 +205,6 @@ func (b *EnvironmentBuilder) WithNumberFormat(numberFormat *NumberFormat) *Envir
 
 func (b *EnvironmentBuilder) WithRedactionPolicy(redactionPolicy RedactionPolicy) *EnvironmentBuilder {
 	b.env.redactionPolicy = redactionPolicy
-	return b
-}
-
-func (b *EnvironmentBuilder) WithMaxValueLength(maxValueLength int) *EnvironmentBuilder {
-	b.env.maxValueLength = maxValueLength
 	return b
 }
 

--- a/envs/environment_test.go
+++ b/envs/environment_test.go
@@ -45,7 +45,6 @@ func TestEnvironmentMarshaling(t *testing.T) {
 	assert.Equal(t, envs.NilLanguage, env.DefaultLanguage())
 	assert.Nil(t, env.AllowedLanguages())
 	assert.Equal(t, envs.NilCountry, env.DefaultCountry())
-	assert.Equal(t, 640, env.MaxValueLength())
 	assert.Nil(t, env.LocationResolver())
 
 	// can create with valid values
@@ -68,7 +67,7 @@ func TestEnvironmentMarshaling(t *testing.T) {
 
 	data, err := jsonx.Marshal(env)
 	require.NoError(t, err)
-	assert.Equal(t, string(data), `{"date_format":"DD-MM-YYYY","time_format":"tt:mm:ss","timezone":"Africa/Kigali","allowed_languages":["eng","fra"],"number_format":{"decimal_symbol":".","digit_grouping_symbol":","},"default_country":"RW","redaction_policy":"none","max_value_length":640}`)
+	assert.Equal(t, string(data), `{"date_format":"DD-MM-YYYY","time_format":"tt:mm:ss","timezone":"Africa/Kigali","allowed_languages":["eng","fra"],"number_format":{"decimal_symbol":".","digit_grouping_symbol":","},"default_country":"RW","redaction_policy":"none"}`)
 }
 
 func TestEnvironmentEqual(t *testing.T) {
@@ -106,7 +105,6 @@ func TestEnvironmentBuilder(t *testing.T) {
 		WithDefaultCountry(envs.Country("RW")).
 		WithNumberFormat(&envs.NumberFormat{DecimalSymbol: "'"}).
 		WithRedactionPolicy(envs.RedactionPolicyURNs).
-		WithMaxValueLength(1024).
 		Build()
 
 	assert.Equal(t, envs.DateFormatDayMonthYear, env.DateFormat())
@@ -116,6 +114,5 @@ func TestEnvironmentBuilder(t *testing.T) {
 	assert.Equal(t, envs.Country("RW"), env.DefaultCountry())
 	assert.Equal(t, &envs.NumberFormat{DecimalSymbol: "'"}, env.NumberFormat())
 	assert.Equal(t, envs.RedactionPolicyURNs, env.RedactionPolicy())
-	assert.Equal(t, 1024, env.MaxValueLength())
 	assert.Nil(t, env.LocationResolver())
 }

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -178,7 +178,9 @@ func (a *baseAction) updateWebhook(run flows.Run, call *flows.WebhookCall) {
 // helper to apply a contact modifier
 func (a *baseAction) applyModifier(run flows.Run, mod flows.Modifier, logModifier flows.ModifierCallback, logEvent flows.EventCallback) bool {
 	logModifier(mod)
-	return modifiers.Apply(run.Session().MergedEnvironment(), run.Session().Engine().Services(), run.Session().Assets(), run.Contact(), mod, logEvent)
+
+	s := run.Session()
+	return modifiers.Apply(s.Engine(), s.MergedEnvironment(), s.Assets(), run.Contact(), mod, logEvent)
 }
 
 // helper to log a failure

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -11,10 +11,8 @@ import (
 
 // an instance of the engine
 type engine struct {
-	services             *services
-	maxStepsPerSprint    int
-	maxResumesPerSession int
-	maxTemplateChars     int
+	services *services
+	options  *flows.EngineOptions
 }
 
 // NewSession creates a new session
@@ -40,10 +38,8 @@ func (e *engine) ReadSession(sa flows.SessionAssets, data json.RawMessage, missi
 	return readSession(e, sa, data, missing)
 }
 
-func (e *engine) Services() flows.Services  { return e.services }
-func (e *engine) MaxStepsPerSprint() int    { return e.maxStepsPerSprint }
-func (e *engine) MaxResumesPerSession() int { return e.maxResumesPerSession }
-func (e *engine) MaxTemplateChars() int     { return e.maxTemplateChars }
+func (e *engine) Services() flows.Services      { return e.services }
+func (e *engine) Options() *flows.EngineOptions { return e.options }
 
 var _ flows.Engine = (*engine)(nil)
 
@@ -60,10 +56,14 @@ type Builder struct {
 func NewBuilder() *Builder {
 	return &Builder{
 		eng: &engine{
-			services:             newEmptyServices(),
-			maxStepsPerSprint:    100,
-			maxResumesPerSession: 500,
-			maxTemplateChars:     10000,
+			services: newEmptyServices(),
+			options: &flows.EngineOptions{
+				MaxStepsPerSprint:    100,
+				MaxResumesPerSession: 500,
+				MaxTemplateChars:     10000,
+				MaxFieldChars:        640,
+				MaxResultChars:       640,
+			},
 		},
 	}
 }
@@ -100,19 +100,31 @@ func (b *Builder) WithAirtimeServiceFactory(f AirtimeServiceFactory) *Builder {
 
 // WithMaxStepsPerSprint sets the maximum number of steps allowed in a single sprint
 func (b *Builder) WithMaxStepsPerSprint(max int) *Builder {
-	b.eng.maxStepsPerSprint = max
+	b.eng.options.MaxStepsPerSprint = max
 	return b
 }
 
 // WithMaxResumesPerSession sets the maximum number of resumes allowed in a single session
 func (b *Builder) WithMaxResumesPerSession(max int) *Builder {
-	b.eng.maxResumesPerSession = max
+	b.eng.options.MaxResumesPerSession = max
 	return b
 }
 
 // WithMaxTemplateChars sets the maximum number of characters allowed from an evaluated template
 func (b *Builder) WithMaxTemplateChars(max int) *Builder {
-	b.eng.maxTemplateChars = max
+	b.eng.options.MaxTemplateChars = max
+	return b
+}
+
+// WithMaxFieldChars sets the maximum number of characters allowed in a contact field value
+func (b *Builder) WithMaxFieldChars(max int) *Builder {
+	b.eng.options.MaxFieldChars = max
+	return b
+}
+
+// WithMaxResultChars sets the maximum number of characters allowed in a result value
+func (b *Builder) WithMaxResultChars(max int) *Builder {
+	b.eng.options.MaxResultChars = max
 	return b
 }
 

--- a/flows/engine/engine_test.go
+++ b/flows/engine/engine_test.go
@@ -13,10 +13,19 @@ import (
 
 func TestBuilder(t *testing.T) {
 	// create engine with no services
-	eng := engine.NewBuilder().WithMaxStepsPerSprint(123).WithMaxResumesPerSession(567).Build()
+	eng := engine.NewBuilder().
+		WithMaxStepsPerSprint(123).
+		WithMaxResumesPerSession(567).
+		WithMaxTemplateChars(999).
+		WithMaxFieldChars(888).
+		WithMaxResultChars(777).
+		Build()
 
-	assert.Equal(t, 123, eng.MaxStepsPerSprint())
-	assert.Equal(t, 567, eng.MaxResumesPerSession())
+	assert.Equal(t, 123, eng.Options().MaxStepsPerSprint)
+	assert.Equal(t, 567, eng.Options().MaxResumesPerSession)
+	assert.Equal(t, 999, eng.Options().MaxTemplateChars)
+	assert.Equal(t, 888, eng.Options().MaxFieldChars)
+	assert.Equal(t, 777, eng.Options().MaxResultChars)
 
 	_, err := eng.Services().Email(nil)
 	assert.EqualError(t, err, "no email service factory configured")

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -252,8 +252,8 @@ func (s *session) tryToResume(sprint *sprint, waitingRun flows.Run, resume flows
 		return nil
 	}
 
-	if s.countWaits() >= s.engine.MaxResumesPerSession() {
-		failSession("reached maximum number of resumes per session (%d)", s.Engine().MaxResumesPerSession())
+	if s.countWaits() >= s.engine.Options().MaxResumesPerSession {
+		failSession("reached maximum number of resumes per session (%d)", s.engine.Options().MaxResumesPerSession)
 		return nil
 	}
 
@@ -415,9 +415,9 @@ func (s *session) continueUntilWait(sprint *sprint, currentRun flows.Run, node f
 		if destination != "" {
 			numNewSteps++
 
-			if numNewSteps > s.Engine().MaxStepsPerSprint() {
+			if numNewSteps > s.engine.Options().MaxStepsPerSprint {
 				// we've hit the step limit - usually a sign of a loop
-				failRun(sprint, currentRun, step, errors.Errorf("reached maximum number of steps per sprint (%d)", s.Engine().MaxStepsPerSprint()))
+				failRun(sprint, currentRun, step, errors.Errorf("reached maximum number of steps per sprint (%d)", s.engine.Options().MaxStepsPerSprint))
 			} else {
 				node = currentRun.Flow().GetNode(destination)
 				if node == nil {

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -382,7 +382,6 @@ func TestEventMarshaling(t *testing.T) {
 					],
 					"date_format": "DD-MM-YYYY",
 					"default_country": "US",
-					"max_value_length": 640,
 					"number_format": {
 						"decimal_symbol": ".",
 						"digit_grouping_symbol": ","

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -276,7 +276,7 @@ type Resume interface {
 type Modifier interface {
 	utils.Typed
 
-	Apply(envs.Environment, Services, SessionAssets, *Contact, EventCallback) bool
+	Apply(Engine, envs.Environment, SessionAssets, *Contact, EventCallback) bool
 }
 
 // ModifierCallback is a callback invoked when a modifier has been generated
@@ -316,15 +316,21 @@ type Step interface {
 	Leave(ExitUUID)
 }
 
+type EngineOptions struct {
+	MaxStepsPerSprint    int
+	MaxResumesPerSession int
+	MaxTemplateChars     int
+	MaxFieldChars        int
+	MaxResultChars       int
+}
+
 // Engine provides callers with session starting and resuming
 type Engine interface {
 	NewSession(SessionAssets, Trigger) (Session, Sprint, error)
 	ReadSession(SessionAssets, json.RawMessage, assets.MissingCallback) (Session, error)
 
 	Services() Services
-	MaxStepsPerSprint() int
-	MaxResumesPerSession() int
-	MaxTemplateChars() int
+	Options() *EngineOptions
 }
 
 // Segment is a movement on the flow graph from an exit to another node

--- a/flows/modifiers/base.go
+++ b/flows/modifiers/base.go
@@ -39,8 +39,8 @@ func newBaseModifier(typeName string) baseModifier {
 func (m *baseModifier) Type() string { return m.Type_ }
 
 // Apply applies the given modifier to the given contact and re-evaluates query based groups if necessary
-func Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, c *flows.Contact, mod flows.Modifier, logEvent flows.EventCallback) bool {
-	modified := mod.Apply(env, svcs, sa, c, logEvent)
+func Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, c *flows.Contact, mod flows.Modifier, logEvent flows.EventCallback) bool {
+	modified := mod.Apply(eng, env, sa, c, logEvent)
 	if modified {
 		ReevaluateGroups(env, c, logEvent)
 	}

--- a/flows/modifiers/base_test.go
+++ b/flows/modifiers/base_test.go
@@ -31,11 +31,11 @@ func TestModifierTypes(t *testing.T) {
 	eng := test.NewEngine()
 
 	for typeName := range modifiers.RegisteredTypes {
-		testModifierType(t, eng.Services(), sa, typeName)
+		testModifierType(t, eng, env, sa, typeName)
 	}
 }
 
-func testModifierType(t *testing.T, svcs flows.Services, sa flows.SessionAssets, typeName string) {
+func testModifierType(t *testing.T, eng flows.Engine, env envs.Environment, sa flows.SessionAssets, typeName string) {
 	testPath := fmt.Sprintf("testdata/%s.json", typeName)
 	testFile, err := os.ReadFile(testPath)
 	require.NoError(t, err)
@@ -71,9 +71,8 @@ func testModifierType(t *testing.T, svcs flows.Services, sa flows.SessionAssets,
 		require.NoError(t, err, "error loading contact_before in %s", testName)
 
 		// apply the modifier
-		env := envs.NewBuilder().WithMaxValueLength(256).Build()
 		eventLog := test.NewEventLog()
-		modifiers.Apply(env, svcs, sa, contact, modifier, eventLog.Log)
+		modifiers.Apply(eng, env, sa, contact, modifier, eventLog.Log)
 
 		// clone test case and populate with actual values
 		actual := tc

--- a/flows/modifiers/channel.go
+++ b/flows/modifiers/channel.go
@@ -34,7 +34,7 @@ func NewChannel(channel *flows.Channel) *ChannelModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *ChannelModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *ChannelModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	if m.channel != nil && !m.channel.HasRole(assets.ChannelRoleSend) {
 		log(events.NewErrorf("can't set channel that can't send as the preferred channel"))
 

--- a/flows/modifiers/field.go
+++ b/flows/modifiers/field.go
@@ -38,14 +38,14 @@ func NewField(field *flows.Field, value string) *FieldModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *FieldModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *FieldModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	oldValue := contact.Fields().Get(m.field)
 
 	newValue := contact.Fields().Parse(env, sa.Fields(), m.field, m.value)
 
 	// truncate text value if necessary
 	if newValue != nil {
-		newValue.Text = types.NewXText(stringsx.Truncate(newValue.Text.Native(), env.MaxValueLength()))
+		newValue.Text = types.NewXText(stringsx.Truncate(newValue.Text.Native(), eng.Options().MaxFieldChars))
 	}
 
 	if !newValue.Equals(oldValue) {

--- a/flows/modifiers/groups.go
+++ b/flows/modifiers/groups.go
@@ -45,7 +45,7 @@ func NewGroups(groups []*flows.Group, modification GroupsModification) *GroupsMo
 }
 
 // Apply applies this modification to the given contact
-func (m *GroupsModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *GroupsModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	if contact.Status() == flows.ContactStatusBlocked || contact.Status() == flows.ContactStatusStopped {
 		log(events.NewErrorf("can't add blocked or stopped contacts to groups"))
 		return false

--- a/flows/modifiers/language.go
+++ b/flows/modifiers/language.go
@@ -33,7 +33,7 @@ func NewLanguage(language envs.Language) *LanguageModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *LanguageModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *LanguageModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	if contact.Language() != m.Language {
 		contact.SetLanguage(m.Language)
 		log(events.NewContactLanguageChanged(m.Language))

--- a/flows/modifiers/name.go
+++ b/flows/modifiers/name.go
@@ -34,10 +34,10 @@ func NewName(name string) *NameModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *NameModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *NameModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	if contact.Name() != m.Name {
 		// truncate value if necessary
-		name := stringsx.Truncate(m.Name, env.MaxValueLength())
+		name := stringsx.Truncate(m.Name, eng.Options().MaxFieldChars)
 
 		contact.SetName(name)
 		log(events.NewContactNameChanged(name))

--- a/flows/modifiers/status.go
+++ b/flows/modifiers/status.go
@@ -33,7 +33,7 @@ func NewStatus(status flows.ContactStatus) *StatusModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *StatusModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *StatusModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	if contact.Status() != m.Status {
 		contact.SetStatus(m.Status)
 		log(events.NewContactStatusChanged(m.Status))

--- a/flows/modifiers/ticket.go
+++ b/flows/modifiers/ticket.go
@@ -40,7 +40,7 @@ func NewTicket(ticketer *flows.Ticketer, topic *flows.Topic, body string, assign
 }
 
 // Apply applies this modification to the given contact
-func (m *TicketModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *TicketModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	// if there's already an open ticket, nothing to do
 	if contact.Ticket() != nil {
 		return false
@@ -49,7 +49,7 @@ func (m *TicketModifier) Apply(env envs.Environment, svcs flows.Services, sa flo
 	httpLogger := &flows.HTTPLogger{}
 
 	// try to get a ticket service for this ticketer
-	svc, err := svcs.Ticket(m.ticketer)
+	svc, err := eng.Services().Ticket(m.ticketer)
 	if err != nil {
 		log(events.NewError(err))
 		return false

--- a/flows/modifiers/timezone.go
+++ b/flows/modifiers/timezone.go
@@ -35,7 +35,7 @@ func NewTimezone(timezone *time.Location) *TimezoneModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *TimezoneModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *TimezoneModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	if !timezonesEqual(contact.Timezone(), m.timezone) {
 		contact.SetTimezone(m.timezone)
 		log(events.NewContactTimezoneChanged(m.timezone))

--- a/flows/modifiers/urn.go
+++ b/flows/modifiers/urn.go
@@ -46,7 +46,7 @@ func NewURN(urn urns.URN, modification URNModification) *URNModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *URNModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *URNModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	urn := m.URN.Normalize(string(env.DefaultCountry()))
 	modified := false
 

--- a/flows/modifiers/urns.go
+++ b/flows/modifiers/urns.go
@@ -46,7 +46,7 @@ func NewURNs(urnz []urns.URN, modification URNsModification) *URNsModifier {
 }
 
 // Apply applies this modification to the given contact
-func (m *URNsModifier) Apply(env envs.Environment, svcs flows.Services, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
+func (m *URNsModifier) Apply(eng flows.Engine, env envs.Environment, sa flows.SessionAssets, contact *flows.Contact, log flows.EventCallback) bool {
 	modified := false
 
 	if m.Modification == URNsSet {

--- a/flows/runs/run.go
+++ b/flows/runs/run.go
@@ -72,7 +72,7 @@ func (r *run) Events() []flows.Event                { return r.events }
 func (r *run) Results() flows.Results { return r.results }
 func (r *run) SaveResult(result *flows.Result) {
 	// truncate value if necessary
-	result.Value = stringsx.Truncate(result.Value, r.session.MergedEnvironment().MaxValueLength())
+	result.Value = stringsx.Truncate(result.Value, r.session.Engine().Options().MaxResultChars)
 
 	r.results.Save(result)
 	r.modifiedOn = dates.Now()
@@ -316,7 +316,7 @@ func (r *run) EvaluateTemplateText(template string, escaping excellent.Escaping,
 
 	value, err := excellent.EvaluateTemplate(r.session.MergedEnvironment(), ctx, template, escaping)
 	if truncate {
-		value = stringsx.TruncateEllipsis(value, r.Session().Engine().MaxTemplateChars())
+		value = stringsx.TruncateEllipsis(value, r.Session().Engine().Options().MaxTemplateChars)
 	}
 	return value, err
 }

--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -324,8 +324,7 @@ func TestReadTrigger(t *testing.T) {
 				"decimal_symbol": ".",
 				"digit_grouping_symbol": ","
 			},
-			"redaction_policy": "none",
-			"max_value_length": 640
+			"redaction_policy": "none"
 		},
 		"flow": {
 			"uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_campaign.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_campaign.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_channel_incoming_call.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_channel_incoming_call.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_channel_new_conversation.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_channel_new_conversation.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_flow_action.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_flow_action.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_flow_action_ivr.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_flow_action_ivr.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_manual.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_manual.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_manual_ivr.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_manual_ivr.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_manual_minimal.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_manual_minimal.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_msg.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_msg.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/flows/triggers/testdata/TestTriggerMarshaling_ticket_closed.snap
+++ b/flows/triggers/testdata/TestTriggerMarshaling_ticket_closed.snap
@@ -8,8 +8,7 @@
             "decimal_symbol": ".",
             "digit_grouping_symbol": ","
         },
-        "redaction_policy": "none",
-        "max_value_length": 640
+        "redaction_policy": "none"
     },
     "flow": {
         "uuid": "7c37d7e5-6468-4b31-8109-ced2ef8b5ddc",

--- a/test/engine.go
+++ b/test/engine.go
@@ -22,6 +22,7 @@ func NewEngine() flows.Engine {
 	retries := httpx.NewFixedRetries(1*time.Millisecond, 2*time.Millisecond)
 
 	return engine.NewBuilder().
+		WithMaxFieldChars(256).
 		WithEmailServiceFactory(func(s flows.SessionAssets) (flows.EmailService, error) {
 			return newEmailService(), nil
 		}).

--- a/test/testdata/runner/airtime.test_successful_transfer.json
+++ b/test/testdata/runner/airtime.test_successful_transfer.json
@@ -198,7 +198,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -309,7 +308,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/all_actions.test.json
+++ b/test/testdata/runner/all_actions.test.json
@@ -466,7 +466,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -968,7 +967,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/brochure.test.json
+++ b/test/testdata/runner/brochure.test.json
@@ -61,7 +61,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -148,7 +147,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -272,7 +270,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -442,7 +439,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/date_parse.test.json
+++ b/test/testdata/runner/date_parse.test.json
@@ -53,7 +53,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -134,7 +133,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -252,7 +250,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -412,7 +409,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/default_result.test.json
+++ b/test/testdata/runner/default_result.test.json
@@ -58,7 +58,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -247,7 +246,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/empty.test.json
+++ b/test/testdata/runner/empty.test.json
@@ -29,7 +29,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/enter_flow_loop.test.json
+++ b/test/testdata/runner/enter_flow_loop.test.json
@@ -49,7 +49,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -125,7 +124,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -274,7 +272,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -510,7 +507,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -653,7 +649,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1036,7 +1031,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1099,7 +1093,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1512,7 +1505,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1582,7 +1574,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/enter_flow_terminal.test.json
+++ b/test/testdata/runner/enter_flow_terminal.test.json
@@ -65,7 +65,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/expirations.test_all_expire.json
+++ b/test/testdata/runner/expirations.test_all_expire.json
@@ -72,7 +72,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -215,7 +214,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -299,7 +297,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -477,7 +474,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -561,7 +557,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -774,7 +769,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -825,7 +819,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1044,7 +1037,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1100,7 +1092,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/expirations.test_input_for_all.json
+++ b/test/testdata/runner/expirations.test_input_for_all.json
@@ -72,7 +72,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -215,7 +214,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -313,7 +311,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -522,7 +519,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -620,7 +616,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -888,7 +883,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -953,7 +947,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1251,7 +1244,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1322,7 +1314,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/extra.test.json
+++ b/test/testdata/runner/extra.test.json
@@ -132,7 +132,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -388,7 +387,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/field_clear.test.json
+++ b/test/testdata/runner/field_clear.test.json
@@ -58,7 +58,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -145,7 +144,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -188,7 +186,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/initial_wait.test.json
+++ b/test/testdata/runner/initial_wait.test.json
@@ -70,7 +70,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -182,7 +181,6 @@
                     },
                     "environment": {
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/ivr_dial.busy.json
+++ b/test/testdata/runner/ivr_dial.busy.json
@@ -39,7 +39,6 @@
                     ],
                     "date_format": "YYYY-MM-DD",
                     "default_country": "US",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -120,7 +119,6 @@
                         ],
                         "date_format": "YYYY-MM-DD",
                         "default_country": "US",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -188,7 +186,6 @@
                     ],
                     "date_format": "YYYY-MM-DD",
                     "default_country": "US",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -298,7 +295,6 @@
                         ],
                         "date_format": "YYYY-MM-DD",
                         "default_country": "US",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -362,7 +358,6 @@
             ],
             "date_format": "YYYY-MM-DD",
             "default_country": "US",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/ivr_dial.invalid_phone.json
+++ b/test/testdata/runner/ivr_dial.invalid_phone.json
@@ -44,7 +44,6 @@
                     ],
                     "date_format": "YYYY-MM-DD",
                     "default_country": "US",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -140,7 +139,6 @@
                         ],
                         "date_format": "YYYY-MM-DD",
                         "default_country": "US",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -195,7 +193,6 @@
             ],
             "date_format": "YYYY-MM-DD",
             "default_country": "US",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/legacy_favorites.test.json
+++ b/test/testdata/runner/legacy_favorites.test.json
@@ -48,7 +48,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -123,7 +122,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -223,7 +221,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -367,7 +364,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -454,7 +450,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -647,7 +642,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/legacy_registration.test.json
+++ b/test/testdata/runner/legacy_registration.test.json
@@ -50,7 +50,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -127,7 +126,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -231,7 +229,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -379,7 +376,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -477,7 +473,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -681,7 +676,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -807,7 +801,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1088,7 +1081,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1159,7 +1151,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/legacy_subflow.test.json
+++ b/test/testdata/runner/legacy_subflow.test.json
@@ -50,7 +50,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -127,7 +126,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -225,7 +223,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -367,7 +364,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -432,7 +428,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -594,7 +589,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -656,7 +650,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/legacy_timeout.test.json
+++ b/test/testdata/runner/legacy_timeout.test.json
@@ -55,7 +55,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -137,7 +136,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -216,7 +214,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -344,7 +341,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/legacy_webhook.test.json
+++ b/test/testdata/runner/legacy_webhook.test.json
@@ -76,7 +76,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -184,7 +183,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/nlu_booking.flight.json
+++ b/test/testdata/runner/nlu_booking.flight.json
@@ -49,7 +49,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -124,7 +123,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -281,7 +279,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -518,7 +515,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -572,7 +568,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/no_contact.test.json
+++ b/test/testdata/runner/no_contact.test.json
@@ -45,7 +45,6 @@
             "session": {
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -130,7 +129,6 @@
                 "trigger": {
                     "environment": {
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/node_loop.test.json
+++ b/test/testdata/runner/node_loop.test.json
@@ -2240,7 +2240,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -4402,7 +4401,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/number_quiz.exceed_limit.json
+++ b/test/testdata/runner/number_quiz.exceed_limit.json
@@ -54,7 +54,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -135,7 +134,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -245,7 +243,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -401,7 +398,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -511,7 +507,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -725,7 +720,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -822,7 +816,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1083,7 +1076,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1154,7 +1146,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/phone_number.test.json
+++ b/test/testdata/runner/phone_number.test.json
@@ -54,7 +54,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -135,7 +134,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -237,7 +235,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -387,7 +384,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -505,7 +501,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -718,7 +713,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -780,7 +774,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/redact_urns.test.json
+++ b/test/testdata/runner/redact_urns.test.json
@@ -69,7 +69,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -159,7 +158,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/resthook.test.json
+++ b/test/testdata/runner/resthook.test.json
@@ -133,7 +133,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/router_tests.test.json
+++ b/test/testdata/runner/router_tests.test.json
@@ -120,7 +120,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -283,7 +282,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/smart_groups.test.json
+++ b/test/testdata/runner/smart_groups.test.json
@@ -236,7 +236,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/smart_groups_correction.test.json
+++ b/test/testdata/runner/smart_groups_correction.test.json
@@ -54,7 +54,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/stop.test.json
+++ b/test/testdata/runner/stop.test.json
@@ -66,7 +66,6 @@
                     ],
                     "date_format": "MM-DD-YYYY",
                     "default_country": "US",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -189,7 +188,6 @@
                         ],
                         "date_format": "MM-DD-YYYY",
                         "default_country": "US",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -269,7 +267,6 @@
             ],
             "date_format": "MM-DD-YYYY",
             "default_country": "US",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/subflow.test.json
+++ b/test/testdata/runner/subflow.test.json
@@ -79,7 +79,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -207,7 +206,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -331,7 +329,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -547,7 +544,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/subflow.test_resume_with_expiration.json
+++ b/test/testdata/runner/subflow.test_resume_with_expiration.json
@@ -79,7 +79,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -207,7 +206,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -290,7 +288,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -446,7 +443,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/subflow_loop_with_wait.test.json
+++ b/test/testdata/runner/subflow_loop_with_wait.test.json
@@ -84,7 +84,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -215,7 +214,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -350,7 +348,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -588,7 +585,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/subflow_other.test.json
+++ b/test/testdata/runner/subflow_other.test.json
@@ -94,7 +94,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -234,7 +233,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -347,7 +345,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -563,7 +560,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -699,7 +695,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -992,7 +987,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1105,7 +1099,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1463,7 +1456,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -1564,7 +1556,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -1967,7 +1958,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/ticketing.test.json
+++ b/test/testdata/runner/ticketing.test.json
@@ -46,7 +46,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -118,7 +117,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -268,7 +266,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -454,7 +451,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -504,7 +500,6 @@
                 "eng"
             ],
             "date_format": "YYYY-MM-DD",
-            "max_value_length": 640,
             "number_format": {
                 "decimal_symbol": ".",
                 "digit_grouping_symbol": ","

--- a/test/testdata/runner/triggered.test.json
+++ b/test/testdata/runner/triggered.test.json
@@ -48,7 +48,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -125,7 +124,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/two_questions.test.json
+++ b/test/testdata/runner/two_questions.test.json
@@ -63,7 +63,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -146,7 +145,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -176,7 +174,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -307,7 +304,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -364,7 +360,6 @@
                                         "fra"
                                     ],
                                     "date_format": "YYYY-MM-DD",
-                                    "max_value_length": 640,
                                     "number_format": {
                                         "decimal_symbol": ".",
                                         "digit_grouping_symbol": ","
@@ -514,7 +509,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -630,7 +624,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -687,7 +680,6 @@
                                         "fra"
                                     ],
                                     "date_format": "YYYY-MM-DD",
-                                    "max_value_length": 640,
                                     "number_format": {
                                         "decimal_symbol": ".",
                                         "digit_grouping_symbol": ","
@@ -905,7 +897,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/two_questions.test_resume_with_expiration.json
+++ b/test/testdata/runner/two_questions.test_resume_with_expiration.json
@@ -55,7 +55,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -138,7 +137,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -194,7 +192,6 @@
                         "fra"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -283,7 +280,6 @@
                             "fra"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/two_questions_offline.test.json
+++ b/test/testdata/runner/two_questions_offline.test.json
@@ -46,7 +46,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -120,7 +119,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -215,7 +213,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -347,7 +344,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -445,7 +441,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -629,7 +624,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","
@@ -693,7 +687,6 @@
                         "eng"
                     ],
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -894,7 +887,6 @@
                             "eng"
                         ],
                         "date_format": "YYYY-MM-DD",
-                        "max_value_length": 640,
                         "number_format": {
                             "decimal_symbol": ".",
                             "digit_grouping_symbol": ","

--- a/test/testdata/runner/webhook_migrated.test.json
+++ b/test/testdata/runner/webhook_migrated.test.json
@@ -32,7 +32,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -183,7 +182,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","

--- a/test/testdata/runner/webhook_results.test.json
+++ b/test/testdata/runner/webhook_results.test.json
@@ -88,7 +88,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -329,7 +328,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","
@@ -628,7 +626,6 @@
                 },
                 "environment": {
                     "date_format": "YYYY-MM-DD",
-                    "max_value_length": 640,
                     "number_format": {
                         "decimal_symbol": ".",
                         "digit_grouping_symbol": ","


### PR DESCRIPTION
Should never have been an env setting because it's engine level