### PR TITLE
Rework template translation finding

### DIFF
--- a/assets/static/template.go
+++ b/assets/static/template.go
@@ -38,15 +38,15 @@ func (t *Template) Translations() []assets.TemplateTranslation {
 
 // TemplateTranslation represents a single template translation
 type TemplateTranslation struct {
-	Channel_       assets.ChannelReference `json:"channel"         validate:"required"`
-	Content_       string                  `json:"content"         validate:"required"`
-	Locale_        i18n.Locale             `json:"locale"          validate:"required"`
-	Namespace_     string                  `json:"namespace"`
-	VariableCount_ int                     `json:"variable_count"`
+	Channel_       *assets.ChannelReference `json:"channel"         validate:"required"`
+	Content_       string                   `json:"content"         validate:"required"`
+	Locale_        i18n.Locale              `json:"locale"          validate:"required"`
+	Namespace_     string                   `json:"namespace"`
+	VariableCount_ int                      `json:"variable_count"`
 }
 
 // NewTemplateTranslation creates a new template translation
-func NewTemplateTranslation(channel assets.ChannelReference, locale i18n.Locale, content string, variableCount int, namespace string) *TemplateTranslation {
+func NewTemplateTranslation(channel *assets.ChannelReference, locale i18n.Locale, content string, variableCount int, namespace string) *TemplateTranslation {
 	return &TemplateTranslation{
 		Channel_:       channel,
 		Content_:       content,
@@ -69,4 +69,4 @@ func (t *TemplateTranslation) Locale() i18n.Locale { return t.Locale_ }
 func (t *TemplateTranslation) VariableCount() int { return t.VariableCount_ }
 
 // Channel returns the channel this template translation is for
-func (t *TemplateTranslation) Channel() assets.ChannelReference { return t.Channel_ }
+func (t *TemplateTranslation) Channel() *assets.ChannelReference { return t.Channel_ }

--- a/assets/static/template_test.go
+++ b/assets/static/template_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestTemplate(t *testing.T) {
-	channel := assets.ChannelReference{
-		Name: "Test Channel",
-		UUID: assets.ChannelUUID("ffffffff-9b24-92e1-ffff-ffffb207cdb4"),
-	}
+	channel := assets.NewChannelReference("Test Channel", "ffffffff-9b24-92e1-ffff-ffffb207cdb4")
 
 	translation := NewTemplateTranslation(channel, i18n.Locale("eng-US"), "Hello {{1}}", 1, "0162a7f4_dfe4_4c96_be07_854d5dba3b2b")
 	assert.Equal(t, channel, translation.Channel())

--- a/assets/template.go
+++ b/assets/template.go
@@ -48,7 +48,7 @@ type TemplateTranslation interface {
 	Locale() i18n.Locale
 	Namespace() string
 	VariableCount() int
-	Channel() ChannelReference
+	Channel() *ChannelReference
 }
 
 // TemplateReference is used to reference a Template

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -88,6 +88,11 @@ func (a *SendMsgAction) Execute(run flows.Run, step flows.Step, logModifier flow
 
 	sa := run.Session().Assets()
 
+	var template *flows.Template
+	if a.Templating != nil {
+		template = sa.Templates().Get(a.Templating.Template.UUID)
+	}
+
 	// create a new message for each URN+channel destination
 	for _, dest := range destinations {
 		urn := dest.URN.URN()
@@ -95,14 +100,14 @@ func (a *SendMsgAction) Execute(run flows.Run, step flows.Step, logModifier flow
 
 		// do we have a template defined?
 		var templating *flows.MsgTemplating
-		if a.Templating != nil {
+		if template != nil {
 			// looks for a translation in the contact locale or environment default
 			locales := []i18n.Locale{
 				run.Session().MergedEnvironment().DefaultLocale(),
 				run.Session().Environment().DefaultLocale(),
 			}
 
-			translation := sa.Templates().FindTranslation(a.Templating.Template.UUID, channelRef, locales)
+			translation := template.FindTranslation(dest.Channel, locales)
 			if translation != nil {
 				localizedVariables, _ := run.GetTextArray(uuids.UUID(a.Templating.UUID), "variables", a.Templating.Variables, nil)
 


### PR DESCRIPTION
So that it can work with locales that we get from WhatsApp like `en-US` using a smart matcher and so we don't have to map those on the RP side and then map them back in courier.