### PR TITLE
Trim whitespace from evaluated message attachments

### DIFF
--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -99,6 +99,7 @@ func (a *baseAction) evaluateMessage(run flows.Run, languages []i18n.Language, a
 		if err != nil {
 			logEvent(events.NewError(err))
 		}
+		evaluatedAttachment = strings.TrimSpace(evaluatedAttachment)
 		if evaluatedAttachment == "" {
 			logEvent(events.NewErrorf("attachment text evaluated to empty string, skipping"))
 			continue

--- a/flows/actions/testdata/send_msg.json
+++ b/flows/actions/testdata/send_msg.json
@@ -111,7 +111,7 @@
             "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
             "text": "Hi there",
             "attachments": [
-                "@(\"\")"
+                "@(\" \")"
             ],
             "quick_replies": [
                 "@(\"\")"


### PR DESCRIPTION
A couple of times we've seen attachments with trailing newlines etc that then blows up in courier trying to parse the URL