### PR TITLE
Deprecated values updates

### DIFF
--- a/flows/results.go
+++ b/flows/results.go
@@ -58,19 +58,28 @@ func (r *Result) Context(env envs.Environment) map[string]types.XValue {
 		categoryLocalized = r.Category
 	}
 
+	values := types.NewXArray(types.NewXText(r.Value))
+	values.SetDeprecated("result.values: use value instead")
+	categories := types.NewXArray(types.NewXText(r.Category))
+	categories.SetDeprecated("result.categories: use category instead")
+	categoriesLocalized := types.NewXArray(types.NewXText(categoryLocalized))
+	categoriesLocalized.SetDeprecated("result.categories_localized: use category_localized instead")
+
 	return map[string]types.XValue{
-		"__default__":          types.NewXText(r.Value),
-		"name":                 types.NewXText(r.Name),
-		"value":                types.NewXText(r.Value),
-		"values":               types.NewXArray(types.NewXText(r.Value)),
-		"category":             types.NewXText(r.Category),
-		"categories":           types.NewXArray(types.NewXText(r.Category)),
-		"category_localized":   types.NewXText(categoryLocalized),
-		"categories_localized": types.NewXArray(types.NewXText(categoryLocalized)),
-		"input":                types.NewXText(r.Input),
-		"extra":                types.JSONToXValue(r.Extra),
-		"node_uuid":            types.NewXText(string(r.NodeUUID)),
-		"created_on":           types.NewXDateTime(r.CreatedOn),
+		"__default__":        types.NewXText(r.Value),
+		"name":               types.NewXText(r.Name),
+		"value":              types.NewXText(r.Value),
+		"category":           types.NewXText(r.Category),
+		"category_localized": types.NewXText(categoryLocalized),
+		"input":              types.NewXText(r.Input),
+		"extra":              types.JSONToXValue(r.Extra),
+		"node_uuid":          types.NewXText(string(r.NodeUUID)),
+		"created_on":         types.NewXDateTime(r.CreatedOn),
+
+		// deprecated
+		"values":               values,
+		"categories":           categories,
+		"categories_localized": categoriesLocalized,
 	}
 }
 


### PR DESCRIPTION
 * Support excluding deprecated object properties from marshaling
 * Deprecate undocumented multi-match result fields