### PR TITLE
Instead of supporting both variables and components in `send_msg` actions, add 13.4 migration

### DIFF
--- a/flows/actions/testdata/_assets.json
+++ b/flows/actions/testdata/_assets.json
@@ -3,7 +3,7 @@
         {
             "uuid": "bead76f5-dac4-4c9d-996c-c62b326e8c0a",
             "name": "Action Tester",
-            "spec_version": "13.3.0",
+            "spec_version": "13.4.0",
             "language": "eng",
             "type": "messaging",
             "revision": 123,
@@ -23,7 +23,7 @@
         {
             "uuid": "7a84463d-d209-4d3e-a0ff-79f977cd7bd0",
             "name": "Voice Action Tester",
-            "spec_version": "13.2",
+            "spec_version": "13.4.0",
             "language": "eng",
             "type": "voice",
             "revision": 123,
@@ -43,7 +43,7 @@
         {
             "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
             "name": "Collect Age",
-            "spec_version": "13.2",
+            "spec_version": "13.4.0",
             "revision": 123,
             "language": "eng",
             "type": "messaging",

--- a/flows/actions/testdata/send_msg.json
+++ b/flows/actions/testdata/send_msg.json
@@ -351,9 +351,15 @@
                     "uuid": "b620b463-8d15-427f-b2e3-4f44f9f071ec",
                     "name": "missing"
                 },
-                "variables": [
-                    "@contact.name",
-                    "boy"
+                "components": [
+                    {
+                        "uuid": "aa304c85-c14f-4f94-b97c-ec59c07a3f39",
+                        "name": "body",
+                        "params": [
+                            "@contact.name",
+                            "boy"
+                        ]
+                    }
                 ]
             }
         },
@@ -945,128 +951,6 @@
             "Yeah",
             "Nope",
             "http://templates.com/red.jpg"
-        ],
-        "inspection": {
-            "dependencies": [
-                {
-                    "uuid": "ce00c80e-991a-4c03-b373-3273c23ee042",
-                    "name": "gender_update",
-                    "type": "template"
-                }
-            ],
-            "issues": [],
-            "results": [],
-            "waiting_exits": [],
-            "parent_refs": []
-        }
-    },
-    {
-        "description": "Use template translation with legacy variables",
-        "action": {
-            "type": "send_msg",
-            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
-            "text": "Hey Ryan Lewis, your gender is saved as boy.",
-            "templating": {
-                "uuid": "9c4bf5b5-3aa4-48ec-9bb9-424a9cbc6785",
-                "template": {
-                    "uuid": "ce00c80e-991a-4c03-b373-3273c23ee042",
-                    "name": "gender_update"
-                },
-                "variables": [
-                    "@contact.name",
-                    "boy"
-                ]
-            }
-        },
-        "localization": {
-            "spa": {
-                "ad154980-7bf7-4ab8-8728-545fd6378912": {
-                    "text": [
-                        "Hola!"
-                    ],
-                    "attachments": [
-                        "http://example.com/rojo.jpg"
-                    ],
-                    "quick_replies": [
-                        "Si",
-                        "No"
-                    ]
-                },
-                "9c4bf5b5-3aa4-48ec-9bb9-424a9cbc6785": {
-                    "variables": [
-                        "@contact.name",
-                        "niño"
-                    ]
-                }
-            }
-        },
-        "events": [
-            {
-                "type": "msg_created",
-                "created_on": "2018-10-18T14:20:30.000123456Z",
-                "step_uuid": "59d74b86-3e2f-4a93-aece-b05d2fdcde0c",
-                "msg": {
-                    "uuid": "9688d21d-95aa-4bed-afc7-f31b35731a3d",
-                    "urn": "tel:+12065551212?channel=57f1078f-88aa-46f4-a59a-948a5739c03d&id=123",
-                    "channel": {
-                        "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d",
-                        "name": "My Android Phone"
-                    },
-                    "text": "Hola, Ryan Lewis, tu género está guardado como niño.",
-                    "quick_replies": [
-                        "",
-                        "No"
-                    ],
-                    "templating": {
-                        "template": {
-                            "uuid": "ce00c80e-991a-4c03-b373-3273c23ee042",
-                            "name": "gender_update"
-                        },
-                        "params": {
-                            "body": [
-                                {
-                                    "type": "text",
-                                    "value": "Ryan Lewis"
-                                },
-                                {
-                                    "type": "text",
-                                    "value": "niño"
-                                }
-                            ],
-                            "button.0": [
-                                {
-                                    "type": "text",
-                                    "value": ""
-                                }
-                            ],
-                            "header": [
-                                {
-                                    "type": "image",
-                                    "value": ""
-                                }
-                            ]
-                        },
-                        "namespace": ""
-                    },
-                    "locale": "spa"
-                }
-            }
-        ],
-        "templates": [
-            "Hey Ryan Lewis, your gender is saved as boy.",
-            "Hola!",
-            "http://example.com/rojo.jpg",
-            "Si",
-            "No",
-            "@contact.name",
-            "boy",
-            "@contact.name",
-            "niño"
-        ],
-        "localizables": [
-            "Hey Ryan Lewis, your gender is saved as boy.",
-            "@contact.name",
-            "boy"
         ],
         "inspection": {
             "dependencies": [

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CurrentSpecVersion is the flow spec version supported by this library
-var CurrentSpecVersion = semver.MustParse("13.3.0")
+var CurrentSpecVersion = semver.MustParse("13.4.0")
 
 // IsVersionSupported checks the given version is supported
 func IsVersionSupported(v *semver.Version) bool {

--- a/flows/definition/migrations/primitives_test.go
+++ b/flows/definition/migrations/primitives_test.go
@@ -118,6 +118,7 @@ func TestLocalizationPrimitives(t *testing.T) {
 
 	spa.DeleteTranslation("8eebd020-1af5-431c-b943-aa670fc74da9", "text")
 	spa.DeleteTranslation("8eebd020-1af5-431c-b943-aa670fc74da9", "empty")
+	spa.DeleteTranslation("8eebd020-1af5-431c-b943-aa670fc74da9", "foo") // doesn't exist
 	spa.DeleteTranslation("6f865930-e783-4fde-8e28-34b93b3a17c6", "text")
 
 	test.AssertEqualJSON(t, []byte(`{

--- a/flows/definition/migrations/specdata/templates.json
+++ b/flows/definition/migrations/specdata/templates.json
@@ -1,5 +1,5 @@
 {
-    "13.3.0": {
+    "13.4.0": {
         "actions": {
             "add_contact_groups": [
                 ".groups[*].name_match"
@@ -51,6 +51,94 @@
                 ".attachments[*]",
                 ".quick_replies[*]",
                 ".templating.components[*].params[*]",
+                ".text"
+            ],
+            "set_contact_channel": [],
+            "set_contact_field": [
+                ".value"
+            ],
+            "set_contact_language": [
+                ".language"
+            ],
+            "set_contact_name": [
+                ".name"
+            ],
+            "set_contact_status": [],
+            "set_contact_timezone": [
+                ".timezone"
+            ],
+            "set_run_result": [
+                ".value"
+            ],
+            "start_session": [
+                ".contact_query",
+                ".groups[*].name_match",
+                ".legacy_vars[*]"
+            ],
+            "transfer_airtime": []
+        },
+        "routers": {
+            "random": [
+                ".operand",
+                ".cases[*].arguments[*]"
+            ],
+            "switch": [
+                ".operand",
+                ".cases[*].arguments[*]"
+            ]
+        }
+    },
+    "13.3.0": {
+        "actions": {
+            "add_contact_groups": [
+                ".groups[*].name_match"
+            ],
+            "add_contact_urn": [
+                ".path"
+            ],
+            "add_input_labels": [
+                ".labels[*].name_match"
+            ],
+            "call_classifier": [
+                ".input"
+            ],
+            "call_resthook": [],
+            "call_webhook": [
+                ".body",
+                ".headers.*",
+                ".url"
+            ],
+            "enter_flow": [],
+            "open_ticket": [
+                ".assignee.email_match",
+                ".body"
+            ],
+            "play_audio": [
+                ".audio_url"
+            ],
+            "remove_contact_groups": [
+                ".groups[*].name_match"
+            ],
+            "request_optin": [],
+            "say_msg": [
+                ".text"
+            ],
+            "send_broadcast": [
+                ".attachments[*]",
+                ".contact_query",
+                ".groups[*].name_match",
+                ".legacy_vars[*]",
+                ".quick_replies[*]",
+                ".text"
+            ],
+            "send_email": [
+                ".addresses[*]",
+                ".body",
+                ".subject"
+            ],
+            "send_msg": [
+                ".attachments[*]",
+                ".quick_replies[*]",
                 ".templating.variables[*]",
                 ".text"
             ],

--- a/flows/definition/migrations/testdata/migrations/13.4.0.json
+++ b/flows/definition/migrations/testdata/migrations/13.4.0.json
@@ -1,0 +1,184 @@
+[
+    {
+        "description": "flow with localization",
+        "original": {
+            "uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
+            "name": "Testing",
+            "spec_version": "13.3.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {
+                "spa": {
+                    "8eebd020-1af5-431c-b943-aa670fc74da9": {
+                        "text": [
+                            "Hola"
+                        ]
+                    },
+                    "9c4bf5b5-3aa4-48ec-9bb9-424a9cbc6785": {
+                        "variables": [
+                            "@contact"
+                        ]
+                    }
+                }
+            },
+            "nodes": [
+                {
+                    "uuid": "365293c7-633c-45bd-96b7-0b059766588d",
+                    "actions": [
+                        {
+                            "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
+                            "type": "send_msg",
+                            "text": "Hello",
+                            "templating": {
+                                "uuid": "9c4bf5b5-3aa4-48ec-9bb9-424a9cbc6785",
+                                "template": {
+                                    "uuid": "ce00c80e-991a-4c03-b373-3273c23ee042",
+                                    "name": "welcome"
+                                },
+                                "variables": [
+                                    "@contact.name"
+                                ]
+                            }
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "3bd19c40-1114-4b83-b12e-f0c38054ba3f"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
+            "name": "Testing",
+            "spec_version": "13.4.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {
+                "spa": {
+                    "8eebd020-1af5-431c-b943-aa670fc74da9": {
+                        "text": [
+                            "Hola"
+                        ]
+                    },
+                    "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5": {
+                        "params": [
+                            "@contact"
+                        ]
+                    }
+                }
+            },
+            "nodes": [
+                {
+                    "uuid": "365293c7-633c-45bd-96b7-0b059766588d",
+                    "actions": [
+                        {
+                            "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
+                            "type": "send_msg",
+                            "text": "Hello",
+                            "templating": {
+                                "uuid": "9c4bf5b5-3aa4-48ec-9bb9-424a9cbc6785",
+                                "template": {
+                                    "uuid": "ce00c80e-991a-4c03-b373-3273c23ee042",
+                                    "name": "welcome"
+                                },
+                                "components": [
+                                    {
+                                        "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+                                        "name": "body",
+                                        "params": [
+                                            "@contact.name"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "3bd19c40-1114-4b83-b12e-f0c38054ba3f"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "description": "flow without localization",
+        "original": {
+            "uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
+            "name": "Testing",
+            "spec_version": "13.3.0",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": [
+                {
+                    "uuid": "365293c7-633c-45bd-96b7-0b059766588d",
+                    "actions": [
+                        {
+                            "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
+                            "type": "send_msg",
+                            "text": "Hello",
+                            "templating": {
+                                "uuid": "9c4bf5b5-3aa4-48ec-9bb9-424a9cbc6785",
+                                "template": {
+                                    "uuid": "ce00c80e-991a-4c03-b373-3273c23ee042",
+                                    "name": "welcome"
+                                },
+                                "variables": [
+                                    "@contact.name"
+                                ]
+                            }
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "3bd19c40-1114-4b83-b12e-f0c38054ba3f"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
+            "name": "Testing",
+            "spec_version": "13.4.0",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": [
+                {
+                    "uuid": "365293c7-633c-45bd-96b7-0b059766588d",
+                    "actions": [
+                        {
+                            "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
+                            "type": "send_msg",
+                            "text": "Hello",
+                            "templating": {
+                                "uuid": "9c4bf5b5-3aa4-48ec-9bb9-424a9cbc6785",
+                                "template": {
+                                    "uuid": "ce00c80e-991a-4c03-b373-3273c23ee042",
+                                    "name": "welcome"
+                                },
+                                "components": [
+                                    {
+                                        "uuid": "d2f852ec-7b4e-457f-ae7f-f8b243c49ff5",
+                                        "name": "body",
+                                        "params": [
+                                            "@contact.name"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "3bd19c40-1114-4b83-b12e-f0c38054ba3f"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_ara.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_ara.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "13.3.0",
+    "spec_version": "13.4.0",
     "language": "ara",
     "type": "messaging",
     "revision": 16,

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_kin.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_kin.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "13.3.0",
+    "spec_version": "13.4.0",
     "language": "kin",
     "type": "messaging",
     "revision": 16,

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_spa.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_spa.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "13.3.0",
+    "spec_version": "13.4.0",
     "language": "spa",
     "type": "messaging",
     "revision": 16,

--- a/flows/definition/testdata/change_language.json
+++ b/flows/definition/testdata/change_language.json
@@ -3,7 +3,7 @@
     {
       "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
       "name": "Change Language",
-      "spec_version": "13.3.0",
+      "spec_version": "13.4.0",
       "language": "eng",
       "type": "messaging",
       "revision": 16,


### PR DESCRIPTION
In the end the strategy of supporting both in the engine and having the editor support reading both... wasn't as doable as we thought.