### PR TITLE
Truncate quick replies for template preview messages

### DIFF
--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/nyaruka/gocommon/i18n"
+	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
@@ -181,7 +182,7 @@ func (a *SendMsgAction) getTemplateMsg(run flows.Run, urn urns.URN, channelRef *
 	var previewQRs []string
 	for _, key := range utils.SortedKeys(preview) {
 		if strings.HasPrefix(key, "button.") {
-			previewQRs = append(previewQRs, preview[key])
+			previewQRs = append(previewQRs, stringsx.TruncateEllipsis(preview[key], maxQuickReplyLength))
 		}
 	}
 


### PR DESCRIPTION
I think this is https://textit.sentry.io/issues/5069379664/?alert_rule_id=515582&alert_timestamp=1710500035628&alert_type=email&notification_uuid=5623cbac-2390-48c8-aac0-531a26c4ae8e&project=1285856

Generally we might need to have a think about supporting quick replies that are text + payload since that's a thing that several channel types support... but would require a more complex editing widget.