### PR TITLE
Rework the format of `MsgTemplating`

### DIFF
--- a/flows/actions/testdata/send_msg.json
+++ b/flows/actions/testdata/send_msg.json
@@ -463,16 +463,20 @@
                             {
                                 "type": "body",
                                 "name": "body",
-                                "params": [
-                                    {
-                                        "type": "text",
-                                        "value": "Ryan Lewis"
-                                    },
-                                    {
-                                        "type": "text",
-                                        "value": "boy"
-                                    }
-                                ]
+                                "variables": {
+                                    "1": 0,
+                                    "2": 1
+                                }
+                            }
+                        ],
+                        "variables": [
+                            {
+                                "type": "text",
+                                "value": "Ryan Lewis"
+                            },
+                            {
+                                "type": "text",
+                                "value": "boy"
                             }
                         ]
                     },
@@ -560,16 +564,20 @@
                             {
                                 "type": "body",
                                 "name": "body",
-                                "params": [
-                                    {
-                                        "type": "text",
-                                        "value": "Ryan Lewis"
-                                    },
-                                    {
-                                        "type": "text",
-                                        "value": "niño"
-                                    }
-                                ]
+                                "variables": {
+                                    "1": 0,
+                                    "2": 1
+                                }
+                            }
+                        ],
+                        "variables": [
+                            {
+                                "type": "text",
+                                "value": "Ryan Lewis"
+                            },
+                            {
+                                "type": "text",
+                                "value": "niño"
                             }
                         ]
                     },
@@ -896,26 +904,31 @@
                             {
                                 "type": "body",
                                 "name": "body",
-                                "params": [
-                                    {
-                                        "type": "text",
-                                        "value": "Ryan Lewis"
-                                    },
-                                    {
-                                        "type": "text",
-                                        "value": "niño"
-                                    }
-                                ]
+                                "variables": {
+                                    "1": 0,
+                                    "2": 1
+                                }
                             },
                             {
                                 "type": "button/quick_reply",
                                 "name": "button.0",
-                                "params": [
-                                    {
-                                        "type": "text",
-                                        "value": "Sip"
-                                    }
-                                ]
+                                "variables": {
+                                    "1": 2
+                                }
+                            }
+                        ],
+                        "variables": [
+                            {
+                                "type": "text",
+                                "value": "Ryan Lewis"
+                            },
+                            {
+                                "type": "text",
+                                "value": "niño"
+                            },
+                            {
+                                "type": "text",
+                                "value": "Sip"
                             }
                         ]
                     },

--- a/flows/msg.go
+++ b/flows/msg.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"slices"
-	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/nyaruka/gocommon/i18n"
@@ -170,52 +168,29 @@ func (m *MsgOut) Locale() i18n.Locale { return m.Locale_ }
 // UnsendableReason returns the reason this message can't be sent (if any)
 func (m *MsgOut) UnsendableReason() UnsendableReason { return m.UnsendableReason_ }
 
-type TemplatingParam struct {
+type TemplatingVariable struct {
 	Type  string `json:"type"`
 	Value string `json:"value"`
 }
 
 type TemplatingComponent struct {
-	Type   string            `json:"type"`
-	Name   string            `json:"name"`
-	Params []TemplatingParam `json:"params"`
-}
-
-var templateVariableRegex = regexp.MustCompile(`{{(\d+)}}`)
-
-// Preview returns the content of the given template component rendered using these templating params
-func (tc *TemplatingComponent) Preview(c assets.TemplateComponent) string {
-	content := c.Content()
-
-	for i, p := range tc.Params {
-		content = strings.ReplaceAll(content, fmt.Sprintf("{{%d}}", i+1), p.Value)
-	}
-
-	content = templateVariableRegex.ReplaceAllString(content, "")
-
-	return content
+	Type      string         `json:"type"`
+	Name      string         `json:"name"`
+	Variables map[string]int `json:"variables"`
 }
 
 // MsgTemplating represents any substituted message template that should be applied when sending this message
 type MsgTemplating struct {
-	Template_   *assets.TemplateReference `json:"template"`
-	Namespace_  string                    `json:"namespace"`
-	Components_ []*TemplatingComponent    `json:"components,omitempty"`
+	Template   *assets.TemplateReference `json:"template"`
+	Namespace  string                    `json:"namespace"`
+	Components []*TemplatingComponent    `json:"components,omitempty"`
+	Variables  []*TemplatingVariable     `json:"variables,omitempty"`
 }
 
 // NewMsgTemplating creates and returns a new msg template
-func NewMsgTemplating(template *assets.TemplateReference, namespace string, components []*TemplatingComponent) *MsgTemplating {
-	return &MsgTemplating{Template_: template, Namespace_: namespace, Components_: components}
+func NewMsgTemplating(template *assets.TemplateReference, namespace string, components []*TemplatingComponent, variables []*TemplatingVariable) *MsgTemplating {
+	return &MsgTemplating{Template: template, Namespace: namespace, Components: components, Variables: variables}
 }
-
-// Template returns the template this msg template is for
-func (t *MsgTemplating) Template() *assets.TemplateReference { return t.Template_ }
-
-// Namespace returns the namespace that should be for the template
-func (t *MsgTemplating) Namespace() string { return t.Namespace_ }
-
-// Components returns the components that should be used for the templates
-func (t *MsgTemplating) Components() []*TemplatingComponent { return t.Components_ }
 
 // BroadcastTranslation is the broadcast content in a particular language
 type BroadcastTranslation struct {

--- a/flows/msg_test.go
+++ b/flows/msg_test.go
@@ -163,11 +163,17 @@ func TestMsgTemplating(t *testing.T) {
 
 	templateRef := assets.NewTemplateReference("61602f3e-f603-4c70-8a8f-c477505bf4bf", "Affirmation")
 
-	msgTemplating := flows.NewMsgTemplating(templateRef, "0162a7f4_dfe4_4c96_be07_854d5dba3b2b", []*flows.TemplatingComponent{{Type: "body", Name: "body", Params: []flows.TemplatingParam{{Type: "text", Value: "Ryan Lewis"}, {Type: "text", Value: "boy"}}}})
+	msgTemplating := flows.NewMsgTemplating(
+		templateRef,
+		"0162a7f4_dfe4_4c96_be07_854d5dba3b2b",
+		[]*flows.TemplatingComponent{{Type: "body", Name: "body", Variables: map[string]int{"1": 0, "2": 1}}},
+		[]*flows.TemplatingVariable{{Type: "text", Value: "Ryan Lewis"}, {Type: "text", Value: "boy"}},
+	)
 
-	assert.Equal(t, templateRef, msgTemplating.Template())
-	assert.Equal(t, "0162a7f4_dfe4_4c96_be07_854d5dba3b2b", msgTemplating.Namespace())
-	assert.Equal(t, []*flows.TemplatingComponent{{Type: "body", Name: "body", Params: []flows.TemplatingParam{{Type: "text", Value: "Ryan Lewis"}, {Type: "text", Value: "boy"}}}}, msgTemplating.Components())
+	assert.Equal(t, templateRef, msgTemplating.Template)
+	assert.Equal(t, "0162a7f4_dfe4_4c96_be07_854d5dba3b2b", msgTemplating.Namespace)
+	assert.Equal(t, []*flows.TemplatingComponent{{Type: "body", Name: "body", Variables: map[string]int{"1": 0, "2": 1}}}, msgTemplating.Components)
+	assert.Equal(t, []*flows.TemplatingVariable{{Type: "text", Value: "Ryan Lewis"}, {Type: "text", Value: "boy"}}, msgTemplating.Variables)
 
 	// test marshaling our msg
 	marshaled, err := jsonx.Marshal(msgTemplating)
@@ -183,22 +189,23 @@ func TestMsgTemplating(t *testing.T) {
 			{
 				"type": "body",
 				"name": "body",
-				"params":[
-					{
-						"type": "text",
-						"value": "Ryan Lewis"
-					},
-					{
-						"type": "text",
-						"value": "boy"
-					}
-				]
+				"variables": {"1": 0, "2": 1}
+			}
+		],
+		"variables": [
+			{
+				"type": "text",
+				"value": "Ryan Lewis"
+			},
+			{
+				"type": "text",
+				"value": "boy"
 			}
 		]
 	  }`), marshaled, "JSON mismatch")
 }
 
-func TestTemplatingComponentPreview(t *testing.T) {
+/*func TestTemplatingComponentPreview(t *testing.T) {
 	tcs := []struct {
 		templating *flows.TemplatingComponent
 		component  assets.TemplateComponent
@@ -235,4 +242,4 @@ func TestTemplatingComponentPreview(t *testing.T) {
 		actualContent := tc.templating.Preview(tc.component)
 		assert.Equal(t, tc.expected, actualContent, "content mismatch in test %d", i)
 	}
-}
+}*/


### PR DESCRIPTION
We can have mailroom save this as `msg.templating` and the old format (which it can create) as `msg.metadata.templating`

```

"components": [
	{
		"type": "body",
		"name": "body",
		"params": [{type": "text", "value": "Bob"}, {type": "text", "value": "TextIt"}]
	},
	{
		"type": "button/quick-reply",
		"name": "button.0",
		"params": [{type": "text", "value": "A"}]
	},
	{
		"type": "button/url",
		"name": "button.1",
		"params": [{type": "text", "value": "B"}]
	}
]
```

becomes...

```
"components": [
	{
		"type": "body",
		"name": "body",
		"variables": {"1": 0, "2": 1}
	},
	{
		"type": "button/quick-reply",
		"name": "button.0",
		"variables": {"1": 2}
	},
	{
		"type": "button/url",
		"name": "button.1",
		"variables": {"1": 3}
	}
],
"variables": [
	{type": "text", "value": "Bob"},
	{type": "text", "value": "TextIt"},
	{type": "text", "value": "A"},
	{type": "text", "value": "B"}
]
```