### PR TITLE
Re-include legacy .params field on components temporarily

### DIFF
--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
+	"github.com/nyaruka/goflow/utils"
 )
 
 func init() {
@@ -176,7 +177,16 @@ func (a *SendMsgAction) getTemplateMsg(run flows.Run, urn urns.URN, channelRef *
 	components := make([]*flows.TemplatingComponent, 0, len(translation.Components()))
 	for _, comp := range translation.Components() {
 		if len(comp.Variables()) > 0 {
-			components = append(components, &flows.TemplatingComponent{Type: comp.Type(), Name: comp.Name(), Variables: comp.Variables()})
+			tc := &flows.TemplatingComponent{Type: comp.Type(), Name: comp.Name(), Variables: comp.Variables()}
+
+			// TODO remove when courier updated
+			tc.Params = make([]*flows.TemplatingVariable, 0, len(comp.Variables()))
+			for _, vn := range utils.SortedKeys(comp.Variables()) {
+				vi := comp.Variables()[vn]
+				tc.Params = append(tc.Params, variables[vi])
+			}
+
+			components = append(components, tc)
 		}
 	}
 

--- a/flows/actions/testdata/send_msg.json
+++ b/flows/actions/testdata/send_msg.json
@@ -466,7 +466,17 @@
                                 "variables": {
                                     "1": 0,
                                     "2": 1
-                                }
+                                },
+                                "params": [
+                                    {
+                                        "type": "text",
+                                        "value": "Ryan Lewis"
+                                    },
+                                    {
+                                        "type": "text",
+                                        "value": "boy"
+                                    }
+                                ]
                             }
                         ],
                         "variables": [
@@ -567,7 +577,17 @@
                                 "variables": {
                                     "1": 0,
                                     "2": 1
-                                }
+                                },
+                                "params": [
+                                    {
+                                        "type": "text",
+                                        "value": "Ryan Lewis"
+                                    },
+                                    {
+                                        "type": "text",
+                                        "value": "niño"
+                                    }
+                                ]
                             }
                         ],
                         "variables": [
@@ -907,14 +927,30 @@
                                 "variables": {
                                     "1": 0,
                                     "2": 1
-                                }
+                                },
+                                "params": [
+                                    {
+                                        "type": "text",
+                                        "value": "Ryan Lewis"
+                                    },
+                                    {
+                                        "type": "text",
+                                        "value": "niño"
+                                    }
+                                ]
                             },
                             {
                                 "type": "button/quick_reply",
                                 "name": "button.0",
                                 "variables": {
                                     "1": 2
-                                }
+                                },
+                                "params": [
+                                    {
+                                        "type": "text",
+                                        "value": "Sip"
+                                    }
+                                ]
                             }
                         ],
                         "variables": [

--- a/flows/msg.go
+++ b/flows/msg.go
@@ -174,9 +174,10 @@ type TemplatingVariable struct {
 }
 
 type TemplatingComponent struct {
-	Type      string         `json:"type"`
-	Name      string         `json:"name"`
-	Variables map[string]int `json:"variables"`
+	Type      string                `json:"type"`
+	Name      string                `json:"name"`
+	Variables map[string]int        `json:"variables"`
+	Params    []*TemplatingVariable `json:"params"` // deprecated
 }
 
 // MsgTemplating represents any substituted message template that should be applied when sending this message

--- a/flows/msg_test.go
+++ b/flows/msg_test.go
@@ -189,7 +189,8 @@ func TestMsgTemplating(t *testing.T) {
 			{
 				"type": "body",
 				"name": "body",
-				"variables": {"1": 0, "2": 1}
+				"variables": {"1": 0, "2": 1},
+				"params": null
 			}
 		],
 		"variables": [
@@ -204,42 +205,3 @@ func TestMsgTemplating(t *testing.T) {
 		]
 	  }`), marshaled, "JSON mismatch")
 }
-
-/*func TestTemplatingComponentPreview(t *testing.T) {
-	tcs := []struct {
-		templating *flows.TemplatingComponent
-		component  assets.TemplateComponent
-		expected   string
-	}{
-		{ // 0: no params
-			component:  static.NewTemplateComponent("body", "body", "Hello", "", map[string]int{}),
-			templating: &flows.TemplatingComponent{Type: "body", Params: []flows.TemplatingParam{}},
-			expected:   "Hello",
-		},
-		{ // 1: two params on component and two params in templating
-			component:  static.NewTemplateComponent("body", "body", "Hello {{1}} {{2}}", "", map[string]int{"1": 0, "2": 1}),
-			templating: &flows.TemplatingComponent{Type: "body", Params: []flows.TemplatingParam{{Type: "text", Value: "Dr"}, {Type: "text", Value: "Bob"}}},
-			expected:   "Hello Dr Bob",
-		},
-		{ // 2: one less param in templating than on component
-			component:  static.NewTemplateComponent("body", "body", "Hello {{1}} {{2}}", "", map[string]int{"1": 0, "2": 1}),
-			templating: &flows.TemplatingComponent{Type: "body", Params: []flows.TemplatingParam{{Type: "text", Value: "Dr"}}},
-			expected:   "Hello Dr ",
-		},
-		{ // 3
-			component:  static.NewTemplateComponent("button/quick_reply", "button.0", "{{1}}", "", map[string]int{"1": 0, "2": 1}),
-			templating: &flows.TemplatingComponent{Type: "button/quick_reply", Params: []flows.TemplatingParam{{Type: "text", Value: "Yes"}}},
-			expected:   "Yes",
-		},
-		{ // 4: one param for content, one for display
-			component:  static.NewTemplateComponent("button/url", "button.0", "example.com?p={{1}}", "{{1}}", map[string]int{"1": 0, "2": 1}),
-			templating: &flows.TemplatingComponent{Type: "button/url", Params: []flows.TemplatingParam{{Type: "text", Value: "123"}, {Type: "text", Value: "Go"}}},
-			expected:   "example.com?p=123",
-		},
-	}
-
-	for i, tc := range tcs {
-		actualContent := tc.templating.Preview(tc.component)
-		assert.Equal(t, tc.expected, actualContent, "content mismatch in test %d", i)
-	}
-}*/


### PR DESCRIPTION
On reflection it's a lot easier to add these back here than have mailroom generate two formats...