### PR TITLE
Make template message code usable outside of actions part 1

### DIFF
--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -22,12 +22,6 @@ import (
 // max number of bytes to be saved to extra on a result
 const resultExtraMaxBytes = 10000
 
-// max length of a message attachment (type:url)
-const maxAttachmentLength = 2048
-
-// max length of a quick reply
-const maxQuickReplyLength = 64
-
 // common category names
 const (
 	CategorySuccess = "Success"
@@ -96,8 +90,8 @@ func (a *baseAction) evaluateMessage(run flows.Run, languages []i18n.Language, a
 			logEvent(events.NewErrorf("attachment text evaluated to empty string, skipping"))
 			continue
 		}
-		if len(evaluatedAttachment) > maxAttachmentLength {
-			logEvent(events.NewErrorf("evaluated attachment is longer than %d limit, skipping", maxAttachmentLength))
+		if len(evaluatedAttachment) > flows.MaxAttachmentLength {
+			logEvent(events.NewErrorf("evaluated attachment is longer than %d limit, skipping", flows.MaxAttachmentLength))
 			continue
 		}
 		evaluatedAttachments = append(evaluatedAttachments, utils.Attachment(evaluatedAttachment))
@@ -112,7 +106,7 @@ func (a *baseAction) evaluateMessage(run flows.Run, languages []i18n.Language, a
 			logEvent(events.NewErrorf("quick reply text evaluated to empty string, skipping"))
 			continue
 		}
-		evaluatedQuickReplies = append(evaluatedQuickReplies, stringsx.TruncateEllipsis(evaluatedQuickReply, maxQuickReplyLength))
+		evaluatedQuickReplies = append(evaluatedQuickReplies, stringsx.TruncateEllipsis(evaluatedQuickReply, flows.MaxQuickReplyLength))
 	}
 
 	// although it's possible for the different parts of the message to have different languages, we want to resolve

--- a/flows/msg.go
+++ b/flows/msg.go
@@ -22,6 +22,12 @@ func init() {
 type UnsendableReason string
 
 const (
+	// max length of a message attachment (type:url)
+	MaxAttachmentLength = 2048
+
+	// max length of a quick reply
+	MaxQuickReplyLength = 64
+
 	NilUnsendableReason           UnsendableReason = ""
 	UnsendableReasonNoDestination UnsendableReason = "no_destination" // no sendable channel+URN pair
 	UnsendableReasonContactStatus UnsendableReason = "contact_status" // contact is blocked or stopped or archived

--- a/flows/template_test.go
+++ b/flows/template_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/nyaruka/gocommon/i18n"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/test"
+	"github.com/nyaruka/goflow/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,4 +57,129 @@ func TestFindTranslation(t *testing.T) {
 	assert.NotNil(t, template)
 	assert.Equal(t, assets.NewTemplateReference("c520cbda-e118-440f-aaf6-c0485088384f", "greeting"), template.Reference())
 	assert.Equal(t, (*assets.TemplateReference)(nil), (*flows.Template)(nil).Reference())
+}
+
+func TestTemplateTranslationPreview(t *testing.T) {
+	tcs := []struct {
+		translation []byte
+		variables   []*flows.TemplatingVariable
+		expected    *flows.MsgContent
+	}{
+		{ // 0: empty translation
+			translation: []byte(`{
+				"channel": {"uuid": "79401ef2-8eb6-48f4-9f9d-0604530b1ac0", "name": "WhatsApp"}, 
+				"locale": "eng",
+				"components": [],
+				"variables": []
+			}`),
+			variables: []*flows.TemplatingVariable{},
+			expected:  &flows.MsgContent{},
+		},
+		{ // 1: body only
+			translation: []byte(`{
+				"channel": {"uuid": "79401ef2-8eb6-48f4-9f9d-0604530b1ac0", "name": "WhatsApp"}, 
+				"locale": "eng",
+				"components": [
+					{
+						"name": "body",
+						"type": "body/text",
+						"content": "Hi {{1}}, who's a good {{2}}?",
+						"variables": {"1": 0, "2": 1}
+					}
+				],
+				"variables": [
+					{"type": "text"},
+					{"type": "text"}
+				]
+			}`),
+			variables: []*flows.TemplatingVariable{{Type: "text", Value: "Chef"}, {Type: "text", Value: "boy"}},
+			expected:  &flows.MsgContent{Text: "Hi Chef, who's a good boy?"},
+		},
+		{ // 2: multiple text component types
+			translation: []byte(`{
+				"channel": {"uuid": "79401ef2-8eb6-48f4-9f9d-0604530b1ac0", "name": "WhatsApp"}, 
+				"locale": "eng",
+				"components": [
+					{
+						"name": "header",
+						"type": "header/text",
+						"content": "Header {{1}}",
+						"variables": {"1": 0}
+					},
+					{
+						"name": "body",
+						"type": "body/text",
+						"content": "Body {{1}}",
+						"variables": {"1": 1}
+					},
+					{
+						"name": "footer",
+						"type": "footer/text",
+						"content": "Footer {{1}}",
+						"variables": {"1": 2}
+					}
+				],
+				"variables": [
+					{"type": "text"},
+					{"type": "text"},
+					{"type": "text"}
+				]
+			}`),
+			variables: []*flows.TemplatingVariable{{Type: "text", Value: "A"}, {Type: "text", Value: "B"}, {Type: "text", Value: "C"}},
+			expected:  &flows.MsgContent{Text: "Header A\n\nBody B\n\nFooter C"},
+		},
+		{ // 3: buttons become quick replies
+			translation: []byte(`{
+				"channel": {"uuid": "79401ef2-8eb6-48f4-9f9d-0604530b1ac0", "name": "WhatsApp"}, 
+				"locale": "eng",
+				"components": [
+					{
+						"name": "button.1",
+						"type": "button/quick_reply",
+						"content": "{{1}}",
+						"variables": {"1": 0}
+					},
+					{
+						"name": "button.2",
+						"type": "button/quick_reply",
+						"content": "{{1}}",
+						"variables": {"1": 1}
+					}
+				],
+				"variables": [
+					{"type": "text"},
+					{"type": "text"}
+				]
+			}`),
+			variables: []*flows.TemplatingVariable{{Type: "text", Value: "Yes"}, {Type: "text", Value: "No"}},
+			expected:  &flows.MsgContent{QuickReplies: []string{"Yes", "No"}},
+		},
+		{ // 4: header image becomes an attachment
+			translation: []byte(`{
+				"channel": {"uuid": "79401ef2-8eb6-48f4-9f9d-0604530b1ac0", "name": "WhatsApp"}, 
+				"locale": "eng",
+				"components": [
+					{
+						"name": "header",
+						"type": "header/image",
+						"content": "{{1}}",
+						"variables": {"1": 0}
+					}
+				],
+				"variables": [
+					{"type": "image"}
+				]
+			}`),
+			variables: []*flows.TemplatingVariable{{Type: "image", Value: "image/jpeg:http://example.com/test.jpg"}},
+			expected:  &flows.MsgContent{Attachments: []utils.Attachment{"image/jpeg:http://example.com/test.jpg"}},
+		},
+	}
+
+	for i, tc := range tcs {
+		trans := &static.TemplateTranslation{}
+		jsonx.MustUnmarshal(tc.translation, trans)
+
+		actual := flows.NewTemplateTranslation(trans).Preview(tc.variables)
+		assert.Equal(t, tc.expected, actual, "%d: preview mismatch", i)
+	}
 }


### PR DESCRIPTION
Move functionality to generate preview content for template message from `send_msg` action to `TemplateTranslation`