### PR TITLE
Rework results so they're keyed by name rather than snakified name

### DIFF
--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -299,7 +299,7 @@ func TestWaitTimeout(t *testing.T) {
 	require.Equal(t, 2, len(run.Path()))
 	require.Equal(t, 5, len(run.Events()))
 
-	result := run.Results().Get("favorite_color")
+	result := run.Results().Get("Favorite Color")
 	require.Equal(t, "Timeout", result.Category)
 	require.Equal(t, "2018-04-11T13:24:30.123456Z", result.Value)
 	require.Equal(t, "", result.Input)

--- a/flows/results_test.go
+++ b/flows/results_test.go
@@ -1,6 +1,7 @@
 package flows_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -23,8 +24,8 @@ func TestResults(t *testing.T) {
 	results.Save(result1)
 	results.Save(result2)
 
-	assert.Equal(t, result1, results.Get("beer"))
-	assert.Equal(t, result2, results.Get("empty"))
+	assert.Equal(t, result1, results.Get("Beer"))
+	assert.Equal(t, result2, results.Get("Empty"))
 	assert.Nil(t, results.Get("xxx"))
 
 	resultsAsContext := flows.Context(env, results)
@@ -60,6 +61,19 @@ func TestResults(t *testing.T) {
 			"values":               types.NewXArray(types.NewXText("")),
 		}),
 	}), resultsAsContext)
+
+	// test marshalling
+	marshaled, err := json.Marshal(results)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"Beer": {"category": "Skol", "created_on":"2019-04-05T14:16:30.000123456Z", "name": "Beer", "node_uuid": "26493ebb-a254-4461-a28d-c7761784e276", "value": "skol!"}, 
+		"Empty": {"created_on":"2019-04-05T14:16:30.000123456Z", "name": "Empty", "node_uuid": "26493ebb-a254-4461-a28d-c7761784e276", "value": ""}
+	}`, string(marshaled))
+
+	var unmarshaled flows.Results
+	err = json.Unmarshal(marshaled, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, results, unmarshaled)
 }
 
 func TestResultNameAndCategoryValidation(t *testing.T) {

--- a/flows/routers/testdata/random.json
+++ b/flows/routers/testdata/random.json
@@ -23,7 +23,7 @@
             ]
         },
         "results": {
-            "random_result": {
+            "Random Result": {
                 "name": "Random Result",
                 "value": "1",
                 "category": "No",

--- a/flows/routers/testdata/switch.json
+++ b/flows/routers/testdata/switch.json
@@ -178,7 +178,7 @@
             "default_category_uuid": "78ae8f05-f92e-43b2-a886-406eaea1b8e0"
         },
         "results": {
-            "favorite_color": {
+            "Favorite Color": {
                 "name": "Favorite Color",
                 "value": "YES",
                 "category": "Yes",
@@ -267,7 +267,7 @@
             "default_category_uuid": "78ae8f05-f92e-43b2-a886-406eaea1b8e0"
         },
         "results": {
-            "is_member": {
+            "Is Member": {
                 "name": "Is Member",
                 "value": "[]",
                 "category": "Other",
@@ -356,7 +356,7 @@
             "default_category_uuid": "78ae8f05-f92e-43b2-a886-406eaea1b8e0"
         },
         "results": {
-            "in_group": {
+            "In Group": {
                 "name": "In Group",
                 "value": "[]",
                 "category": "Other",
@@ -464,7 +464,7 @@
             "default_category_uuid": "78ae8f05-f92e-43b2-a886-406eaea1b8e0"
         },
         "results": {
-            "favorite_color": {
+            "Favorite Color": {
                 "name": "Favorite Color",
                 "value": "YES",
                 "category": "Yes",

--- a/flows/runs/run_test.go
+++ b/flows/runs/run_test.go
@@ -296,9 +296,8 @@ func TestSaveResult(t *testing.T) {
 	assert.Nil(t, prev)
 	assert.True(t, changed)
 
-	// name is snaked
-	assert.Equal(t, "red", run.Results().Get("response_1").Value)
-	assert.Equal(t, "Red", run.Results().Get("response_1").Category)
+	assert.Equal(t, "red", run.Results().Get("Response 1").Value)
+	assert.Equal(t, "Red", run.Results().Get("Response 1").Category)
 	assert.Equal(t, time.Date(2020, 4, 20, 12, 39, 30, 123456789, time.UTC), run.ModifiedOn())
 
 	prev, changed = run.SaveResult(flows.NewResult("Response 1", "blue", "Blue", "Azul", "6d35528e-cae3-4e30-b842-8fe6ed7d5c02", "I like blue", nil, dates.Now()))
@@ -308,8 +307,8 @@ func TestSaveResult(t *testing.T) {
 	assert.True(t, changed)
 
 	// result is overwritten
-	assert.Equal(t, "blue", run.Results().Get("response_1").Value)
-	assert.Equal(t, "Blue", run.Results().Get("response_1").Category)
+	assert.Equal(t, "blue", run.Results().Get("Response 1").Value)
+	assert.Equal(t, "Blue", run.Results().Get("Response 1").Category)
 	assert.Equal(t, time.Date(2020, 4, 20, 12, 39, 30, 123456789, time.UTC), run.ModifiedOn())
 
 	// try saving new result with same value and category again
@@ -322,7 +321,7 @@ func TestSaveResult(t *testing.T) {
 	assert.NotNil(t, prev)
 	assert.True(t, changed)
 
-	assert.Equal(t, strings.Repeat("創", 640), run.Results().Get("response_1").Value)
+	assert.Equal(t, strings.Repeat("創", 640), run.Results().Get("Response 1").Value)
 }
 
 func TestTranslation(t *testing.T) {

--- a/test/testdata/runner/airtime.test_successful_transfer.json
+++ b/test/testdata/runner/airtime.test_successful_transfer.json
@@ -279,7 +279,7 @@
                             }
                         ],
                         "results": {
-                            "transfer": {
+                            "Transfer": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:10.123456789Z",
                                 "name": "Transfer",

--- a/test/testdata/runner/all_actions.test.json
+++ b/test/testdata/runner/all_actions.test.json
@@ -910,7 +910,7 @@
                             }
                         ],
                         "results": {
-                            "gender": {
+                            "Gender": {
                                 "category": "Male",
                                 "created_on": "2018-07-06T12:30:39.123456789Z",
                                 "name": "Gender",

--- a/test/testdata/runner/brochure.test.json
+++ b/test/testdata/runner/brochure.test.json
@@ -397,7 +397,7 @@
                             }
                         ],
                         "results": {
-                            "name": {
+                            "Name": {
                                 "category": "Not Empty",
                                 "created_on": "2018-07-06T12:30:12.123456789Z",
                                 "input": "Ryan Lewis",

--- a/test/testdata/runner/date_parse.test.json
+++ b/test/testdata/runner/date_parse.test.json
@@ -367,7 +367,7 @@
                             }
                         ],
                         "results": {
-                            "birth_date": {
+                            "Birth Date": {
                                 "category": "Valid",
                                 "created_on": "2018-07-06T12:30:11.123456789Z",
                                 "input": "I was born on 1977.06.23 at 3:34 pm",

--- a/test/testdata/runner/default_result.test.json
+++ b/test/testdata/runner/default_result.test.json
@@ -373,7 +373,7 @@
                             }
                         ],
                         "results": {
-                            "contact_name": {
+                            "Contact Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:12.123456789Z",
                                 "input": "Ryan Lewis",

--- a/test/testdata/runner/enter_flow_loop.test.json
+++ b/test/testdata/runner/enter_flow_loop.test.json
@@ -367,7 +367,7 @@
                             }
                         ],
                         "results": {
-                            "command": {
+                            "Command": {
                                 "category": "Name",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "name",
@@ -744,7 +744,7 @@
                             }
                         ],
                         "results": {
-                            "command": {
+                            "Command": {
                                 "category": "Name",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "name",
@@ -896,7 +896,7 @@
                             }
                         ],
                         "results": {
-                            "command": {
+                            "Command": {
                                 "category": "Name",
                                 "created_on": "2018-07-06T12:30:49.123456789Z",
                                 "input": "name",
@@ -1187,7 +1187,7 @@
                             }
                         ],
                         "results": {
-                            "command": {
+                            "Command": {
                                 "category": "Name",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "name",
@@ -1339,7 +1339,7 @@
                             }
                         ],
                         "results": {
-                            "command": {
+                            "Command": {
                                 "category": "Name",
                                 "created_on": "2018-07-06T12:30:49.123456789Z",
                                 "input": "name",
@@ -1469,7 +1469,7 @@
                             }
                         ],
                         "results": {
-                            "command": {
+                            "Command": {
                                 "category": "Exit",
                                 "created_on": "2018-07-06T12:31:27.123456789Z",
                                 "input": "exit",

--- a/test/testdata/runner/expirations.test_input_for_all.json
+++ b/test/testdata/runner/expirations.test_input_for_all.json
@@ -497,7 +497,7 @@
                             }
                         ],
                         "results": {
-                            "first_name": {
+                            "First Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:21.123456789Z",
                                 "input": "Dwayne",
@@ -804,7 +804,7 @@
                             }
                         ],
                         "results": {
-                            "middle_name": {
+                            "Middle Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:41.123456789Z",
                                 "input": "Douglas",
@@ -878,7 +878,7 @@
                             }
                         ],
                         "results": {
-                            "first_name": {
+                            "First Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:21.123456789Z",
                                 "input": "Dwayne",
@@ -1078,7 +1078,7 @@
                             }
                         ],
                         "results": {
-                            "last_name": {
+                            "Last Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:31:01.123456789Z",
                                 "input": "Johnson",
@@ -1175,7 +1175,7 @@
                             }
                         ],
                         "results": {
-                            "middle_name": {
+                            "Middle Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:41.123456789Z",
                                 "input": "Douglas",
@@ -1249,7 +1249,7 @@
                             }
                         ],
                         "results": {
-                            "first_name": {
+                            "First Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:21.123456789Z",
                                 "input": "Dwayne",

--- a/test/testdata/runner/extra.test.json
+++ b/test/testdata/runner/extra.test.json
@@ -293,7 +293,7 @@
                             }
                         ],
                         "results": {
-                            "name_check": {
+                            "Name Check": {
                                 "category": "Valid",
                                 "created_on": "2018-07-06T12:30:08.123456789Z",
                                 "extra": {
@@ -631,14 +631,14 @@
                             }
                         ],
                         "results": {
-                            "continue": {
+                            "Continue": {
                                 "created_on": "2018-07-06T12:30:36.123456789Z",
                                 "input": "Ryan Lewis",
                                 "name": "Continue",
                                 "node_uuid": "11a772f3-3ca2-4429-8b33-20fdcfc2b69e",
                                 "value": "Ryan Lewis"
                             },
-                            "name_check": {
+                            "Name Check": {
                                 "category": "Valid",
                                 "created_on": "2018-07-06T12:30:08.123456789Z",
                                 "extra": {

--- a/test/testdata/runner/initial_wait.test.json
+++ b/test/testdata/runner/initial_wait.test.json
@@ -144,7 +144,7 @@
                             }
                         ],
                         "results": {
-                            "command": {
+                            "Command": {
                                 "category": "Ping",
                                 "created_on": "2018-07-06T12:30:04.123456789Z",
                                 "input": "PING",

--- a/test/testdata/runner/ivr_dial.busy.json
+++ b/test/testdata/runner/ivr_dial.busy.json
@@ -235,7 +235,7 @@
                             }
                         ],
                         "results": {
-                            "redirect": {
+                            "Redirect": {
                                 "category": "Busy",
                                 "created_on": "2018-07-06T12:30:09.123456789Z",
                                 "input": "busy",

--- a/test/testdata/runner/ivr_dial.invalid_phone.json
+++ b/test/testdata/runner/ivr_dial.invalid_phone.json
@@ -87,7 +87,7 @@
                             }
                         ],
                         "results": {
-                            "redirect": {
+                            "Redirect": {
                                 "category": "Failed",
                                 "created_on": "2018-07-06T12:30:04.123456789Z",
                                 "name": "Redirect",

--- a/test/testdata/runner/legacy_favorites.test.json
+++ b/test/testdata/runner/legacy_favorites.test.json
@@ -332,7 +332,7 @@
                             }
                         ],
                         "results": {
-                            "color": {
+                            "Color": {
                                 "category": "Blue",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "I like blue!",
@@ -601,7 +601,7 @@
                             }
                         ],
                         "results": {
-                            "beer": {
+                            "Beer": {
                                 "category": "Pilsner",
                                 "created_on": "2018-07-06T12:30:30.123456789Z",
                                 "input": "Pilsner",
@@ -609,7 +609,7 @@
                                 "node_uuid": "deabc51b-a4af-4a7e-bb89-2a634bbc862d",
                                 "value": "Pilsner"
                             },
-                            "color": {
+                            "Color": {
                                 "category": "Blue",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "I like blue!",

--- a/test/testdata/runner/legacy_registration.test.json
+++ b/test/testdata/runner/legacy_registration.test.json
@@ -342,7 +342,7 @@
                             }
                         ],
                         "results": {
-                            "name": {
+                            "Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "Bobby",
@@ -633,7 +633,7 @@
                             }
                         ],
                         "results": {
-                            "age": {
+                            "Age": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:32.123456789Z",
                                 "input": "123",
@@ -641,7 +641,7 @@
                                 "node_uuid": "7963b7ee-137a-4d70-92ee-f57da97cc607",
                                 "value": "123"
                             },
-                            "name": {
+                            "Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "Bobby",
@@ -1034,7 +1034,7 @@
                             }
                         ],
                         "results": {
-                            "age": {
+                            "Age": {
                                 "category": "10 - 100",
                                 "created_on": "2018-07-06T12:30:49.123456789Z",
                                 "input": "18",
@@ -1042,7 +1042,7 @@
                                 "node_uuid": "7963b7ee-137a-4d70-92ee-f57da97cc607",
                                 "value": "18"
                             },
-                            "name": {
+                            "Name": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "Bobby",
@@ -1050,7 +1050,7 @@
                                 "node_uuid": "797e66c1-99bf-4d65-8944-812e723be5f1",
                                 "value": "Bobby"
                             },
-                            "response_3": {
+                            "Response 3": {
                                 "category": "Youth",
                                 "created_on": "2018-07-06T12:30:59.123456789Z",
                                 "input": "18",

--- a/test/testdata/runner/legacy_subflow.test.json
+++ b/test/testdata/runner/legacy_subflow.test.json
@@ -330,7 +330,7 @@
                             }
                         ],
                         "results": {
-                            "number": {
+                            "Number": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "xx",
@@ -562,7 +562,7 @@
                             }
                         ],
                         "results": {
-                            "number": {
+                            "Number": {
                                 "category": "Numeric",
                                 "created_on": "2018-07-06T12:30:30.123456789Z",
                                 "input": "13",

--- a/test/testdata/runner/legacy_timeout.test.json
+++ b/test/testdata/runner/legacy_timeout.test.json
@@ -296,7 +296,7 @@
                             }
                         ],
                         "results": {
-                            "older": {
+                            "Older": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:19.123456789Z",
                                 "input": "30",
@@ -304,7 +304,7 @@
                                 "node_uuid": "cfb8674d-1a45-4271-8deb-40b2f6994949",
                                 "value": "30"
                             },
-                            "take_part": {
+                            "Take Part": {
                                 "category": "No Response",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "name": "Take Part",

--- a/test/testdata/runner/legacy_webhook.test.json
+++ b/test/testdata/runner/legacy_webhook.test.json
@@ -158,7 +158,7 @@
                             }
                         ],
                         "results": {
-                            "webhook_result": {
+                            "Webhook Result": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:06.123456789Z",
                                 "extra": {

--- a/test/testdata/runner/nlu_booking.flight.json
+++ b/test/testdata/runner/nlu_booking.flight.json
@@ -438,7 +438,26 @@
                             }
                         ],
                         "results": {
-                            "_intent_classification": {
+                            "Intent": {
+                                "category": "Book Flight",
+                                "created_on": "2018-07-06T12:30:24.123456789Z",
+                                "extra": {
+                                    "location": "Quito"
+                                },
+                                "input": "book_flight",
+                                "name": "Intent",
+                                "node_uuid": "145eb3d3-b841-4e66-abac-297ae525c7ad",
+                                "value": "book_flight"
+                            },
+                            "Response 1": {
+                                "category": "All Responses",
+                                "created_on": "2018-07-06T12:30:12.123456789Z",
+                                "input": "I'd like to book a flight to Quito",
+                                "name": "Response 1",
+                                "node_uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82",
+                                "value": "I'd like to book a flight to Quito"
+                            },
+                            "_Intent Classification": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:20.123456789Z",
                                 "extra": {
@@ -465,25 +484,6 @@
                                 "name": "_Intent Classification",
                                 "node_uuid": "145eb3d3-b841-4e66-abac-297ae525c7ad",
                                 "value": "book_flight"
-                            },
-                            "intent": {
-                                "category": "Book Flight",
-                                "created_on": "2018-07-06T12:30:24.123456789Z",
-                                "extra": {
-                                    "location": "Quito"
-                                },
-                                "input": "book_flight",
-                                "name": "Intent",
-                                "node_uuid": "145eb3d3-b841-4e66-abac-297ae525c7ad",
-                                "value": "book_flight"
-                            },
-                            "response_1": {
-                                "category": "All Responses",
-                                "created_on": "2018-07-06T12:30:12.123456789Z",
-                                "input": "I'd like to book a flight to Quito",
-                                "name": "Response 1",
-                                "node_uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82",
-                                "value": "I'd like to book a flight to Quito"
                             }
                         },
                         "status": "completed",

--- a/test/testdata/runner/number_quiz.exceed_limit.json
+++ b/test/testdata/runner/number_quiz.exceed_limit.json
@@ -364,7 +364,7 @@
                             }
                         ],
                         "results": {
-                            "result_1": {
+                            "Result 1": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "3",
@@ -693,7 +693,7 @@
                             }
                         ],
                         "results": {
-                            "result_1": {
+                            "Result 1": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:32.123456789Z",
                                 "input": "5",
@@ -1059,7 +1059,7 @@
                             }
                         ],
                         "results": {
-                            "result_1": {
+                            "Result 1": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:51.123456789Z",
                                 "input": "22",

--- a/test/testdata/runner/phone_number.test.json
+++ b/test/testdata/runner/phone_number.test.json
@@ -350,7 +350,7 @@
                             }
                         ],
                         "results": {
-                            "backup_phone": {
+                            "Backup Phone": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:13.123456789Z",
                                 "input": "135532",
@@ -686,7 +686,7 @@
                             }
                         ],
                         "results": {
-                            "backup_phone": {
+                            "Backup Phone": {
                                 "category": "Has Phone",
                                 "created_on": "2018-07-06T12:30:30.123456789Z",
                                 "input": "718-456-7890",

--- a/test/testdata/runner/resthook.test.json
+++ b/test/testdata/runner/resthook.test.json
@@ -257,7 +257,7 @@
                             }
                         ],
                         "results": {
-                            "response_1": {
+                            "Response 1": {
                                 "category": "Failure",
                                 "created_on": "2018-07-06T12:30:12.123456789Z",
                                 "extra": {

--- a/test/testdata/runner/router_tests.test.json
+++ b/test/testdata/runner/router_tests.test.json
@@ -218,7 +218,7 @@
                             }
                         ],
                         "results": {
-                            "district_check": {
+                            "District Check": {
                                 "category": "Valid",
                                 "created_on": "2018-07-06T12:30:14.123456789Z",
                                 "input": "I live in gasabo",
@@ -226,7 +226,7 @@
                                 "node_uuid": "8476e6fe-1c22-436c-be2c-c27afdc940f3",
                                 "value": "Rwanda > Kigali City > Gasabo"
                             },
-                            "group_check": {
+                            "Group Check": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:08.123456789Z",
                                 "input": "[]",
@@ -234,7 +234,7 @@
                                 "node_uuid": "08d71f03-dc18-450a-a82b-496f64862a56",
                                 "value": "[]"
                             },
-                            "urn_check": {
+                            "URN Check": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:02.123456789Z",
                                 "name": "URN Check",

--- a/test/testdata/runner/subflow.test.json
+++ b/test/testdata/runner/subflow.test.json
@@ -502,7 +502,7 @@
                             }
                         ],
                         "results": {
-                            "name": {
+                            "Name": {
                                 "category": "Name",
                                 "created_on": "2018-07-06T12:30:16.123456789Z",
                                 "input": "Ryan Lewis",

--- a/test/testdata/runner/subflow_other.test.json
+++ b/test/testdata/runner/subflow_other.test.json
@@ -518,7 +518,7 @@
                             }
                         ],
                         "results": {
-                            "answer": {
+                            "Answer": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:20.123456789Z",
                                 "input": "neither",
@@ -952,7 +952,7 @@
                             }
                         ],
                         "results": {
-                            "answer": {
+                            "Answer": {
                                 "category": "Yes",
                                 "created_on": "2018-07-06T12:30:36.123456789Z",
                                 "input": "yes",
@@ -1264,7 +1264,7 @@
                             }
                         ],
                         "results": {
-                            "answer": {
+                            "Answer": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:57.123456789Z",
                                 "input": "never",
@@ -1423,7 +1423,7 @@
                             }
                         ],
                         "results": {
-                            "answer": {
+                            "Answer": {
                                 "category": "Yes",
                                 "created_on": "2018-07-06T12:30:36.123456789Z",
                                 "input": "yes",
@@ -1775,7 +1775,7 @@
                             }
                         ],
                         "results": {
-                            "answer": {
+                            "Answer": {
                                 "category": "No",
                                 "created_on": "2018-07-06T12:31:13.123456789Z",
                                 "input": "no",
@@ -1934,7 +1934,7 @@
                             }
                         ],
                         "results": {
-                            "answer": {
+                            "Answer": {
                                 "category": "Yes",
                                 "created_on": "2018-07-06T12:30:36.123456789Z",
                                 "input": "yes",

--- a/test/testdata/runner/ticketing.test.json
+++ b/test/testdata/runner/ticketing.test.json
@@ -353,7 +353,7 @@
                             }
                         ],
                         "results": {
-                            "response_1": {
+                            "Response 1": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:12.123456789Z",
                                 "input": "Rats",
@@ -361,7 +361,7 @@
                                 "node_uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82",
                                 "value": "Rats"
                             },
-                            "ticket": {
+                            "Ticket": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:20.123456789Z",
                                 "name": "Ticket",

--- a/test/testdata/runner/two_questions.test.json
+++ b/test/testdata/runner/two_questions.test.json
@@ -472,7 +472,7 @@
                             }
                         ],
                         "results": {
-                            "favorite_color": {
+                            "Favorite Color": {
                                 "category": "Blue",
                                 "created_on": "2018-07-06T12:30:14.123456789Z",
                                 "input": "I like blue!",
@@ -849,7 +849,7 @@
                             }
                         ],
                         "results": {
-                            "favorite_color": {
+                            "Favorite Color": {
                                 "category": "Blue",
                                 "created_on": "2018-07-06T12:30:14.123456789Z",
                                 "input": "I like blue!",
@@ -857,7 +857,7 @@
                                 "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
                                 "value": "blue"
                             },
-                            "soda": {
+                            "Soda": {
                                 "category": "Coke",
                                 "category_localized": "Coke",
                                 "created_on": "2018-07-06T12:30:30.123456789Z",

--- a/test/testdata/runner/two_questions_offline.test.json
+++ b/test/testdata/runner/two_questions_offline.test.json
@@ -305,7 +305,7 @@
                             }
                         ],
                         "results": {
-                            "favorite_color": {
+                            "Favorite Color": {
                                 "category": "Red",
                                 "created_on": "2018-07-06T12:30:10.123456789Z",
                                 "input": "red",
@@ -576,7 +576,7 @@
                             }
                         ],
                         "results": {
-                            "favorite_color": {
+                            "Favorite Color": {
                                 "category": "Red",
                                 "created_on": "2018-07-06T12:30:10.123456789Z",
                                 "input": "red",
@@ -584,7 +584,7 @@
                                 "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
                                 "value": "red"
                             },
-                            "soda": {
+                            "Soda": {
                                 "category": "Pepsi",
                                 "created_on": "2018-07-06T12:30:24.123456789Z",
                                 "input": "pepsi",
@@ -839,7 +839,7 @@
                             }
                         ],
                         "results": {
-                            "favorite_color": {
+                            "Favorite Color": {
                                 "category": "Red",
                                 "created_on": "2018-07-06T12:30:10.123456789Z",
                                 "input": "red",
@@ -847,7 +847,7 @@
                                 "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
                                 "value": "red"
                             },
-                            "soda": {
+                            "Soda": {
                                 "category": "Pepsi",
                                 "created_on": "2018-07-06T12:30:24.123456789Z",
                                 "input": "pepsi",

--- a/test/testdata/runner/webhook_migrated.test.json
+++ b/test/testdata/runner/webhook_migrated.test.json
@@ -295,7 +295,7 @@
                             }
                         ],
                         "results": {
-                            "country": {
+                            "Country": {
                                 "category": "Valid",
                                 "created_on": "2018-07-06T12:30:26.123456789Z",
                                 "input": "valid",
@@ -303,7 +303,7 @@
                                 "node_uuid": "e5d0c54c-7702-4e6b-9080-3de1a120a647",
                                 "value": "valid"
                             },
-                            "country_response": {
+                            "Country Response": {
                                 "category": "Other",
                                 "created_on": "2018-07-06T12:30:08.123456789Z",
                                 "input": "Ryan Lewis",
@@ -311,7 +311,7 @@
                                 "node_uuid": "5b5abbf2-5f12-4f83-a804-90695e6c4302",
                                 "value": "Ryan Lewis"
                             },
-                            "country_webhook": {
+                            "Country Webhook": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:18.123456789Z",
                                 "extra": {

--- a/test/testdata/runner/webhook_results.test.json
+++ b/test/testdata/runner/webhook_results.test.json
@@ -166,7 +166,7 @@
                             }
                         ],
                         "results": {
-                            "call_1": {
+                            "Call 1": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:06.123456789Z",
                                 "input": "GET http://temba.io/1",
@@ -517,7 +517,7 @@
                             }
                         ],
                         "results": {
-                            "call_1": {
+                            "Call 1": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:06.123456789Z",
                                 "input": "GET http://temba.io/1",
@@ -525,7 +525,7 @@
                                 "node_uuid": "03eec86c-190c-48a2-bdaa-bbe07b36bd2f",
                                 "value": "200"
                             },
-                            "call_2": {
+                            "Call 2": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:39.123456789Z",
                                 "extra": {
@@ -536,7 +536,7 @@
                                 "node_uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
                                 "value": "200"
                             },
-                            "response": {
+                            "Response": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:23.123456789Z",
                                 "input": "Ok",
@@ -866,7 +866,7 @@
                             }
                         ],
                         "results": {
-                            "call_1": {
+                            "Call 1": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:06.123456789Z",
                                 "input": "GET http://temba.io/1",
@@ -874,7 +874,7 @@
                                 "node_uuid": "03eec86c-190c-48a2-bdaa-bbe07b36bd2f",
                                 "value": "200"
                             },
-                            "call_2": {
+                            "Call 2": {
                                 "category": "Success",
                                 "created_on": "2018-07-06T12:30:39.123456789Z",
                                 "extra": {
@@ -885,7 +885,7 @@
                                 "node_uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
                                 "value": "200"
                             },
-                            "response": {
+                            "Response": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:23.123456789Z",
                                 "input": "Ok",
@@ -893,7 +893,7 @@
                                 "node_uuid": "763f3570-bc76-4e6e-85fb-da62cc112cd4",
                                 "value": "Ok"
                             },
-                            "response_2": {
+                            "Response 2": {
                                 "category": "All Responses",
                                 "created_on": "2018-07-06T12:30:56.123456789Z",
                                 "input": "Sure",


### PR DESCRIPTION
Snakified name is really just for expressions. To maintain the existing storage format on runs, mailroom can snakify the names.