### PR TITLE
Convert quick replies into structs

### DIFF
--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -99,14 +99,14 @@ func (a *baseAction) evaluateMessage(run flows.Run, languages []i18n.Language, a
 
 	// localize and evaluate the quick replies
 	translatedQuickReplies, qrsLang := run.GetTextArray(uuids.UUID(a.UUID()), "quick_replies", actionQuickReplies, languages)
-	evaluatedQuickReplies := make([]string, 0, len(translatedQuickReplies))
+	evaluatedQuickReplies := make([]flows.QuickReply, 0, len(translatedQuickReplies))
 	for _, qr := range translatedQuickReplies {
 		evaluatedQuickReply, _ := run.EvaluateTemplate(qr, logEvent)
 		if evaluatedQuickReply == "" {
 			logEvent(events.NewErrorf("quick reply evaluated to empty string, skipping"))
 			continue
 		}
-		evaluatedQuickReplies = append(evaluatedQuickReplies, stringsx.TruncateEllipsis(evaluatedQuickReply, flows.MaxQuickReplyLength))
+		evaluatedQuickReplies = append(evaluatedQuickReplies, flows.QuickReply{Text: stringsx.TruncateEllipsis(evaluatedQuickReply, flows.MaxQuickReplyLength)})
 	}
 
 	// although it's possible for the different parts of the message to have different languages, we want to resolve

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -475,7 +475,7 @@ func TestEventMarshaling(t *testing.T) {
 					&flows.MsgContent{
 						Text:         "Hi there",
 						Attachments:  []utils.Attachment{"image/jpeg:http://s3.amazon.com/bucket/test.jpg"},
-						QuickReplies: []string{"yes", "no"},
+						QuickReplies: []flows.QuickReply{{Text: "yes"}, {Text: "no"}},
 					},
 					nil,
 					flows.MsgTopicAgent,

--- a/flows/runs/run_test.go
+++ b/flows/runs/run_test.go
@@ -352,7 +352,7 @@ func TestTranslation(t *testing.T) {
 		msgAction            []byte
 		expectedText         string
 		expectedAttachments  []utils.Attachment
-		expectedQuickReplies []string
+		expectedQuickReplies []flows.QuickReply
 	}{
 		{
 			description:  "contact language is valid and is flow base language, msg action has all fields",
@@ -364,7 +364,7 @@ func TestTranslation(t *testing.T) {
 				"image/jpeg:http://media.com/hello.jpg",
 				"audio/mp4:http://media.com/hello.m4a",
 			},
-			expectedQuickReplies: []string{"yes", "no"},
+			expectedQuickReplies: []flows.QuickReply{{Text: "yes"}, {Text: "no"}},
 		},
 		{
 			description:  "contact language is valid and translations exist, msg action has all fields",
@@ -375,7 +375,7 @@ func TestTranslation(t *testing.T) {
 			expectedAttachments: []utils.Attachment{
 				"audio/mp4:http://media.com/hola.m4a",
 			},
-			expectedQuickReplies: []string{"si"},
+			expectedQuickReplies: []flows.QuickReply{{Text: "si"}},
 		},
 		{
 			description:  "contact language is allowed but no translations exist, msg action has all fields",
@@ -387,7 +387,7 @@ func TestTranslation(t *testing.T) {
 				"image/jpeg:http://media.com/hello.jpg",
 				"audio/mp4:http://media.com/hello.m4a",
 			},
-			expectedQuickReplies: []string{"yes", "no"},
+			expectedQuickReplies: []flows.QuickReply{{Text: "yes"}, {Text: "no"}},
 		},
 		{
 			description:  "contact language is not allowed and translations exist, msg action has all fields",
@@ -399,7 +399,7 @@ func TestTranslation(t *testing.T) {
 				"image/jpeg:http://media.com/hello.jpg",
 				"audio/mp4:http://media.com/hello.m4a",
 			},
-			expectedQuickReplies: []string{"yes", "no"},
+			expectedQuickReplies: []flows.QuickReply{{Text: "yes"}, {Text: "no"}},
 		},
 		{
 			description:          "contact language is valid and is flow base language, msg action only has text",
@@ -408,7 +408,7 @@ func TestTranslation(t *testing.T) {
 			msgAction:            msgAction2,
 			expectedText:         "Hello",
 			expectedAttachments:  []utils.Attachment{},
-			expectedQuickReplies: []string{},
+			expectedQuickReplies: []flows.QuickReply{},
 		},
 		{
 			description:  "contact language is valid and translations exist, msg action only has text",
@@ -419,7 +419,7 @@ func TestTranslation(t *testing.T) {
 			expectedAttachments: []utils.Attachment{
 				"audio/mp4:http://media.com/hola.m4a",
 			},
-			expectedQuickReplies: []string{"si"},
+			expectedQuickReplies: []flows.QuickReply{{Text: "si"}},
 		},
 		{
 			description:  "attachments and quick replies translations are single empty strings and should be ignored",
@@ -431,7 +431,7 @@ func TestTranslation(t *testing.T) {
 				"image/jpeg:http://media.com/hello.jpg",
 				"audio/mp4:http://media.com/hello.m4a",
 			},
-			expectedQuickReplies: []string{"yes", "no"},
+			expectedQuickReplies: []flows.QuickReply{{Text: "yes"}, {Text: "no"}},
 		},
 	}
 

--- a/flows/template.go
+++ b/flows/template.go
@@ -94,7 +94,7 @@ func (t *TemplateTranslation) Asset() assets.TemplateTranslation { return t.Temp
 func (t *TemplateTranslation) Preview(vars []*TemplatingVariable) *MsgContent {
 	var text []string
 	var attachments []utils.Attachment
-	var quickReplies []string
+	var quickReplies []QuickReply
 
 	for _, comp := range t.Components() {
 		content := comp.Content()
@@ -112,7 +112,7 @@ func (t *TemplateTranslation) Preview(vars []*TemplatingVariable) *MsgContent {
 			if comp.Type() == "header/text" || comp.Type() == "body/text" || comp.Type() == "footer/text" {
 				text = append(text, content)
 			} else if strings.HasPrefix(comp.Type(), "button/") {
-				quickReplies = append(quickReplies, stringsx.TruncateEllipsis(content, MaxQuickReplyLength))
+				quickReplies = append(quickReplies, QuickReply{Text: stringsx.TruncateEllipsis(content, MaxQuickReplyLength)})
 			}
 		}
 	}

--- a/flows/template_test.go
+++ b/flows/template_test.go
@@ -242,7 +242,7 @@ func TestTemplating(t *testing.T) {
 					{Type: "text", Value: "No"},
 				},
 			},
-			expectedPreview: &flows.MsgContent{QuickReplies: []string{"Yes", "No"}},
+			expectedPreview: &flows.MsgContent{QuickReplies: []flows.QuickReply{{Text: "Yes"}, {Text: "No"}}},
 		},
 		{ // 4: header image becomes an attachment
 			template: []byte(`{


### PR DESCRIPTION
Because these are in events.. need to temporarily support loading from single string or struct, but always marshaling to string. Then can switch to always marshaling as struct.

Still need to reduce to actual strings to store in `Msg.quick_replies`...