### PR TITLE
Udpate to go 1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "GoFlow",
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.24-bullseye",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/pandoc:1": {
 			"version": "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 env:
-  go-version: "1.23.x"
+  go-version: "1.24.x"
 jobs:
   test:
     name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nyaruka/goflow
 
-go 1.23
+go 1.24
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Requires https://github.com/devcontainers/images/pull/1304 before devcontainer will install