### PR TITLE
Tweak `llm_prompt` so onus is on the caller to format args

### DIFF
--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -2073,7 +2073,7 @@ func FormatURN(env envs.Environment, arg *types.XText) types.XValue {
 //
 // Note that the actual prompt text may differ from the examples below.
 //
-//	@(llm_prompt("categorize", array("Positive", "Negative"))) -> Categorize the following text into one of the following: Positive, Negative
+//	@(llm_prompt("categorize", array("Positive", "Negative"))) -> Categorize the following text into one of the following: [Positive, Negative]
 //	@(llm_prompt("xx")) -> ERROR
 //
 // @function llm_prompt(name, args...)
@@ -2085,7 +2085,7 @@ func LLMPrompt(env envs.Environment, name *types.XText, args ...types.XValue) ty
 
 	tplArgs := make(map[string]string, len(args))
 	for i, arg := range args {
-		tplArgs[fmt.Sprintf("arg%d", i)] = arg.Format(env)
+		tplArgs[fmt.Sprintf("arg%d", i+1)] = arg.Render()
 	}
 
 	var buf strings.Builder

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -20,7 +20,7 @@ import (
 var errorArg = types.NewXErrorf("I am error")
 var la, _ = time.LoadLocation("America/Los_Angeles")
 var prompts = map[string]*template.Template{
-	"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following: {{ .arg0 }}")),
+	"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following: {{ .arg1 }}")),
 }
 
 var xs = types.NewXText
@@ -419,7 +419,7 @@ func TestFunctions(t *testing.T) {
 		{"legacy_add", mdy, []types.XValue{xs("03-10-2019 1:00am"), xn("1")}, xdt(time.Date(2019, 3, 11, 1, 0, 0, 0, la))},
 		{"legacy_add", mdy, []types.XValue{xs("11-03-2019 1:00am"), xn("1")}, xdt(time.Date(2019, 11, 4, 1, 0, 0, 0, la))},
 
-		{"llm_prompt", dmy, []types.XValue{xs("categorize"), xa(xs("Positive"), xs("Negative"))}, xs("Categorize the following text into one of the following: Positive, Negative")},
+		{"llm_prompt", dmy, []types.XValue{xs("categorize"), xa(xs("Positive"), xs("Negative"))}, xs("Categorize the following text into one of the following: [Positive, Negative]")},
 		{"llm_prompt", dmy, []types.XValue{xs("categorize")}, xs("Categorize the following text into one of the following: <no value>")},
 		{"llm_prompt", dmy, []types.XValue{xs("xxx")}, ERROR},
 		{"llm_prompt", dmy, []types.XValue{}, ERROR},

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -223,7 +223,7 @@ func testActionType(t *testing.T, assetsJSON json.RawMessage, typeName string) {
 		// create an engine instance
 		eng := engine.NewBuilder().
 			WithLLMPrompts(map[string]*template.Template{
-				"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: {{ .arg0 }}")),
+				"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: {{ .arg1 }}")),
 			}).
 			WithEmailServiceFactory(func(flows.SessionAssets) (flows.EmailService, error) {
 				return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io", nil)

--- a/test/engine.go
+++ b/test/engine.go
@@ -19,7 +19,7 @@ func NewEngine() flows.Engine {
 	return engine.NewBuilder().
 		WithMaxFieldChars(256).
 		WithLLMPrompts(map[string]*template.Template{
-			"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following: {{ .arg0 }}")),
+			"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following: {{ .arg1 }}")),
 		}).
 		WithWebhookServiceFactory(webhooks.NewServiceFactory(http.DefaultClient, retries, nil, map[string]string{"User-Agent": "goflow-testing"}, 10000)).
 		WithEmailServiceFactory(func(s flows.SessionAssets) (flows.EmailService, error) {

--- a/test/runner_test.go
+++ b/test/runner_test.go
@@ -119,7 +119,7 @@ func runFlow(assetsPath string, rawTrigger json.RawMessage, rawResumes []json.Ra
 
 	eng := engine.NewBuilder().
 		WithLLMPrompts(map[string]*template.Template{
-			"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: {{ .arg0 }}")),
+			"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: {{ .arg1 }}")),
 		}).
 		WithEmailServiceFactory(func(flows.SessionAssets) (flows.EmailService, error) {
 			return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io", nil)

--- a/test/services/llm.go
+++ b/test/services/llm.go
@@ -23,7 +23,7 @@ func (s *LLMService) Response(ctx context.Context, instructions, input string, m
 		output = input[8:]
 	} else if strings.HasPrefix(instructions, "Categorize") { // instructions like "Categorize... Category2, Category3" will return "Category3"
 		words := strings.Fields(instructions)
-		output = words[len(words)-1]
+		output = strings.TrimSuffix(words[len(words)-1], "]")
 	} else {
 		output = "You asked:\n\n" + instructions + "\n\n" + input
 	}

--- a/test/testdata/runner/llm_categorize.flight.json
+++ b/test/testdata/runner/llm_categorize.flight.json
@@ -167,7 +167,7 @@
                     "created_on": "2018-07-06T12:30:21.123456789Z",
                     "elapsed_ms": 1000,
                     "input": "I'd like to book a flight to Quito",
-                    "instructions": "Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: Flights, Hotels",
+                    "instructions": "Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: [Flights, Hotels]",
                     "llm": {
                         "name": "Claude",
                         "uuid": "1c06c884-39dd-4ce4-ad9f-9a01cbe6c000"
@@ -294,7 +294,7 @@
                                 "created_on": "2018-07-06T12:30:21.123456789Z",
                                 "elapsed_ms": 1000,
                                 "input": "I'd like to book a flight to Quito",
-                                "instructions": "Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: Flights, Hotels",
+                                "instructions": "Categorize the following text into one of the following categories and only return that category or <CANT> if you can't: [Flights, Hotels]",
                                 "llm": {
                                     "name": "Claude",
                                     "uuid": "1c06c884-39dd-4ce4-ad9f-9a01cbe6c000"


### PR DESCRIPTION
Initially I wanted this as simple as possible so the function itself was doing some formatting.. but moving that to the expression provides more flexibility

```
@(llm_prompt("categorize", array("Positive", "Negative"))) -> "Categorize..: [Positive, Negative]"
@(llm_prompt("categorize", join(array("Positive", "Negative"), ","))) -> "Categorize..: Positive, Negative"
@(llm_prompt("categorize", json(array("Positive", "Negative")))) -> "Categorize..: ["Positive", "Negative"]"
```