### PR TITLE
Enforce recent session state changes, part 1

### DIFF
--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -593,8 +593,8 @@ type sessionEnvelope struct {
 	Type        flows.FlowType      `json:"type"                validate:"required"`
 	CreatedOn   time.Time           `json:"created_on"` // TODO validate:"required"`
 	Trigger     json.RawMessage     `json:"trigger"             validate:"required"`
-	ContactUUID flows.ContactUUID   `json:"contact_uuid"        validate:"omitempty,uuid"` // TODO validate:"required"`
-	CallUUID    flows.CallUUID      `json:"call_uuid,omitempty" validate:"omitempty,uuid"` // TODO validate:"required"`
+	ContactUUID flows.ContactUUID   `json:"contact_uuid"        validate:"required,uuid"`
+	CallUUID    flows.CallUUID      `json:"call_uuid,omitempty" validate:"omitempty,uuid"`
 	Runs        []json.RawMessage   `json:"runs"`
 	Status      flows.SessionStatus `json:"status"              validate:"required"`
 	Wait        json.RawMessage     `json:"wait,omitempty"`
@@ -615,6 +615,7 @@ func readSession(eng flows.Engine, sa flows.SessionAssets, data []byte, env envs
 		assets:     sa,
 		uuid:       e.UUID,
 		type_:      e.Type,
+		createdOn:  e.CreatedOn,
 		status:     e.Status,
 		env:        env,
 		contact:    contact,

--- a/flows/events/base.go
+++ b/flows/events/base.go
@@ -18,9 +18,9 @@ func registerType(name string, initFunc func() flows.Event) {
 
 // BaseEvent is the base of all event types
 type BaseEvent struct {
-	UUID_      flows.EventUUID `json:"uuid" validate:"omitempty,uuid"` // TODO make required
-	Type_      string          `json:"type" validate:"required"`
-	CreatedOn_ time.Time       `json:"created_on"` // TODO re-add validate:"required" when ticket triggers all use real events
+	UUID_      flows.EventUUID `json:"uuid"                validate:"required,uuid"`
+	Type_      string          `json:"type"                validate:"required"`
+	CreatedOn_ time.Time       `json:"created_on"          validate:"required"`
 	StepUUID_  flows.StepUUID  `json:"step_uuid,omitempty" validate:"omitempty,uuid"`
 }
 

--- a/flows/events/campaign_fired.go
+++ b/flows/events/campaign_fired.go
@@ -29,8 +29,8 @@ const TypeCampaignFired string = "campaign_fired"
 type CampaignFired struct {
 	BaseEvent
 
-	Campaign  *assets.CampaignReference `json:"campaign" validate:"required"`
-	PointUUID assets.CampaignPointUUID  `json:"point_uuid"` // TODO make required
+	Campaign  *assets.CampaignReference `json:"campaign"   validate:"required"`
+	PointUUID assets.CampaignPointUUID  `json:"point_uuid" validate:"required"`
 }
 
 // NewCampaignFired returns a new campaign fired event

--- a/flows/events/optin_started.go
+++ b/flows/events/optin_started.go
@@ -32,8 +32,8 @@ const TypeOptInStarted string = "optin_started"
 type OptInStarted struct {
 	BaseEvent
 
-	OptIn   *assets.OptInReference   `json:"optin" validate:"required"`
-	Channel *assets.ChannelReference `json:"channel,omitempty"` // TODO make required
+	OptIn   *assets.OptInReference   `json:"optin"   validate:"required"`
+	Channel *assets.ChannelReference `json:"channel" validate:"required"`
 }
 
 // NewOptInStarted returns a new optin started event

--- a/flows/events/optin_stopped.go
+++ b/flows/events/optin_stopped.go
@@ -32,8 +32,8 @@ const TypeOptInStopped string = "optin_stopped"
 type OptInStopped struct {
 	BaseEvent
 
-	OptIn   *assets.OptInReference   `json:"optin" validate:"required"`
-	Channel *assets.ChannelReference `json:"channel,omitempty"` // TODO make required
+	OptIn   *assets.OptInReference   `json:"optin"   validate:"required"`
+	Channel *assets.ChannelReference `json:"channel" validate:"required"`
 }
 
 // NewOptInStopped returns a new optin stopped event

--- a/flows/triggers/msg.go
+++ b/flows/triggers/msg.go
@@ -28,7 +28,6 @@ const TypeMsg string = "msg"
 //	    "type": "msg_received",
 //	    "created_on": "2006-01-02T15:04:05Z",
 //	    "msg": {
-//	      "uuid": "2d611e17-fb22-457f-b802-b8f7ec5cda5b",
 //	      "channel": {"uuid": "61602f3e-f603-4c70-8a8f-c477505bf4bf", "name": "Twilio"},
 //	      "urn": "tel:+12065551212",
 //	      "text": "hi there",
@@ -128,8 +127,7 @@ func (b *MsgBuilder) Build() *Msg {
 type msgEnvelope struct {
 	baseEnvelope
 
-	Event *events.MsgReceived `json:"event"`         // TODO make required
-	Msg   *flows.MsgIn        `json:"msg,omitempty"` // used by older sessions
+	Event *events.MsgReceived `json:"event"                   validate:"required"`
 	Match *KeywordMatch       `json:"keyword_match,omitempty" validate:"omitempty"`
 }
 
@@ -139,18 +137,7 @@ func readMsg(sa flows.SessionAssets, data []byte, missing assets.MissingCallback
 		return nil, err
 	}
 
-	t := &Msg{
-		event: e.Event,
-		match: e.Match,
-	}
-
-	// older triggers will have msg instead of event so convert that into an event
-	if e.Msg != nil {
-		t.event = &events.MsgReceived{
-			BaseEvent: events.BaseEvent{UUID_: flows.NewEventUUID(), Type_: events.TypeMsgReceived, CreatedOn_: e.baseEnvelope.TriggeredOn},
-			Msg:       e.Msg,
-		}
-	}
+	t := &Msg{event: e.Event, match: e.Match}
 
 	if err := t.unmarshal(sa, &e.baseEnvelope, missing); err != nil {
 		return nil, err

--- a/flows/triggers/optin.go
+++ b/flows/triggers/optin.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/buger/jsonparser"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
@@ -101,19 +100,6 @@ func readOptIn(sa flows.SessionAssets, data []byte, missing assets.MissingCallba
 	e := &optInEnvelope{}
 	if err := utils.UnmarshalAndValidate(data, e); err != nil {
 		return nil, err
-	}
-
-	// TODO remove this once all triggers are using real events
-	evtType, err := jsonparser.GetString(e.Event, "type")
-	if err != nil {
-		return nil, fmt.Errorf("error reading type from optin trigger event: %w", err)
-	}
-	if evtType == "started" {
-		e.Event, _ = jsonparser.Set(e.Event, []byte(`"optin_started"`), "type")
-		e.Event, _ = jsonparser.Set(e.Event, jsonx.MustMarshal(e.TriggeredOn), "created_on")
-	} else if evtType == "stopped" {
-		e.Event, _ = jsonparser.Set(e.Event, []byte(`"optin_stopped"`), "type")
-		e.Event, _ = jsonparser.Set(e.Event, jsonx.MustMarshal(e.TriggeredOn), "created_on")
 	}
 
 	event, err := events.Read(e.Event)

--- a/flows/triggers/optin.go
+++ b/flows/triggers/optin.go
@@ -29,9 +29,14 @@ const TypeOptIn string = "optin"
 //	  "event": {
 //	    "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
 //	    "type": "optin_started",
+//	    "created_on": "2006-01-02T15:04:05Z",
 //	    "optin": {
 //	      "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
 //	      "name": "Joke Of The Day"
+//	    },
+//	    "channel": {
+//	      "uuid": "4bb288a0-7fca-4da1-abe8-59a593aff648",
+//	      "name": "Facebook"
 //	    }
 //	  },
 //	  "triggered_on": "2000-01-01T00:00:00.000000000-00:00"

--- a/flows/triggers/testdata/campaign.json
+++ b/flows/triggers/testdata/campaign.json
@@ -24,7 +24,7 @@
                     "uuid": "58e9b092-fe42-4173-876c-ff45a14a24fe",
                     "name": "Reminders"
                 },
-                "point_uuid": ""
+                "point_uuid": "b045ae01-5041-4787-8f85-e288822ed728"
             }
         },
         "context": {

--- a/flows/triggers/testdata/msg.json
+++ b/flows/triggers/testdata/msg.json
@@ -5,7 +5,7 @@
             "type": "msg",
             "triggered_on": "2000-01-01T00:00:00Z"
         },
-        "read_error": "field 'flow' is required"
+        "read_error": "field 'flow' is required, field 'event' is required"
     },
     {
         "description": "with missing type in keyword match",
@@ -20,7 +20,6 @@
                 "type": "msg_received",
                 "created_on": "2006-01-02T15:04:05Z",
                 "msg": {
-                    "uuid": "2d611e17-fb22-457f-b802-b8f7ec5cda5b",
                     "channel": {
                         "uuid": "61602f3e-f603-4c70-8a8f-c477505bf4bf",
                         "name": "Twilio"

--- a/flows/triggers/testdata/optin.json
+++ b/flows/triggers/testdata/optin.json
@@ -23,6 +23,10 @@
                 "optin": {
                     "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
                     "name": "Joke Of The Day"
+                },
+                "channel": {
+                    "uuid": "4bb288a0-7fca-4da1-abe8-59a593aff648",
+                    "name": "Facebook"
                 }
             }
         },

--- a/test/testdata/runner/all_actions.test.json
+++ b/test/testdata/runner/all_actions.test.json
@@ -38,8 +38,8 @@
         {
             "events": [
                 {
-                    "created_on": "2025-05-04T12:30:53.123456789Z",
-                    "input_uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+                    "created_on": "2025-05-04T12:30:52.123456789Z",
+                    "input_uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
                     "labels": [
                         {
                             "name": "Spam",
@@ -50,12 +50,12 @@
                             "uuid": "b017c07a-d35b-4da4-8917-3bf8bff80168"
                         }
                     ],
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "input_labels_added",
-                    "uuid": "01969b47-20db-76f8-8f41-6b2d9f33d623"
+                    "uuid": "01969b47-1cf3-76f8-8228-9728778b6c98"
                 },
                 {
-                    "created_on": "2025-05-04T12:30:56.123456789Z",
+                    "created_on": "2025-05-04T12:30:55.123456789Z",
                     "groups_added": [
                         {
                             "name": "Survey Audience",
@@ -66,13 +66,13 @@
                             "uuid": "d7ff4872-9238-452f-9d38-2f558fea89e0"
                         }
                     ],
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_groups_changed",
-                    "uuid": "01969b47-2c93-76f8-a17e-f85e49829fb9"
+                    "uuid": "01969b47-28ab-76f8-8f41-6b2d9f33d623"
                 },
                 {
-                    "created_on": "2025-05-04T12:30:59.123456789Z",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "created_on": "2025-05-04T12:30:58.123456789Z",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_urns_changed",
                     "urns": [
                         "tel:+12065551212",
@@ -80,44 +80,44 @@
                         "mailto:ben@macklemore",
                         "twitter:ben_haggerty"
                     ],
-                    "uuid": "01969b47-384b-76f8-ba00-bd7f0d08e671"
+                    "uuid": "01969b47-3463-76f8-a17e-f85e49829fb9"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:03.123456789Z",
+                    "created_on": "2025-05-04T12:31:02.123456789Z",
                     "field": {
                         "key": "activation_token",
                         "name": "Activation Token"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_field_changed",
-                    "uuid": "01969b47-47eb-76f8-b86e-4b881f09a186",
+                    "uuid": "01969b47-4403-76f8-ba00-bd7f0d08e671",
                     "value": {
                         "text": "XXX-YYY-ZZZ"
                     }
                 },
                 {
                     "body": "Hi Ben, Your activation token is XXX-YYY-ZZZ, your coupon is AAA-BBB-CCC",
-                    "created_on": "2025-05-04T12:31:06.123456789Z",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "created_on": "2025-05-04T12:31:05.123456789Z",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "subject": "Here is your activation token",
                     "to": [
                         "ben@macklemore",
                         "test@example.com"
                     ],
                     "type": "email_sent",
-                    "uuid": "01969b47-53a3-76f8-a691-235cbe720980"
+                    "uuid": "01969b47-4fbb-76f8-b86e-4b881f09a186"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:09.123456789Z",
+                    "created_on": "2025-05-04T12:31:08.123456789Z",
                     "flow": {
                         "name": "Registration Flow",
                         "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d"
                     },
-                    "parent_run_uuid": "01969b47-1523-76f8-92a3-d648ab64bccb",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "parent_run_uuid": "01969b47-113b-76f8-9c0b-2014ddc77094",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "terminal": false,
                     "type": "flow_entered",
-                    "uuid": "01969b47-5f5b-76f8-bebe-b4a1f677cf4c"
+                    "uuid": "01969b47-5b73-76f8-a691-235cbe720980"
                 },
                 {
                     "contacts": [
@@ -126,7 +126,7 @@
                             "uuid": "820f5923-3369-41c6-b3cd-af577c0bd4b8"
                         }
                     ],
-                    "created_on": "2025-05-04T12:31:12.123456789Z",
+                    "created_on": "2025-05-04T12:31:11.123456789Z",
                     "exclusions": {},
                     "flow": {
                         "name": "Registration Flow",
@@ -135,7 +135,7 @@
                     "history": {
                         "ancestors": 1,
                         "ancestors_since_input": 0,
-                        "parent_uuid": "01969b47-096b-76f8-bd38-d266ec8d3716"
+                        "parent_uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
                     },
                     "run_summary": {
                         "contact": {
@@ -167,7 +167,7 @@
                             ],
                             "id": 1234567,
                             "language": "eng",
-                            "last_seen_on": "2000-01-01T00:00:00Z",
+                            "last_seen_on": "2006-01-02T15:04:05Z",
                             "name": "Ben Haggerty",
                             "status": "active",
                             "timezone": "America/Guayaquil",
@@ -185,16 +185,16 @@
                         },
                         "results": {},
                         "status": "active",
-                        "uuid": "01969b47-1523-76f8-92a3-d648ab64bccb"
+                        "uuid": "01969b47-113b-76f8-9c0b-2014ddc77094"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "session_triggered",
-                    "uuid": "01969b47-6b13-76f8-8dbf-00ecf5d03034"
+                    "uuid": "01969b47-672b-76f8-bebe-b4a1f677cf4c"
                 },
                 {
                     "base_language": "eng",
-                    "created_on": "2025-05-04T12:31:15.123456789Z",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "created_on": "2025-05-04T12:31:14.123456789Z",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "translations": {
                         "eng": {
                             "text": "Hi Ben Haggerty, are you ready?"
@@ -207,18 +207,18 @@
                     "urns": [
                         "tel:+12065551212"
                     ],
-                    "uuid": "01969b47-76cb-76f8-acca-bbca70987315"
+                    "uuid": "01969b47-72e3-76f8-8dbf-00ecf5d03034"
                 },
                 {
                     "base_language": "eng",
-                    "created_on": "2025-05-04T12:31:18.123456789Z",
+                    "created_on": "2025-05-04T12:31:17.123456789Z",
                     "groups": [
                         {
                             "name": "Survey Audience",
                             "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                         }
                     ],
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "translations": {
                         "eng": {
                             "attachments": [
@@ -234,34 +234,34 @@
                         }
                     },
                     "type": "broadcast_created",
-                    "uuid": "01969b47-8283-76f8-afcb-91a2073e5459"
+                    "uuid": "01969b47-7e9b-76f8-acca-bbca70987315"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:21.123456789Z",
+                    "created_on": "2025-05-04T12:31:20.123456789Z",
                     "groups_removed": [
                         {
                             "name": "Survey Audience",
                             "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                         }
                     ],
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_groups_changed",
-                    "uuid": "01969b47-8e3b-76f8-9654-8a7258fbaae4"
+                    "uuid": "01969b47-8a53-76f8-afcb-91a2073e5459"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:24.123456789Z",
+                    "created_on": "2025-05-04T12:31:23.123456789Z",
                     "groups_added": [
                         {
                             "name": "Survey Audience",
                             "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                         }
                     ],
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_groups_changed",
-                    "uuid": "01969b47-99f3-76f8-8e78-3bde7b3370ae"
+                    "uuid": "01969b47-960b-76f8-9654-8a7258fbaae4"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:27.123456789Z",
+                    "created_on": "2025-05-04T12:31:26.123456789Z",
                     "groups_removed": [
                         {
                             "name": "Survey Audience",
@@ -272,12 +272,12 @@
                             "uuid": "d7ff4872-9238-452f-9d38-2f558fea89e0"
                         }
                     ],
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_groups_changed",
-                    "uuid": "01969b47-a5ab-76f8-b62c-3c781ca3b5da"
+                    "uuid": "01969b47-a1c3-76f8-8e78-3bde7b3370ae"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:30.123456789Z",
+                    "created_on": "2025-05-04T12:31:29.123456789Z",
                     "msg": {
                         "channel": {
                             "name": "Android Channel",
@@ -287,12 +287,12 @@
                         "text": "Hi Ben Haggerty, are you ready to complete today's survey?",
                         "urn": "tel:+12065551212"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "msg_created",
-                    "uuid": "01969b47-b163-76f8-af9c-ff2f1faac4db"
+                    "uuid": "01969b47-ad7b-76f8-b62c-3c781ca3b5da"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:33.123456789Z",
+                    "created_on": "2025-05-04T12:31:32.123456789Z",
                     "msg": {
                         "channel": {
                             "name": "Android Channel",
@@ -302,12 +302,12 @@
                         "text": "This is a message to each of Ben Haggerty's urns.",
                         "urn": "tel:+12065551212"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "msg_created",
-                    "uuid": "01969b47-bd1b-76f8-8d9f-e51d30290005"
+                    "uuid": "01969b47-b933-76f8-af9c-ff2f1faac4db"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:36.123456789Z",
+                    "created_on": "2025-05-04T12:31:35.123456789Z",
                     "msg": {
                         "channel": {
                             "name": "Facebook Channel",
@@ -317,12 +317,12 @@
                         "text": "This is a message to each of Ben Haggerty's urns.",
                         "urn": "facebook:1122334455667788"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "msg_created",
-                    "uuid": "01969b47-c8d3-76f8-bec9-e032f4f9af5f"
+                    "uuid": "01969b47-c4eb-76f8-8d9f-e51d30290005"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:39.123456789Z",
+                    "created_on": "2025-05-04T12:31:38.123456789Z",
                     "msg": {
                         "channel": {
                             "name": "Twitter Channel",
@@ -332,12 +332,12 @@
                         "text": "This is a message to each of Ben Haggerty's urns.",
                         "urn": "twitter:ben_haggerty"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "msg_created",
-                    "uuid": "01969b47-d48b-76f8-9853-0310d032b497"
+                    "uuid": "01969b47-d0a3-76f8-bec9-e032f4f9af5f"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:42.123456789Z",
+                    "created_on": "2025-05-04T12:31:41.123456789Z",
                     "msg": {
                         "attachments": [
                             "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
@@ -358,67 +358,67 @@
                         "text": "This is a reply with attachments and quick replies",
                         "urn": "tel:+12065551212"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "msg_created",
-                    "uuid": "01969b47-e043-76f8-8ab7-4a517a86045c"
+                    "uuid": "01969b47-dc5b-76f8-9853-0310d032b497"
                 },
                 {
                     "category": "Male",
-                    "created_on": "2025-05-04T12:31:47.123456789Z",
+                    "created_on": "2025-05-04T12:31:46.123456789Z",
                     "name": "Gender",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "run_result_changed",
-                    "uuid": "01969b47-f3cb-76f8-97a3-ae27459a6be4",
+                    "uuid": "01969b47-efe3-76f8-8ab7-4a517a86045c",
                     "value": "m"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:50.123456789Z",
+                    "created_on": "2025-05-04T12:31:49.123456789Z",
                     "name": "Jeff Jefferson 2",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_name_changed",
-                    "uuid": "01969b47-ff83-76f8-ba82-c15b24dd577f"
+                    "uuid": "01969b47-fb9b-76f8-97a3-ae27459a6be4"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:53.123456789Z",
+                    "created_on": "2025-05-04T12:31:52.123456789Z",
                     "language": "",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_language_changed",
-                    "uuid": "01969b48-0b3b-76f8-ba7e-53c2263e32f8"
+                    "uuid": "01969b48-0753-76f8-ba82-c15b24dd577f"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:57.123456789Z",
+                    "created_on": "2025-05-04T12:31:56.123456789Z",
                     "field": {
                         "key": "gender",
                         "name": "Gender"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_field_changed",
-                    "uuid": "01969b48-1adb-76f8-aaa3-04d3fbce5f9a",
+                    "uuid": "01969b48-16f3-76f8-ba7e-53c2263e32f8",
                     "value": {
                         "text": "Male"
                     }
                 },
                 {
-                    "created_on": "2025-05-04T12:32:00.123456789Z",
+                    "created_on": "2025-05-04T12:31:59.123456789Z",
                     "groups_added": [
                         {
                             "name": "Males",
                             "uuid": "bf282a79-aa74-4557-9932-22a9b3bce537"
                         }
                     ],
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_groups_changed",
-                    "uuid": "01969b48-2693-76f8-a13f-9238de2a0b76"
+                    "uuid": "01969b48-22ab-76f8-aaa3-04d3fbce5f9a"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:04.123456789Z",
+                    "created_on": "2025-05-04T12:32:03.123456789Z",
                     "field": {
                         "key": "district",
                         "name": "District"
                     },
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_field_changed",
-                    "uuid": "01969b48-3633-76f8-9014-2c868db4022e",
+                    "uuid": "01969b48-324b-76f8-a13f-9238de2a0b76",
                     "value": {
                         "district": "Rwanda > Kigali City > Gasabo",
                         "state": "Rwanda > Kigali City",
@@ -426,21 +426,21 @@
                     }
                 },
                 {
-                    "created_on": "2025-05-04T12:32:09.123456789Z",
+                    "created_on": "2025-05-04T12:32:08.123456789Z",
                     "elapsed_ms": 1000,
                     "request": "GET /?cmd=success&name=Jeff%20Jefferson%202 HTTP/1.1\r\nHost: localhost\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.0 200 OK\r\nContent-Length: 16\r\n\r\n{ \"ok\": \"true\" }",
                     "retries": 0,
                     "status": "success",
                     "status_code": 200,
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "webhook_called",
                     "url": "http://localhost/?cmd=success&name=Jeff%20Jefferson%202",
-                    "uuid": "01969b48-49bb-76f8-bef6-3979f99a96f9"
+                    "uuid": "01969b48-45d3-76f8-9014-2c868db4022e"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:12.123456789Z",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "created_on": "2025-05-04T12:32:11.123456789Z",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "contact_urns_changed",
                     "urns": [
                         "tel:+12065551212?channel=57f1078f-88aa-46f4-a59a-948a5739c03d",
@@ -448,7 +448,7 @@
                         "mailto:ben@macklemore",
                         "twitter:ben_haggerty"
                     ],
-                    "uuid": "01969b48-5573-76f8-ba91-c48ad8c50e6b"
+                    "uuid": "01969b48-518b-76f8-bef6-3979f99a96f9"
                 }
             ],
             "segments": [],
@@ -460,18 +460,18 @@
                         "name": "Android Channel",
                         "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
                     },
-                    "created_on": "2000-01-01T00:00:00Z",
+                    "created_on": "2006-01-02T15:04:05Z",
                     "text": "Ryan Lewis",
                     "type": "msg",
                     "urn": "tel:+12065551212",
-                    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
+                    "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
                 },
                 "runs": [
                     {
-                        "created_on": "2025-05-04T12:30:48.123456789Z",
+                        "created_on": "2025-05-04T12:30:47.123456789Z",
                         "events": [
                             {
-                                "created_on": "2000-01-01T00:00:00Z",
+                                "created_on": "2006-01-02T15:04:05Z",
                                 "msg": {
                                     "channel": {
                                         "name": "Nexmo",
@@ -481,11 +481,11 @@
                                     "urn": "tel:+12065551212"
                                 },
                                 "type": "msg_received",
-                                "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
+                                "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
                             },
                             {
-                                "created_on": "2025-05-04T12:30:53.123456789Z",
-                                "input_uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+                                "created_on": "2025-05-04T12:30:52.123456789Z",
+                                "input_uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
                                 "labels": [
                                     {
                                         "name": "Spam",
@@ -496,12 +496,12 @@
                                         "uuid": "b017c07a-d35b-4da4-8917-3bf8bff80168"
                                     }
                                 ],
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "input_labels_added",
-                                "uuid": "01969b47-20db-76f8-8f41-6b2d9f33d623"
+                                "uuid": "01969b47-1cf3-76f8-8228-9728778b6c98"
                             },
                             {
-                                "created_on": "2025-05-04T12:30:56.123456789Z",
+                                "created_on": "2025-05-04T12:30:55.123456789Z",
                                 "groups_added": [
                                     {
                                         "name": "Survey Audience",
@@ -512,13 +512,13 @@
                                         "uuid": "d7ff4872-9238-452f-9d38-2f558fea89e0"
                                     }
                                 ],
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_groups_changed",
-                                "uuid": "01969b47-2c93-76f8-a17e-f85e49829fb9"
+                                "uuid": "01969b47-28ab-76f8-8f41-6b2d9f33d623"
                             },
                             {
-                                "created_on": "2025-05-04T12:30:59.123456789Z",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "created_on": "2025-05-04T12:30:58.123456789Z",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_urns_changed",
                                 "urns": [
                                     "tel:+12065551212",
@@ -526,44 +526,44 @@
                                     "mailto:ben@macklemore",
                                     "twitter:ben_haggerty"
                                 ],
-                                "uuid": "01969b47-384b-76f8-ba00-bd7f0d08e671"
+                                "uuid": "01969b47-3463-76f8-a17e-f85e49829fb9"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:03.123456789Z",
+                                "created_on": "2025-05-04T12:31:02.123456789Z",
                                 "field": {
                                     "key": "activation_token",
                                     "name": "Activation Token"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_field_changed",
-                                "uuid": "01969b47-47eb-76f8-b86e-4b881f09a186",
+                                "uuid": "01969b47-4403-76f8-ba00-bd7f0d08e671",
                                 "value": {
                                     "text": "XXX-YYY-ZZZ"
                                 }
                             },
                             {
                                 "body": "Hi Ben, Your activation token is XXX-YYY-ZZZ, your coupon is AAA-BBB-CCC",
-                                "created_on": "2025-05-04T12:31:06.123456789Z",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "created_on": "2025-05-04T12:31:05.123456789Z",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "subject": "Here is your activation token",
                                 "to": [
                                     "ben@macklemore",
                                     "test@example.com"
                                 ],
                                 "type": "email_sent",
-                                "uuid": "01969b47-53a3-76f8-a691-235cbe720980"
+                                "uuid": "01969b47-4fbb-76f8-b86e-4b881f09a186"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:09.123456789Z",
+                                "created_on": "2025-05-04T12:31:08.123456789Z",
                                 "flow": {
                                     "name": "Registration Flow",
                                     "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d"
                                 },
-                                "parent_run_uuid": "01969b47-1523-76f8-92a3-d648ab64bccb",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "parent_run_uuid": "01969b47-113b-76f8-9c0b-2014ddc77094",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "terminal": false,
                                 "type": "flow_entered",
-                                "uuid": "01969b47-5f5b-76f8-bebe-b4a1f677cf4c"
+                                "uuid": "01969b47-5b73-76f8-a691-235cbe720980"
                             },
                             {
                                 "contacts": [
@@ -572,7 +572,7 @@
                                         "uuid": "820f5923-3369-41c6-b3cd-af577c0bd4b8"
                                     }
                                 ],
-                                "created_on": "2025-05-04T12:31:12.123456789Z",
+                                "created_on": "2025-05-04T12:31:11.123456789Z",
                                 "exclusions": {},
                                 "flow": {
                                     "name": "Registration Flow",
@@ -581,7 +581,7 @@
                                 "history": {
                                     "ancestors": 1,
                                     "ancestors_since_input": 0,
-                                    "parent_uuid": "01969b47-096b-76f8-bd38-d266ec8d3716"
+                                    "parent_uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
                                 },
                                 "run_summary": {
                                     "contact": {
@@ -613,7 +613,7 @@
                                         ],
                                         "id": 1234567,
                                         "language": "eng",
-                                        "last_seen_on": "2000-01-01T00:00:00Z",
+                                        "last_seen_on": "2006-01-02T15:04:05Z",
                                         "name": "Ben Haggerty",
                                         "status": "active",
                                         "timezone": "America/Guayaquil",
@@ -631,16 +631,16 @@
                                     },
                                     "results": {},
                                     "status": "active",
-                                    "uuid": "01969b47-1523-76f8-92a3-d648ab64bccb"
+                                    "uuid": "01969b47-113b-76f8-9c0b-2014ddc77094"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "session_triggered",
-                                "uuid": "01969b47-6b13-76f8-8dbf-00ecf5d03034"
+                                "uuid": "01969b47-672b-76f8-bebe-b4a1f677cf4c"
                             },
                             {
                                 "base_language": "eng",
-                                "created_on": "2025-05-04T12:31:15.123456789Z",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "created_on": "2025-05-04T12:31:14.123456789Z",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "translations": {
                                     "eng": {
                                         "text": "Hi Ben Haggerty, are you ready?"
@@ -653,18 +653,18 @@
                                 "urns": [
                                     "tel:+12065551212"
                                 ],
-                                "uuid": "01969b47-76cb-76f8-acca-bbca70987315"
+                                "uuid": "01969b47-72e3-76f8-8dbf-00ecf5d03034"
                             },
                             {
                                 "base_language": "eng",
-                                "created_on": "2025-05-04T12:31:18.123456789Z",
+                                "created_on": "2025-05-04T12:31:17.123456789Z",
                                 "groups": [
                                     {
                                         "name": "Survey Audience",
                                         "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                                     }
                                 ],
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "translations": {
                                     "eng": {
                                         "attachments": [
@@ -680,34 +680,34 @@
                                     }
                                 },
                                 "type": "broadcast_created",
-                                "uuid": "01969b47-8283-76f8-afcb-91a2073e5459"
+                                "uuid": "01969b47-7e9b-76f8-acca-bbca70987315"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:21.123456789Z",
+                                "created_on": "2025-05-04T12:31:20.123456789Z",
                                 "groups_removed": [
                                     {
                                         "name": "Survey Audience",
                                         "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                                     }
                                 ],
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_groups_changed",
-                                "uuid": "01969b47-8e3b-76f8-9654-8a7258fbaae4"
+                                "uuid": "01969b47-8a53-76f8-afcb-91a2073e5459"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:24.123456789Z",
+                                "created_on": "2025-05-04T12:31:23.123456789Z",
                                 "groups_added": [
                                     {
                                         "name": "Survey Audience",
                                         "uuid": "2aad21f6-30b7-42c5-bd7f-1b720c154817"
                                     }
                                 ],
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_groups_changed",
-                                "uuid": "01969b47-99f3-76f8-8e78-3bde7b3370ae"
+                                "uuid": "01969b47-960b-76f8-9654-8a7258fbaae4"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:27.123456789Z",
+                                "created_on": "2025-05-04T12:31:26.123456789Z",
                                 "groups_removed": [
                                     {
                                         "name": "Survey Audience",
@@ -718,12 +718,12 @@
                                         "uuid": "d7ff4872-9238-452f-9d38-2f558fea89e0"
                                     }
                                 ],
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_groups_changed",
-                                "uuid": "01969b47-a5ab-76f8-b62c-3c781ca3b5da"
+                                "uuid": "01969b47-a1c3-76f8-8e78-3bde7b3370ae"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:30.123456789Z",
+                                "created_on": "2025-05-04T12:31:29.123456789Z",
                                 "msg": {
                                     "channel": {
                                         "name": "Android Channel",
@@ -733,12 +733,12 @@
                                     "text": "Hi Ben Haggerty, are you ready to complete today's survey?",
                                     "urn": "tel:+12065551212"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "msg_created",
-                                "uuid": "01969b47-b163-76f8-af9c-ff2f1faac4db"
+                                "uuid": "01969b47-ad7b-76f8-b62c-3c781ca3b5da"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:33.123456789Z",
+                                "created_on": "2025-05-04T12:31:32.123456789Z",
                                 "msg": {
                                     "channel": {
                                         "name": "Android Channel",
@@ -748,12 +748,12 @@
                                     "text": "This is a message to each of Ben Haggerty's urns.",
                                     "urn": "tel:+12065551212"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "msg_created",
-                                "uuid": "01969b47-bd1b-76f8-8d9f-e51d30290005"
+                                "uuid": "01969b47-b933-76f8-af9c-ff2f1faac4db"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:36.123456789Z",
+                                "created_on": "2025-05-04T12:31:35.123456789Z",
                                 "msg": {
                                     "channel": {
                                         "name": "Facebook Channel",
@@ -763,12 +763,12 @@
                                     "text": "This is a message to each of Ben Haggerty's urns.",
                                     "urn": "facebook:1122334455667788"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "msg_created",
-                                "uuid": "01969b47-c8d3-76f8-bec9-e032f4f9af5f"
+                                "uuid": "01969b47-c4eb-76f8-8d9f-e51d30290005"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:39.123456789Z",
+                                "created_on": "2025-05-04T12:31:38.123456789Z",
                                 "msg": {
                                     "channel": {
                                         "name": "Twitter Channel",
@@ -778,12 +778,12 @@
                                     "text": "This is a message to each of Ben Haggerty's urns.",
                                     "urn": "twitter:ben_haggerty"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "msg_created",
-                                "uuid": "01969b47-d48b-76f8-9853-0310d032b497"
+                                "uuid": "01969b47-d0a3-76f8-bec9-e032f4f9af5f"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:42.123456789Z",
+                                "created_on": "2025-05-04T12:31:41.123456789Z",
                                 "msg": {
                                     "attachments": [
                                         "image/jpeg:http://s3.amazon.com/bucket/test_en.jpg?a=Kigali%20City"
@@ -804,67 +804,67 @@
                                     "text": "This is a reply with attachments and quick replies",
                                     "urn": "tel:+12065551212"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "msg_created",
-                                "uuid": "01969b47-e043-76f8-8ab7-4a517a86045c"
+                                "uuid": "01969b47-dc5b-76f8-9853-0310d032b497"
                             },
                             {
                                 "category": "Male",
-                                "created_on": "2025-05-04T12:31:47.123456789Z",
+                                "created_on": "2025-05-04T12:31:46.123456789Z",
                                 "name": "Gender",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "run_result_changed",
-                                "uuid": "01969b47-f3cb-76f8-97a3-ae27459a6be4",
+                                "uuid": "01969b47-efe3-76f8-8ab7-4a517a86045c",
                                 "value": "m"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:50.123456789Z",
+                                "created_on": "2025-05-04T12:31:49.123456789Z",
                                 "name": "Jeff Jefferson 2",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_name_changed",
-                                "uuid": "01969b47-ff83-76f8-ba82-c15b24dd577f"
+                                "uuid": "01969b47-fb9b-76f8-97a3-ae27459a6be4"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:53.123456789Z",
+                                "created_on": "2025-05-04T12:31:52.123456789Z",
                                 "language": "",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_language_changed",
-                                "uuid": "01969b48-0b3b-76f8-ba7e-53c2263e32f8"
+                                "uuid": "01969b48-0753-76f8-ba82-c15b24dd577f"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:57.123456789Z",
+                                "created_on": "2025-05-04T12:31:56.123456789Z",
                                 "field": {
                                     "key": "gender",
                                     "name": "Gender"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_field_changed",
-                                "uuid": "01969b48-1adb-76f8-aaa3-04d3fbce5f9a",
+                                "uuid": "01969b48-16f3-76f8-ba7e-53c2263e32f8",
                                 "value": {
                                     "text": "Male"
                                 }
                             },
                             {
-                                "created_on": "2025-05-04T12:32:00.123456789Z",
+                                "created_on": "2025-05-04T12:31:59.123456789Z",
                                 "groups_added": [
                                     {
                                         "name": "Males",
                                         "uuid": "bf282a79-aa74-4557-9932-22a9b3bce537"
                                     }
                                 ],
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_groups_changed",
-                                "uuid": "01969b48-2693-76f8-a13f-9238de2a0b76"
+                                "uuid": "01969b48-22ab-76f8-aaa3-04d3fbce5f9a"
                             },
                             {
-                                "created_on": "2025-05-04T12:32:04.123456789Z",
+                                "created_on": "2025-05-04T12:32:03.123456789Z",
                                 "field": {
                                     "key": "district",
                                     "name": "District"
                                 },
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_field_changed",
-                                "uuid": "01969b48-3633-76f8-9014-2c868db4022e",
+                                "uuid": "01969b48-324b-76f8-a13f-9238de2a0b76",
                                 "value": {
                                     "district": "Rwanda > Kigali City > Gasabo",
                                     "state": "Rwanda > Kigali City",
@@ -872,21 +872,21 @@
                                 }
                             },
                             {
-                                "created_on": "2025-05-04T12:32:09.123456789Z",
+                                "created_on": "2025-05-04T12:32:08.123456789Z",
                                 "elapsed_ms": 1000,
                                 "request": "GET /?cmd=success&name=Jeff%20Jefferson%202 HTTP/1.1\r\nHost: localhost\r\nUser-Agent: goflow-testing\r\nAccept-Encoding: gzip\r\n\r\n",
                                 "response": "HTTP/1.0 200 OK\r\nContent-Length: 16\r\n\r\n{ \"ok\": \"true\" }",
                                 "retries": 0,
                                 "status": "success",
                                 "status_code": 200,
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "webhook_called",
                                 "url": "http://localhost/?cmd=success&name=Jeff%20Jefferson%202",
-                                "uuid": "01969b48-49bb-76f8-bef6-3979f99a96f9"
+                                "uuid": "01969b48-45d3-76f8-9014-2c868db4022e"
                             },
                             {
-                                "created_on": "2025-05-04T12:32:12.123456789Z",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "created_on": "2025-05-04T12:32:11.123456789Z",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "contact_urns_changed",
                                 "urns": [
                                     "tel:+12065551212?channel=57f1078f-88aa-46f4-a59a-948a5739c03d",
@@ -894,10 +894,10 @@
                                     "mailto:ben@macklemore",
                                     "twitter:ben_haggerty"
                                 ],
-                                "uuid": "01969b48-5573-76f8-ba91-c48ad8c50e6b"
+                                "uuid": "01969b48-518b-76f8-bef6-3979f99a96f9"
                             }
                         ],
-                        "exited_on": "2025-05-04T12:32:17.123456789Z",
+                        "exited_on": "2025-05-04T12:32:16.123456789Z",
                         "flow": {
                             "name": "All Actions",
                             "uuid": "8ca44c09-791d-453a-9799-a70dd3303306"
@@ -905,45 +905,45 @@
                         "locals": {
                             "counter": "2"
                         },
-                        "modified_on": "2025-05-04T12:32:17.123456789Z",
+                        "modified_on": "2025-05-04T12:32:16.123456789Z",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:30:50.123456789Z",
+                                "arrived_on": "2025-05-04T12:30:49.123456789Z",
                                 "exit_uuid": "118221f7-e637-4cdb-83ca-7f0a5aae98c6",
                                 "node_uuid": "a58be63b-907d-4a1a-856b-0bb5579d7507",
-                                "uuid": "5802813d-6c58-4292-8228-9728778b6c98"
+                                "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
                             }
                         ],
                         "results": {
                             "gender": {
                                 "category": "Male",
-                                "created_on": "2025-05-04T12:31:44.123456789Z",
+                                "created_on": "2025-05-04T12:31:43.123456789Z",
                                 "name": "Gender",
                                 "node_uuid": "a58be63b-907d-4a1a-856b-0bb5579d7507",
                                 "value": "m"
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-1523-76f8-92a3-d648ab64bccb"
+                        "uuid": "01969b47-113b-76f8-9c0b-2014ddc77094"
                     },
                     {
-                        "created_on": "2025-05-04T12:32:14.123456789Z",
-                        "exited_on": "2025-05-04T12:32:16.123456789Z",
+                        "created_on": "2025-05-04T12:32:13.123456789Z",
+                        "exited_on": "2025-05-04T12:32:15.123456789Z",
                         "flow": {
                             "name": "Registration Flow",
                             "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d"
                         },
-                        "modified_on": "2025-05-04T12:32:16.123456789Z",
-                        "parent_uuid": "01969b47-1523-76f8-92a3-d648ab64bccb",
+                        "modified_on": "2025-05-04T12:32:15.123456789Z",
+                        "parent_uuid": "01969b47-113b-76f8-9c0b-2014ddc77094",
                         "path": [],
                         "status": "completed",
-                        "uuid": "01969b48-6513-76f8-be24-6164105d48f2"
+                        "uuid": "01969b48-612b-76f8-ba91-c48ad8c50e6b"
                     }
                 ],
                 "status": "completed",
                 "trigger": {
                     "event": {
-                        "created_on": "2000-01-01T00:00:00Z",
+                        "created_on": "2006-01-02T15:04:05Z",
                         "msg": {
                             "channel": {
                                 "name": "Nexmo",
@@ -953,7 +953,7 @@
                             "urn": "tel:+12065551212"
                         },
                         "type": "msg_received",
-                        "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
+                        "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
                     },
                     "flow": {
                         "name": "All Actions",
@@ -971,24 +971,29 @@
                     "type": "msg"
                 },
                 "type": "messaging",
-                "uuid": "01969b47-096b-76f8-bd38-d266ec8d3716"
+                "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
             }
         }
     ],
     "resumes": [],
     "trigger": {
+        "event": {
+            "created_on": "2006-01-02T15:04:05Z",
+            "msg": {
+                "channel": {
+                    "name": "Nexmo",
+                    "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
+                },
+                "text": "Ryan Lewis",
+                "urn": "tel:+12065551212",
+                "uuid": "9bf91c2b-ce58-4cef-aacc-281e03f69ab5"
+            },
+            "type": "msg_received",
+            "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
+        },
         "flow": {
             "name": "All Actions",
             "uuid": "8ca44c09-791d-453a-9799-a70dd3303306"
-        },
-        "msg": {
-            "channel": {
-                "name": "Nexmo",
-                "uuid": "57f1078f-88aa-46f4-a59a-948a5739c03d"
-            },
-            "text": "Ryan Lewis",
-            "urn": "tel:+12065551212",
-            "uuid": "9bf91c2b-ce58-4cef-aacc-281e03f69ab5"
         },
         "params": {
             "coupons": [

--- a/test/testdata/runner/expirations.test_all_expire.json
+++ b/test/testdata/runner/expirations.test_all_expire.json
@@ -377,7 +377,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:17.508225-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
                             }
                         ],
                         "exited_on": "2025-05-04T12:31:13.123456789Z",
@@ -580,7 +580,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:23.165294-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-3a35-7853-926b-d1e8579e2cae"
                             }
                         ],
                         "exited_on": "2025-05-04T12:31:30.123456789Z",
@@ -637,7 +637,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:17.508225-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
                             }
                         ],
                         "exited_on": "2025-05-04T12:31:13.123456789Z",
@@ -728,7 +728,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:29.501371-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-6c7f-778f-ad69-11798b50fe1f"
                             }
                         ],
                         "exited_on": "2025-05-04T12:31:47.123456789Z",
@@ -803,7 +803,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:23.165294-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-3a35-7853-926b-d1e8579e2cae"
                             }
                         ],
                         "exited_on": "2025-05-04T12:31:30.123456789Z",
@@ -860,7 +860,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:17.508225-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
                             }
                         ],
                         "exited_on": "2025-05-04T12:31:13.123456789Z",
@@ -906,7 +906,8 @@
         {
             "event": {
                 "created_on": "2020-10-12T15:38:17.508225-05:00",
-                "type": "wait_expired"
+                "type": "wait_expired",
+                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
             },
             "resumed_on": "2020-10-12T15:38:17.508225-05:00",
             "type": "wait_expiration"
@@ -914,7 +915,8 @@
         {
             "event": {
                 "created_on": "2020-10-12T15:38:23.165294-05:00",
-                "type": "wait_expired"
+                "type": "wait_expired",
+                "uuid": "0198380e-3a35-7853-926b-d1e8579e2cae"
             },
             "resumed_on": "2020-10-12T15:38:23.165294-05:00",
             "type": "wait_expiration"
@@ -922,7 +924,8 @@
         {
             "event": {
                 "created_on": "2020-10-12T15:38:29.501371-05:00",
-                "type": "wait_expired"
+                "type": "wait_expired",
+                "uuid": "0198380e-6c7f-778f-ad69-11798b50fe1f"
             },
             "resumed_on": "2020-10-12T15:38:29.501371-05:00",
             "type": "wait_expiration"

--- a/test/testdata/runner/initial_wait.test.json
+++ b/test/testdata/runner/initial_wait.test.json
@@ -24,15 +24,15 @@
             "events": [
                 {
                     "category": "Ping",
-                    "created_on": "2025-05-04T12:30:55.123456789Z",
+                    "created_on": "2025-05-04T12:30:54.123456789Z",
                     "name": "Command",
-                    "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                    "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                     "type": "run_result_changed",
-                    "uuid": "01969b47-28ab-76f8-8f41-6b2d9f33d623",
+                    "uuid": "01969b47-24c3-76f8-8228-9728778b6c98",
                     "value": "PING"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:00.123456789Z",
+                    "created_on": "2025-05-04T12:30:59.123456789Z",
                     "msg": {
                         "channel": {
                             "name": "Android Channel",
@@ -42,9 +42,9 @@
                         "text": "You said PING",
                         "urn": "tel:+12065551212"
                     },
-                    "step_uuid": "5ecda5fc-951c-437b-a17e-f85e49829fb9",
+                    "step_uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623",
                     "type": "msg_created",
-                    "uuid": "01969b47-3c33-76f8-ba00-bd7f0d08e671"
+                    "uuid": "01969b47-384b-76f8-a17e-f85e49829fb9"
                 }
             ],
             "segments": [
@@ -54,43 +54,43 @@
                     "flow_uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4",
                     "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
                     "operand": "PING",
-                    "time": "2025-05-04T12:30:57.123456789Z"
+                    "time": "2025-05-04T12:30:56.123456789Z"
                 }
             ],
             "session": {
                 "contact_uuid": "ba96bf7f-bc2a-4873-a7c7-254d1927c4e3",
                 "created_on": "0001-01-01T00:00:00Z",
                 "input": {
-                    "created_on": "2018-10-11T14:27:09.05642-05:00",
+                    "created_on": "2000-01-01T00:00:00Z",
                     "text": "PING",
                     "type": "msg",
                     "urn": "tel:+12065551212",
-                    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
+                    "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
                 },
                 "runs": [
                     {
-                        "created_on": "2025-05-04T12:30:48.123456789Z",
+                        "created_on": "2025-05-04T12:30:47.123456789Z",
                         "events": [
                             {
-                                "created_on": "2018-10-11T14:27:09.05642-05:00",
+                                "created_on": "2000-01-01T00:00:00Z",
                                 "msg": {
                                     "text": "PING",
                                     "urn": "tel:+12065551212"
                                 },
                                 "type": "msg_received",
-                                "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
+                                "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
                             },
                             {
                                 "category": "Ping",
-                                "created_on": "2025-05-04T12:30:55.123456789Z",
+                                "created_on": "2025-05-04T12:30:54.123456789Z",
                                 "name": "Command",
-                                "step_uuid": "5802813d-6c58-4292-8228-9728778b6c98",
+                                "step_uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb",
                                 "type": "run_result_changed",
-                                "uuid": "01969b47-28ab-76f8-8f41-6b2d9f33d623",
+                                "uuid": "01969b47-24c3-76f8-8228-9728778b6c98",
                                 "value": "PING"
                             },
                             {
-                                "created_on": "2025-05-04T12:31:00.123456789Z",
+                                "created_on": "2025-05-04T12:30:59.123456789Z",
                                 "msg": {
                                     "channel": {
                                         "name": "Android Channel",
@@ -100,35 +100,35 @@
                                     "text": "You said PING",
                                     "urn": "tel:+12065551212"
                                 },
-                                "step_uuid": "5ecda5fc-951c-437b-a17e-f85e49829fb9",
+                                "step_uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623",
                                 "type": "msg_created",
-                                "uuid": "01969b47-3c33-76f8-ba00-bd7f0d08e671"
+                                "uuid": "01969b47-384b-76f8-a17e-f85e49829fb9"
                             }
                         ],
-                        "exited_on": "2025-05-04T12:31:02.123456789Z",
+                        "exited_on": "2025-05-04T12:31:01.123456789Z",
                         "flow": {
                             "name": "Initial Wait",
                             "uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4"
                         },
-                        "modified_on": "2025-05-04T12:31:02.123456789Z",
+                        "modified_on": "2025-05-04T12:31:01.123456789Z",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:30:50.123456789Z",
+                                "arrived_on": "2025-05-04T12:30:49.123456789Z",
                                 "exit_uuid": "1ca74fca-1803-4ae7-8ae9-336e75276cd6",
                                 "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
-                                "uuid": "5802813d-6c58-4292-8228-9728778b6c98"
+                                "uuid": "c34b6c7d-fa06-4563-92a3-d648ab64bccb"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:30:58.123456789Z",
+                                "arrived_on": "2025-05-04T12:30:57.123456789Z",
                                 "exit_uuid": "b6da70e0-fe8e-46fc-8b4c-fcc5173706c1",
                                 "node_uuid": "11a772f3-3ca2-4429-8b33-20fdcfc2b69e",
-                                "uuid": "5ecda5fc-951c-437b-a17e-f85e49829fb9"
+                                "uuid": "970b8069-50f5-4f6f-8f41-6b2d9f33d623"
                             }
                         ],
                         "results": {
                             "command": {
                                 "category": "Ping",
-                                "created_on": "2025-05-04T12:30:52.123456789Z",
+                                "created_on": "2025-05-04T12:30:51.123456789Z",
                                 "input": "PING",
                                 "name": "Command",
                                 "node_uuid": "46d51f50-58de-49da-8d13-dadbf322685d",
@@ -136,19 +136,19 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-1523-76f8-92a3-d648ab64bccb"
+                        "uuid": "01969b47-113b-76f8-9c0b-2014ddc77094"
                     }
                 ],
                 "status": "completed",
                 "trigger": {
                     "event": {
-                        "created_on": "2018-10-11T14:27:09.05642-05:00",
+                        "created_on": "2000-01-01T00:00:00Z",
                         "msg": {
                             "text": "PING",
                             "urn": "tel:+12065551212"
                         },
                         "type": "msg_received",
-                        "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
+                        "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
                     },
                     "flow": {
                         "name": "Initial Wait",
@@ -158,20 +158,24 @@
                     "type": "msg"
                 },
                 "type": "messaging",
-                "uuid": "01969b47-096b-76f8-bd38-d266ec8d3716"
+                "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5"
             }
         }
     ],
     "resumes": [],
     "trigger": {
+        "event": {
+            "created_on": "2000-01-01T00:00:00Z",
+            "msg": {
+                "text": "PING",
+                "urn": "tel:+12065551212"
+            },
+            "type": "msg_received",
+            "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108"
+        },
         "flow": {
             "name": "Initial Wait",
             "uuid": "615b8a0f-588c-4d20-a05f-363b0b4ce6f4"
-        },
-        "msg": {
-            "text": "PING",
-            "urn": "tel:+12065551212",
-            "uuid": "0932960c-2b34-4b1e-a739-725ac77c7210"
         },
         "triggered_on": "2018-10-11T14:27:09.05642-05:00",
         "type": "msg"

--- a/test/testdata/runner/subflow.test_resume_with_expiration.json
+++ b/test/testdata/runner/subflow.test_resume_with_expiration.json
@@ -314,7 +314,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:17.508225-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
                             }
                         ],
                         "exited_on": "2025-05-04T12:31:08.123456789Z",
@@ -353,7 +353,8 @@
         {
             "event": {
                 "created_on": "2020-10-12T15:38:17.508225-05:00",
-                "type": "wait_expired"
+                "type": "wait_expired",
+                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
             },
             "resumed_on": "2000-01-01T00:00:00.000000000-00:00",
             "type": "wait_expiration"

--- a/test/testdata/runner/two_questions.test_resume_with_expiration.json
+++ b/test/testdata/runner/two_questions.test_resume_with_expiration.json
@@ -168,7 +168,7 @@
                             {
                                 "created_on": "2020-10-12T15:38:17.508225-05:00",
                                 "type": "wait_expired",
-                                "uuid": ""
+                                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
                             }
                         ],
                         "exited_on": "2025-05-04T12:30:59.123456789Z",
@@ -206,7 +206,8 @@
         {
             "event": {
                 "created_on": "2020-10-12T15:38:17.508225-05:00",
-                "type": "wait_expired"
+                "type": "wait_expired",
+                "uuid": "0198380e-0d7f-7773-8ebc-d81412e49a58"
             },
             "resumed_on": "2000-01-01T00:00:00.000000000-00:00",
             "type": "wait_expiration"


### PR DESCRIPTION
Make a bunch of additions we made a month ago, required now:

 * `events.BaseEvent.uuid`
 * `events.CampaignFired.point_uuid`
 * `events.OptInStarted.channel`
 * `events.OptInStopped.channel`
 * `engine.Session.contact_uuid`
 * `triggers.Msg.event`