### PR TITLE
Honor test LLM directives inside JSON array inputs

### DIFF
--- a/test/services/llm.go
+++ b/test/services/llm.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -16,11 +17,25 @@ func NewLLM() *LLMService {
 }
 
 func (s *LLMService) Response(ctx context.Context, instructions, input string, maxTokens int) (*flows.LLMResponse, error) {
+	// If input is a JSON array of strings whose first element is an \error or
+	// \return directive, apply the directive as if the input were just that
+	// element. Lets callers that marshal their input as a JSON array still
+	// exercise the directives without needing a wrapper.
+	effective := input
+	if len(input) > 0 && input[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal([]byte(input), &arr); err == nil && len(arr) > 0 {
+			if strings.HasPrefix(arr[0], "\\error ") || strings.HasPrefix(arr[0], "\\return ") {
+				effective = arr[0]
+			}
+		}
+	}
+
 	var output string
-	if strings.HasPrefix(input, "\\error ") { // an input like "\error foo" will return the error "foo"
-		return nil, errors.New(input[7:])
-	} else if strings.HasPrefix(input, "\\return ") { // an input like "\return foo" will return "foo"
-		output = input[8:]
+	if strings.HasPrefix(effective, "\\error ") { // an input like "\error foo" will return the error "foo"
+		return nil, errors.New(effective[7:])
+	} else if strings.HasPrefix(effective, "\\return ") { // an input like "\return foo" will return "foo"
+		output = effective[8:]
 	} else if strings.HasPrefix(instructions, "Categorize") { // instructions like "Categorize... Category2, Category3]" will return "Category3"
 		words := strings.Fields(instructions)
 		output = strings.TrimSuffix(words[len(words)-1], "]")

--- a/test/services/llm_test.go
+++ b/test/services/llm_test.go
@@ -1,0 +1,51 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nyaruka/goflow/test/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLLMService(t *testing.T) {
+	svc := services.NewLLM()
+	ctx := context.Background()
+
+	// plain input is echoed with instructions
+	resp, err := svc.Response(ctx, "Translate", "Hello", 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "You asked:\n\nTranslate\n\nHello", resp.Output)
+
+	// \return directive returns what follows
+	resp, err = svc.Response(ctx, "whatever", "\\return foo", 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", resp.Output)
+
+	// \error directive returns an error
+	_, err = svc.Response(ctx, "whatever", "\\error boom", 100)
+	assert.EqualError(t, err, "boom")
+
+	// Categorize instructions pick the last word
+	resp, err = svc.Response(ctx, "Categorize into [A, B, C]", "input", 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "C", resp.Output)
+
+	// directive in the first element of a JSON array input fires
+	resp, err = svc.Response(ctx, "whatever", `["\\return [\"T-Hi\"]"]`, 100)
+	assert.NoError(t, err)
+	assert.Equal(t, `["T-Hi"]`, resp.Output)
+
+	_, err = svc.Response(ctx, "whatever", `["\\error boom","ignored"]`, 100)
+	assert.EqualError(t, err, "boom")
+
+	// JSON array without a directive falls through to echo
+	resp, err = svc.Response(ctx, "whatever", `["Hi","Bye"]`, 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "You asked:\n\nwhatever\n\n[\"Hi\",\"Bye\"]", resp.Output)
+
+	// non-JSON input starting with [ falls through
+	resp, err = svc.Response(ctx, "whatever", "[not json", 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "You asked:\n\nwhatever\n\n[not json", resp.Output)
+}


### PR DESCRIPTION
Callers that marshal their LLM input as a JSON array of strings (e.g. mailroom's upcoming batched `/llm/translate` endpoint) can't currently exercise the `\return` / `\error` directives on the test LLM service, because the whole input string starts with `[` instead of the directive prefix.

This change makes `LLMService.Response` additionally inspect the first element when the input parses as a JSON array of strings. If that element carries a directive, it's applied as if the whole input had been that element. The existing top-level directive behavior is unchanged.

Unblocks the mailroom PR that switches `/llm/translate` to a batch shape — once this is released, mailroom can drop its local `testLLMService` wrapper in [nyaruka/mailroom#1052](https://github.com/nyaruka/mailroom/pull/1052) and drive every test case via the generic directive mechanism.

## Test plan

- [x] `go test ./test/services/...` — new `llm_test.go` covers the plain, `\return`, `\error`, Categorize, first-element-directive, and non-directive array paths
- [x] `go test ./...` — full suite green