### PR TITLE
Add Translate prefix to test LLM service that converts input to leetspeak

### DIFF
--- a/test/services/llm.go
+++ b/test/services/llm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/nyaruka/goflow/flows"
@@ -15,6 +16,18 @@ type LLMService struct{}
 func NewLLM() *LLMService {
 	return &LLMService{}
 }
+
+var leetify = strings.NewReplacer(
+	"a", "4", "A", "4",
+	"b", "8", "B", "8",
+	"e", "3", "E", "3",
+	"g", "9", "G", "9",
+	"i", "1", "I", "1",
+	"l", "1", "L", "1",
+	"o", "0", "O", "0",
+	"s", "5", "S", "5",
+	"t", "7", "T", "7",
+).Replace
 
 func (s *LLMService) Response(ctx context.Context, instructions, input string, maxTokens int) (*flows.LLMResponse, error) {
 	// If input is a JSON array of strings whose first element is an \error or
@@ -39,6 +52,20 @@ func (s *LLMService) Response(ctx context.Context, instructions, input string, m
 	} else if strings.HasPrefix(instructions, "Categorize") { // instructions like "Categorize... Category2, Category3]" will return "Category3"
 		words := strings.Fields(instructions)
 		output = strings.TrimSuffix(words[len(words)-1], "]")
+	} else if strings.HasPrefix(instructions, "Translate") { // "Translate..." leetifies the input; if "JSON" is mentioned, values of a string->string object
+		if strings.Contains(instructions, "JSON") {
+			obj := map[string]string{}
+			if err := json.Unmarshal([]byte(input), &obj); err != nil {
+				return nil, fmt.Errorf("invalid JSON object input: %w", err)
+			}
+			for k, v := range obj {
+				obj[k] = leetify(v)
+			}
+			b, _ := json.Marshal(obj)
+			output = string(b)
+		} else {
+			output = leetify(input)
+		}
 	} else {
 		output = "You asked:\n\n" + instructions + "\n\n" + input
 	}

--- a/test/services/llm_test.go
+++ b/test/services/llm_test.go
@@ -13,9 +13,36 @@ func TestLLMService(t *testing.T) {
 	ctx := context.Background()
 
 	// plain input is echoed with instructions
-	resp, err := svc.Response(ctx, "Translate", "Hello", 100)
+	resp, err := svc.Response(ctx, "Summarize", "Hello", 100)
 	assert.NoError(t, err)
-	assert.Equal(t, "You asked:\n\nTranslate\n\nHello", resp.Output)
+	assert.Equal(t, "You asked:\n\nSummarize\n\nHello", resp.Output)
+
+	// instructions starting with "Translate" leetify the whole input
+	resp, err = svc.Response(ctx, "Translate to Spanish", "Hello", 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "H3110", resp.Output)
+
+	// lower-case "translate" does NOT trigger — only the capitalized prefix
+	resp, err = svc.Response(ctx, "please translate this", "Hello", 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "You asked:\n\nplease translate this\n\nHello", resp.Output)
+
+	// "Translate" instructions mentioning "JSON" parse the input as a string->string object and leetify values
+	resp, err = svc.Response(ctx, "Translate as JSON", `{"greeting":"Hello","name":"World"}`, 100)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"greeting":"H3110","name":"W0r1d"}`, resp.Output)
+
+	// invalid JSON input with a JSON translate instruction errors
+	_, err = svc.Response(ctx, "Translate as JSON", "not json", 100)
+	assert.Error(t, err)
+
+	// directives still take precedence over translate
+	_, err = svc.Response(ctx, "Translate", "\\error boom", 100)
+	assert.EqualError(t, err, "boom")
+
+	resp, err = svc.Response(ctx, "Translate", "\\return foo", 100)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", resp.Output)
 
 	// \return directive returns what follows
 	resp, err = svc.Response(ctx, "whatever", "\\return foo", 100)


### PR DESCRIPTION
## Summary

Extends the test `LLMService` so that instructions starting with `Translate` produce a deterministic leetspeak version of the input (a→4, b→8, e→3, g→9, i→1, l→1, o→0, s→5, t→7, both cases).

- If the instructions also contain `JSON`, the input is parsed as a `map[string]string` and only the values are leetified (keys preserved). Invalid JSON returns an error.
- Otherwise the raw input is leetified.
- Existing `\error` / `\return` / `Categorize` precedence is preserved.

This gives tests that drive `llm` actions a way to produce a predictable, visibly transformed output — useful for translation-style flows — without reaching for a real model.

## Test plan

- [x] `go test ./test/services/ -run TestLLMService`
- [x] `go test ./...` (full suite passes)