### PR TITLE
Test LLM Translate+JSON assumes map of string->[]string input

### DIFF
--- a/test/services/llm.go
+++ b/test/services/llm.go
@@ -30,25 +30,11 @@ var leetify = strings.NewReplacer(
 ).Replace
 
 func (s *LLMService) Response(ctx context.Context, instructions, input string, maxTokens int) (*flows.LLMResponse, error) {
-	// If input is a JSON array of strings whose first element is an \error or
-	// \return directive, apply the directive as if the input were just that
-	// element. Lets callers that marshal their input as a JSON array still
-	// exercise the directives without needing a wrapper.
-	effective := input
-	if len(input) > 0 && input[0] == '[' {
-		var arr []string
-		if err := json.Unmarshal([]byte(input), &arr); err == nil && len(arr) > 0 {
-			if strings.HasPrefix(arr[0], "\\error ") || strings.HasPrefix(arr[0], "\\return ") {
-				effective = arr[0]
-			}
-		}
-	}
-
 	var output string
-	if strings.HasPrefix(effective, "\\error ") { // an input like "\error foo" will return the error "foo"
-		return nil, errors.New(effective[7:])
-	} else if strings.HasPrefix(effective, "\\return ") { // an input like "\return foo" will return "foo"
-		output = effective[8:]
+	if strings.HasPrefix(input, "\\error ") { // an input like "\error foo" will return the error "foo"
+		return nil, errors.New(input[7:])
+	} else if strings.HasPrefix(input, "\\return ") { // an input like "\return foo" will return "foo"
+		output = input[8:]
 	} else if strings.HasPrefix(instructions, "Categorize") { // instructions like "Categorize... Category2, Category3]" will return "Category3"
 		words := strings.Fields(instructions)
 		output = strings.TrimSuffix(words[len(words)-1], "]")

--- a/test/services/llm.go
+++ b/test/services/llm.go
@@ -52,14 +52,17 @@ func (s *LLMService) Response(ctx context.Context, instructions, input string, m
 	} else if strings.HasPrefix(instructions, "Categorize") { // instructions like "Categorize... Category2, Category3]" will return "Category3"
 		words := strings.Fields(instructions)
 		output = strings.TrimSuffix(words[len(words)-1], "]")
-	} else if strings.HasPrefix(instructions, "Translate") { // "Translate..." leetifies the input; if "JSON" is mentioned, values of a string->string object
+	} else if strings.HasPrefix(instructions, "Translate") { // "Translate..." leetifies the input; if "JSON" is mentioned, values of a string->[]string object
 		if strings.Contains(instructions, "JSON") {
-			obj := map[string]string{}
+			obj := map[string][]string{}
 			if err := json.Unmarshal([]byte(input), &obj); err != nil {
 				return nil, fmt.Errorf("invalid JSON object input: %w", err)
 			}
-			for k, v := range obj {
-				obj[k] = leetify(v)
+			for k, vs := range obj {
+				for i, v := range vs {
+					vs[i] = leetify(v)
+				}
+				obj[k] = vs
 			}
 			b, _ := json.Marshal(obj)
 			output = string(b)

--- a/test/services/llm_test.go
+++ b/test/services/llm_test.go
@@ -58,21 +58,4 @@ func TestLLMService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "C", resp.Output)
 
-	// directive in the first element of a JSON array input fires
-	resp, err = svc.Response(ctx, "whatever", `["\\return [\"T-Hi\"]"]`, 100)
-	assert.NoError(t, err)
-	assert.Equal(t, `["T-Hi"]`, resp.Output)
-
-	_, err = svc.Response(ctx, "whatever", `["\\error boom","ignored"]`, 100)
-	assert.EqualError(t, err, "boom")
-
-	// JSON array without a directive falls through to echo
-	resp, err = svc.Response(ctx, "whatever", `["Hi","Bye"]`, 100)
-	assert.NoError(t, err)
-	assert.Equal(t, "You asked:\n\nwhatever\n\n[\"Hi\",\"Bye\"]", resp.Output)
-
-	// non-JSON input starting with [ falls through
-	resp, err = svc.Response(ctx, "whatever", "[not json", 100)
-	assert.NoError(t, err)
-	assert.Equal(t, "You asked:\n\nwhatever\n\n[not json", resp.Output)
 }

--- a/test/services/llm_test.go
+++ b/test/services/llm_test.go
@@ -27,10 +27,10 @@ func TestLLMService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "You asked:\n\nplease translate this\n\nHello", resp.Output)
 
-	// "Translate" instructions mentioning "JSON" parse the input as a string->string object and leetify values
-	resp, err = svc.Response(ctx, "Translate as JSON", `{"greeting":"Hello","name":"World"}`, 100)
+	// "Translate" instructions mentioning "JSON" parse the input as a string->[]string object and leetify values
+	resp, err = svc.Response(ctx, "Translate as JSON", `{"greeting":["Hello","Hi"],"name":["World"]}`, 100)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"greeting":"H3110","name":"W0r1d"}`, resp.Output)
+	assert.JSONEq(t, `{"greeting":["H3110","H1"],"name":["W0r1d"]}`, resp.Output)
 
 	// invalid JSON input with a JSON translate instruction errors
 	_, err = svc.Response(ctx, "Translate as JSON", "not json", 100)


### PR DESCRIPTION
## Summary
- Switch the test LLM service's `Translate` + `JSON` branch to parse input as `map[string][]string` and leetify each string in every array, matching how translation callers actually shape their JSON payloads.

## Test plan
- [x] `go test ./test/services/`