### PR TITLE
Test LLM translate returns error for value 'error'

### DIFF
--- a/test/services/llm.go
+++ b/test/services/llm.go
@@ -29,11 +29,14 @@ var leetify = strings.NewReplacer(
 	"t", "7", "T", "7",
 ).Replace
 
-func translate(s string) string {
-	if s == "untranslatable" {
-		return "<CANT>"
+func translate(s string) (string, error) {
+	if s == "error" {
+		return "", errors.New("simulated LLM error")
 	}
-	return leetify(s)
+	if s == "untranslatable" {
+		return "<CANT>", nil
+	}
+	return leetify(s), nil
 }
 
 func (s *LLMService) Response(ctx context.Context, instructions, input string, maxTokens int) (*flows.LLMResponse, error) {
@@ -53,14 +56,22 @@ func (s *LLMService) Response(ctx context.Context, instructions, input string, m
 			}
 			for k, vs := range obj {
 				for i, v := range vs {
-					vs[i] = translate(v)
+					tv, err := translate(v)
+					if err != nil {
+						return nil, err
+					}
+					vs[i] = tv
 				}
 				obj[k] = vs
 			}
 			b, _ := json.Marshal(obj)
 			output = string(b)
 		} else {
-			output = translate(input)
+			tv, err := translate(input)
+			if err != nil {
+				return nil, err
+			}
+			output = tv
 		}
 	} else {
 		output = "You asked:\n\n" + instructions + "\n\n" + input

--- a/test/services/llm_test.go
+++ b/test/services/llm_test.go
@@ -41,6 +41,13 @@ func TestLLMService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"a":["H1","<CANT>"]}`, resp.Output)
 
+	// values exactly equal to "error" cause the service to error
+	_, err = svc.Response(ctx, "Translate to Spanish", "error", 100)
+	assert.EqualError(t, err, "simulated LLM error")
+
+	_, err = svc.Response(ctx, "Translate as JSON", `{"a":["Hi","error"]}`, 100)
+	assert.EqualError(t, err, "simulated LLM error")
+
 	// invalid JSON input with a JSON translate instruction errors
 	_, err = svc.Response(ctx, "Translate as JSON", "not json", 100)
 	assert.Error(t, err)


### PR DESCRIPTION
## Summary

Adds a third sentinel to the test \`LLMService\`'s translate path: a value of \`\"error\"\` causes the service to return an error (\`\"simulated LLM error\"\`). Mirrors the existing \`\"untranslatable\"\` → \`<CANT>\` sentinel.

Motivated by translate-style callers that wrap input in a JSON object — the raw \`\\error\` directive only fires on a raw-input prefix, so it's unreachable once the input is marshaled as a JSON map. This gives those callers a way to drive the LLM-service-error path in tests.

## Test plan

- [x] \`go test ./test/services/\`
- [x] \`go test ./...\` (full suite passes)