### PR TITLE
Add roles field to LLM assets

### DIFF
--- a/assets/llm.go
+++ b/assets/llm.go
@@ -9,12 +9,22 @@ import (
 // LLMUUID is the UUID of an LLM
 type LLMUUID uuids.UUID
 
+// LLMRole is a role that an LLM can perform
+type LLMRole string
+
+// different roles that LLMs can perform
+const (
+	LLMRoleTranslation LLMRole = "translation"
+	LLMRoleFlows       LLMRole = "flows"
+)
+
 // LLM is a large language model.
 //
 //	{
 //	  "uuid": "00cc7310-4bb9-473f-851e-39b0880aad78",
 //	  "name": "ChatGPT-4",
-//	  "type": "openai"
+//	  "type": "openai",
+//	  "roles": ["translation", "flows"]
 //	}
 //
 // @asset llm
@@ -22,6 +32,7 @@ type LLM interface {
 	UUID() LLMUUID
 	Name() string
 	Type() string
+	Roles() []LLMRole
 }
 
 // LLMReference is used to reference an LLM

--- a/assets/static/llm.go
+++ b/assets/static/llm.go
@@ -6,17 +6,19 @@ import (
 
 // LLM is a JSON serializable implementation of an LLM asset
 type LLM struct {
-	UUID_ assets.LLMUUID `json:"uuid" validate:"required,uuid"`
-	Name_ string         `json:"name"`
-	Type_ string         `json:"type"`
+	UUID_  assets.LLMUUID   `json:"uuid"  validate:"required,uuid"`
+	Name_  string           `json:"name"`
+	Type_  string           `json:"type"`
+	Roles_ []assets.LLMRole `json:"roles" validate:"min=1,dive,eq=translation|eq=flows"`
 }
 
 // NewLLM creates a new LLM
-func NewLLM(uuid assets.LLMUUID, name string, type_ string) assets.LLM {
+func NewLLM(uuid assets.LLMUUID, name string, type_ string, roles []assets.LLMRole) assets.LLM {
 	return &LLM{
-		UUID_: uuid,
-		Name_: name,
-		Type_: type_,
+		UUID_:  uuid,
+		Name_:  name,
+		Type_:  type_,
+		Roles_: roles,
 	}
 }
 
@@ -28,3 +30,6 @@ func (l *LLM) Name() string { return l.Name_ }
 
 // Type returns the type of this LLM
 func (l *LLM) Type() string { return l.Type_ }
+
+// Roles returns the roles of this LLM
+func (l *LLM) Roles() []assets.LLMRole { return l.Roles_ }

--- a/assets/static/llm_test.go
+++ b/assets/static/llm_test.go
@@ -14,8 +14,10 @@ func TestLLM(t *testing.T) {
 		assets.LLMUUID("37657cf7-5eab-4286-9cb0-bbf270587bad"),
 		"GPT-4",
 		"openai",
+		[]assets.LLMRole{assets.LLMRoleTranslation, assets.LLMRoleFlows},
 	)
 	assert.Equal(t, assets.LLMUUID("37657cf7-5eab-4286-9cb0-bbf270587bad"), llm.UUID())
 	assert.Equal(t, "GPT-4", llm.Name())
 	assert.Equal(t, "openai", llm.Type())
+	assert.Equal(t, []assets.LLMRole{assets.LLMRoleTranslation, assets.LLMRoleFlows}, llm.Roles())
 }

--- a/assets/static/source_test.go
+++ b/assets/static/source_test.go
@@ -58,7 +58,8 @@ var assetsJSON = `{
 		{
 			"uuid": "ae823e89-b0cc-40eb-a711-b8700fe34882",
 			"name": "GPT-4",
-			"type": "openai"
+			"type": "openai",
+			"roles": ["translation", "flows"]
 		}
 	],
 	"optins": [

--- a/flows/actions/call_llm.go
+++ b/flows/actions/call_llm.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/goflow/assets"
@@ -74,6 +75,10 @@ func (a *CallLLM) call(ctx context.Context, run flows.Run, log flows.EventLogger
 	llm := llms.Get(a.LLM.UUID)
 	if llm == nil {
 		log(events.NewDependencyError(a.LLM))
+		return nil
+	}
+	if !llm.HasRole(assets.LLMRoleFlows) {
+		log(events.NewError(fmt.Sprintf("LLM %s does not have the flows role", a.LLM.UUID), ""))
 		return nil
 	}
 

--- a/flows/actions/testdata/_assets.json
+++ b/flows/actions/testdata/_assets.json
@@ -251,12 +251,14 @@
         {
             "uuid": "14115c03-b4c5-49e2-b9ac-390c43e9d7ce",
             "name": "GPT-4",
-            "type": "openai"
+            "type": "openai",
+            "roles": ["translation", "flows"]
         },
         {
             "uuid": "51ade705-8338-40a9-8a77-37657a936966",
             "name": "Claude",
-            "type": "anthropic"
+            "type": "anthropic",
+            "roles": ["translation", "flows"]
         }
     ],
     "optins": [

--- a/flows/engine/assets_test.go
+++ b/flows/engine/assets_test.go
@@ -63,7 +63,8 @@ var assetsJSON = `{
 		{
 			"uuid": "ae823e89-b0cc-40eb-a711-b8700fe34882",
 			"name": "GPT-4",
-			"type": "openai"
+			"type": "openai",
+			"roles": ["translation", "flows"]
 		}
 	],
 	"optins": [

--- a/flows/llm.go
+++ b/flows/llm.go
@@ -1,6 +1,10 @@
 package flows
 
-import "github.com/nyaruka/goflow/assets"
+import (
+	"slices"
+
+	"github.com/nyaruka/goflow/assets"
+)
 
 // LLM represents a large language model.
 type LLM struct {
@@ -18,6 +22,11 @@ func (l *LLM) Asset() assets.LLM { return l.LLM }
 // Reference returns a reference to this LLM
 func (l *LLM) Reference() *assets.LLMReference {
 	return assets.NewLLMReference(l.UUID(), l.Name())
+}
+
+// HasRole returns whether this LLM has the given role
+func (l *LLM) HasRole(role assets.LLMRole) bool {
+	return slices.Contains(l.Roles(), role)
 }
 
 // LLMAssets provides access to all LLM assets

--- a/test/session.go
+++ b/test/session.go
@@ -255,8 +255,8 @@ var sessionAssets = `{
         {"uuid": "3f65d88a-95dc-4140-9451-943e94e06fea", "name": "Spam"}
     ],
     "llms": [
-        {"uuid": "14115c03-b4c5-49e2-b9ac-390c43e9d7ce", "name": "GPT-4", "type": "openai"},
-        {"uuid": "51ade705-8338-40a9-8a77-37657a936966", "name": "Claude", "type": "anthropic"}
+        {"uuid": "14115c03-b4c5-49e2-b9ac-390c43e9d7ce", "name": "GPT-4", "type": "openai", "roles": ["translation", "flows"]},
+        {"uuid": "51ade705-8338-40a9-8a77-37657a936966", "name": "Claude", "type": "anthropic", "roles": ["translation", "flows"]}
     ],
     "locations": [
         {

--- a/test/testdata/runner/llm_categorize.json
+++ b/test/testdata/runner/llm_categorize.json
@@ -189,7 +189,8 @@
         {
             "uuid": "1c06c884-39dd-4ce4-ad9f-9a01cbe6c000",
             "name": "Claude",
-            "type": "anthropic"
+            "type": "anthropic",
+            "roles": ["flows"]
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds a required `roles` field to LLM assets, validated to contain at least one of `translation` or `flows`
- Adds an `LLMRole` type and constants in `assets/llm.go`, plus a `HasRole` helper on `flows.LLM` (mirroring `flows.Channel.HasRole`)
- The `call_llm` action now logs an error and falls back to the existing `<ERROR>` output path if the referenced LLM does not have the `flows` role

## Test plan

- [ ] `go test ./...` passes
- [ ] Confirm callers in mailroom/rapidpro that construct LLM assets pass an appropriate `roles` slice