### PR TITLE
Rename LLM roles translation/flows to editing/engine

### DIFF
--- a/assets/llm.go
+++ b/assets/llm.go
@@ -14,8 +14,8 @@ type LLMRole string
 
 // different roles that LLMs can perform
 const (
-	LLMRoleTranslation LLMRole = "translation"
-	LLMRoleFlows       LLMRole = "flows"
+	LLMRoleEditing LLMRole = "editing"
+	LLMRoleEngine  LLMRole = "engine"
 )
 
 // LLM is a large language model.
@@ -24,7 +24,7 @@ const (
 //	  "uuid": "00cc7310-4bb9-473f-851e-39b0880aad78",
 //	  "name": "ChatGPT-4",
 //	  "type": "openai",
-//	  "roles": ["translation", "flows"]
+//	  "roles": ["editing", "engine"]
 //	}
 //
 // @asset llm

--- a/assets/static/llm.go
+++ b/assets/static/llm.go
@@ -9,7 +9,7 @@ type LLM struct {
 	UUID_  assets.LLMUUID   `json:"uuid"  validate:"required,uuid"`
 	Name_  string           `json:"name"`
 	Type_  string           `json:"type"`
-	Roles_ []assets.LLMRole `json:"roles" validate:"min=1,dive,eq=translation|eq=flows"`
+	Roles_ []assets.LLMRole `json:"roles" validate:"min=1,dive,eq=editing|eq=engine"`
 }
 
 // NewLLM creates a new LLM

--- a/assets/static/llm_test.go
+++ b/assets/static/llm_test.go
@@ -14,10 +14,10 @@ func TestLLM(t *testing.T) {
 		assets.LLMUUID("37657cf7-5eab-4286-9cb0-bbf270587bad"),
 		"GPT-4",
 		"openai",
-		[]assets.LLMRole{assets.LLMRoleTranslation, assets.LLMRoleFlows},
+		[]assets.LLMRole{assets.LLMRoleEditing, assets.LLMRoleEngine},
 	)
 	assert.Equal(t, assets.LLMUUID("37657cf7-5eab-4286-9cb0-bbf270587bad"), llm.UUID())
 	assert.Equal(t, "GPT-4", llm.Name())
 	assert.Equal(t, "openai", llm.Type())
-	assert.Equal(t, []assets.LLMRole{assets.LLMRoleTranslation, assets.LLMRoleFlows}, llm.Roles())
+	assert.Equal(t, []assets.LLMRole{assets.LLMRoleEditing, assets.LLMRoleEngine}, llm.Roles())
 }

--- a/assets/static/source_test.go
+++ b/assets/static/source_test.go
@@ -59,7 +59,7 @@ var assetsJSON = `{
 			"uuid": "ae823e89-b0cc-40eb-a711-b8700fe34882",
 			"name": "GPT-4",
 			"type": "openai",
-			"roles": ["translation", "flows"]
+			"roles": ["editing", "engine"]
 		}
 	],
 	"optins": [

--- a/flows/actions/call_llm.go
+++ b/flows/actions/call_llm.go
@@ -77,8 +77,8 @@ func (a *CallLLM) call(ctx context.Context, run flows.Run, log flows.EventLogger
 		log(events.NewDependencyError(a.LLM))
 		return nil
 	}
-	if !llm.HasRole(assets.LLMRoleFlows) {
-		log(events.NewError(fmt.Sprintf("LLM %s does not have the flows role", a.LLM.UUID), ""))
+	if !llm.HasRole(assets.LLMRoleEngine) {
+		log(events.NewError(fmt.Sprintf("LLM %s does not have the engine role", a.LLM.UUID), ""))
 		return nil
 	}
 

--- a/flows/actions/testdata/_assets.json
+++ b/flows/actions/testdata/_assets.json
@@ -252,13 +252,13 @@
             "uuid": "14115c03-b4c5-49e2-b9ac-390c43e9d7ce",
             "name": "GPT-4",
             "type": "openai",
-            "roles": ["translation", "flows"]
+            "roles": ["editing", "engine"]
         },
         {
             "uuid": "51ade705-8338-40a9-8a77-37657a936966",
             "name": "Claude",
             "type": "anthropic",
-            "roles": ["translation", "flows"]
+            "roles": ["editing", "engine"]
         }
     ],
     "optins": [

--- a/flows/engine/assets_test.go
+++ b/flows/engine/assets_test.go
@@ -64,7 +64,7 @@ var assetsJSON = `{
 			"uuid": "ae823e89-b0cc-40eb-a711-b8700fe34882",
 			"name": "GPT-4",
 			"type": "openai",
-			"roles": ["translation", "flows"]
+			"roles": ["editing", "engine"]
 		}
 	],
 	"optins": [

--- a/test/session.go
+++ b/test/session.go
@@ -255,8 +255,8 @@ var sessionAssets = `{
         {"uuid": "3f65d88a-95dc-4140-9451-943e94e06fea", "name": "Spam"}
     ],
     "llms": [
-        {"uuid": "14115c03-b4c5-49e2-b9ac-390c43e9d7ce", "name": "GPT-4", "type": "openai", "roles": ["translation", "flows"]},
-        {"uuid": "51ade705-8338-40a9-8a77-37657a936966", "name": "Claude", "type": "anthropic", "roles": ["translation", "flows"]}
+        {"uuid": "14115c03-b4c5-49e2-b9ac-390c43e9d7ce", "name": "GPT-4", "type": "openai", "roles": ["editing", "engine"]},
+        {"uuid": "51ade705-8338-40a9-8a77-37657a936966", "name": "Claude", "type": "anthropic", "roles": ["editing", "engine"]}
     ],
     "locations": [
         {

--- a/test/testdata/runner/llm_categorize.json
+++ b/test/testdata/runner/llm_categorize.json
@@ -190,7 +190,7 @@
             "uuid": "1c06c884-39dd-4ce4-ad9f-9a01cbe6c000",
             "name": "Claude",
             "type": "anthropic",
-            "roles": ["flows"]
+            "roles": ["engine"]
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Renames `LLMRoleTranslation` → `LLMRoleEditing` (string `"editing"`) and `LLMRoleFlows` → `LLMRoleEngine` (string `"engine"`).
- Updates the validator tag, doc comment, and all test fixtures.
- Updates the `call_llm` action's role check + error message.

Companion PRs: rapidpro [#6586](https://github.com/nyaruka/rapidpro/pull/6586), and matching changes coming in mailroom.

## Test plan

- [x] `go test ./...` passes