### PR TITLE
Split LLM token usage into input and output

### DIFF
--- a/flows/actions/testdata/call_llm.json
+++ b/flows/actions/testdata/call_llm.json
@@ -86,8 +86,10 @@
                 "instructions": "Categorize the following text as positive or negative",
                 "input": "Hi everybody",
                 "output": "negative",
-                "tokens_input": 45,
-                "tokens_output": 78,
+                "tokens": {
+                    "input": 45,
+                    "output": 78
+                },
                 "elapsed_ms": 1000
             }
         ],

--- a/flows/actions/testdata/call_llm.json
+++ b/flows/actions/testdata/call_llm.json
@@ -86,7 +86,8 @@
                 "instructions": "Categorize the following text as positive or negative",
                 "input": "Hi everybody",
                 "output": "negative",
-                "tokens_used": 123,
+                "tokens_input": 45,
+                "tokens_output": 78,
                 "elapsed_ms": 1000
             }
         ],

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -260,7 +260,7 @@ func TestEventMarshaling(t *testing.T) {
 					gpt4,
 					"Categorize the following text as Positive or Negative",
 					"Please stop messaging me",
-					&flows.LLMResponse{Output: "Positive", TokensUsed: 567},
+					&flows.LLMResponse{Output: "Positive", TokensInput: 234, TokensOutput: 333},
 					123*time.Millisecond,
 				)
 			},

--- a/flows/events/llm_called.go
+++ b/flows/events/llm_called.go
@@ -27,7 +27,8 @@ const TypeLLMCalled string = "llm_called"
 //	  "instructions": "Categorize the following text as Positive or Negative",
 //	  "input": "Please stop messaging me",
 //	  "output": "Positive",
-//	  "tokens_used": 567,
+//	  "tokens_input": 234,
+//	  "tokens_output": 333,
 //	  "elapsed_ms": 123
 //	}
 //
@@ -39,7 +40,8 @@ type LLMCalled struct {
 	Instructions string               `json:"instructions"`
 	Input        string               `json:"input"`
 	Output       string               `json:"output"`
-	TokensUsed   int64                `json:"tokens_used"`
+	TokensInput  int64                `json:"tokens_input"`
+	TokensOutput int64                `json:"tokens_output"`
 	ElapsedMS    int64                `json:"elapsed_ms"`
 }
 
@@ -51,7 +53,8 @@ func NewLLMCalled(llm *flows.LLM, instructions, input string, resp *flows.LLMRes
 		Instructions: instructions,
 		Input:        input,
 		Output:       resp.Output,
-		TokensUsed:   resp.TokensUsed,
+		TokensInput:  resp.TokensInput,
+		TokensOutput: resp.TokensOutput,
 		ElapsedMS:    elapsed.Milliseconds(),
 	}
 }

--- a/flows/events/llm_called.go
+++ b/flows/events/llm_called.go
@@ -27,8 +27,7 @@ const TypeLLMCalled string = "llm_called"
 //	  "instructions": "Categorize the following text as Positive or Negative",
 //	  "input": "Please stop messaging me",
 //	  "output": "Positive",
-//	  "tokens_input": 234,
-//	  "tokens_output": 333,
+//	  "tokens": {"input": 234, "output": 333},
 //	  "elapsed_ms": 123
 //	}
 //
@@ -40,9 +39,13 @@ type LLMCalled struct {
 	Instructions string               `json:"instructions"`
 	Input        string               `json:"input"`
 	Output       string               `json:"output"`
-	TokensInput  int64                `json:"tokens_input"`
-	TokensOutput int64                `json:"tokens_output"`
+	Tokens       LLMTokens            `json:"tokens"`
 	ElapsedMS    int64                `json:"elapsed_ms"`
+}
+
+type LLMTokens struct {
+	Input  int64 `json:"input"`
+	Output int64 `json:"output"`
 }
 
 // NewLLMCalled returns a new LLM called event
@@ -53,8 +56,7 @@ func NewLLMCalled(llm *flows.LLM, instructions, input string, resp *flows.LLMRes
 		Instructions: instructions,
 		Input:        input,
 		Output:       resp.Output,
-		TokensInput:  resp.TokensInput,
-		TokensOutput: resp.TokensOutput,
+		Tokens:       LLMTokens{Input: resp.TokensInput, Output: resp.TokensOutput},
 		ElapsedMS:    elapsed.Milliseconds(),
 	}
 }

--- a/flows/events/testdata/TestEventMarshaling_llm_called.snap
+++ b/flows/events/testdata/TestEventMarshaling_llm_called.snap
@@ -9,7 +9,9 @@
     "instructions": "Categorize the following text as Positive or Negative",
     "input": "Please stop messaging me",
     "output": "Positive",
-    "tokens_input": 234,
-    "tokens_output": 333,
+    "tokens": {
+        "input": 234,
+        "output": 333
+    },
     "elapsed_ms": 123
 }

--- a/flows/events/testdata/TestEventMarshaling_llm_called.snap
+++ b/flows/events/testdata/TestEventMarshaling_llm_called.snap
@@ -9,6 +9,7 @@
     "instructions": "Categorize the following text as Positive or Negative",
     "input": "Please stop messaging me",
     "output": "Positive",
-    "tokens_used": 567,
+    "tokens_input": 234,
+    "tokens_output": 333,
     "elapsed_ms": 123
 }

--- a/flows/services.go
+++ b/flows/services.go
@@ -73,8 +73,9 @@ type ClassificationService interface {
 }
 
 type LLMResponse struct {
-	Output     string
-	TokensUsed int64
+	Output       string
+	TokensInput  int64
+	TokensOutput int64
 }
 
 // LLMService provides LLM functionality to the engine

--- a/test/services/llm.go
+++ b/test/services/llm.go
@@ -77,7 +77,7 @@ func (s *LLMService) Response(ctx context.Context, instructions, input string, m
 		output = "You asked:\n\n" + instructions + "\n\n" + input
 	}
 
-	return &flows.LLMResponse{Output: output, TokensUsed: 123}, nil
+	return &flows.LLMResponse{Output: output, TokensInput: 45, TokensOutput: 78}, nil
 }
 
 var _ flows.LLMService = (*LLMService)(nil)

--- a/test/testdata/runner/llm_categorize.flight.json
+++ b/test/testdata/runner/llm_categorize.flight.json
@@ -115,8 +115,10 @@
                         "uuid": "1c06c884-39dd-4ce4-ad9f-9a01cbe6c000"
                     },
                     "output": "Hotels",
-                    "tokens_input": 45,
-                    "tokens_output": 78,
+                    "tokens": {
+                        "input": 45,
+                        "output": 78
+                    },
                     "type": "llm_called",
                     "uuid": "01969b47-672b-76f8-8dbf-00ecf5d03034"
                 },

--- a/test/testdata/runner/llm_categorize.flight.json
+++ b/test/testdata/runner/llm_categorize.flight.json
@@ -115,7 +115,8 @@
                         "uuid": "1c06c884-39dd-4ce4-ad9f-9a01cbe6c000"
                     },
                     "output": "Hotels",
-                    "tokens_used": 123,
+                    "tokens_input": 45,
+                    "tokens_output": 78,
                     "type": "llm_called",
                     "uuid": "01969b47-672b-76f8-8dbf-00ecf5d03034"
                 },


### PR DESCRIPTION
## Summary
- `LLMResponse` replaces `TokensUsed` with separate `TokensInput` / `TokensOutput` fields
- `llm_called` event JSON now emits `tokens_input` / `tokens_output` instead of `tokens_used`
- All five mailroom LLM service SDKs already return these split counts, so this just stops collapsing them on the way through

This is a breaking change — mailroom's service implementations, `LLM.RecordCall`, the `llm_called` handler, and `web/llm/translate.go` all need a matching update.

## Test plan
- [x] `go test ./...` passes