### PR TITLE
Normalise webhook and resthook split routers to canonical shape

### DIFF
--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -22,8 +22,8 @@ import (
 )
 
 // CurrentSpecVersion is the flow spec version supported by this library
-var CurrentSpecVersion = semver.MustParse("14.4.0")
-var CurrentSupportedSpecs, _ = semver.NewConstraint(">= 11.0.0, < 14.5.0")
+var CurrentSpecVersion = semver.MustParse("14.5.0")
+var CurrentSupportedSpecs, _ = semver.NewConstraint(">= 11.0.0, < 14.6.0")
 
 // IsVersionSupported checks the given version is supported
 func IsVersionSupported(v *semver.Version) bool {

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -34,7 +34,7 @@ func TestIsVersionSupported(t *testing.T) {
 	assert.True(t, definition.IsVersionSupported(semver.MustParse("13.3.0")))
 	assert.True(t, definition.IsVersionSupported(semver.MustParse("14.2.0")))
 	assert.True(t, definition.IsVersionSupported(semver.MustParse("14.3.1")))
-	assert.False(t, definition.IsVersionSupported(semver.MustParse("14.5.0")))
+	assert.False(t, definition.IsVersionSupported(semver.MustParse("14.6.0")))
 	assert.False(t, definition.IsVersionSupported(semver.MustParse("15.0.0")))
 }
 

--- a/flows/definition/migrations/14.x.go
+++ b/flows/definition/migrations/14.x.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
+	"github.com/nyaruka/gocommon/uuids"
 )
 
 func init() {
@@ -25,9 +26,15 @@ func init() {
 // rename) and an early version of temba-components left some flows splitting on @webhook.json.status with a has_text
 // case, which routes 2xx responses to Failure whenever the response body lacks a top-level "status" field.
 //
+// We assume that the first case's category_uuid already points to a "Success" category and that any extra cases'
+// categories are otherwise reachable (e.g. by being the default_category_uuid); this matches every router shape any
+// editor has ever produced for these node types.
+//
 // @version 14_5_0 "14.5.0"
 func Migrate14_5_0(f Flow, cfg *Config) (Flow, error) {
 	webhookActions := []string{"call_webhook", "call_resthook"}
+
+	localization := f.Localization()
 
 	for _, node := range f.Nodes() {
 		actions := node.Actions()
@@ -53,6 +60,24 @@ func Migrate14_5_0(f Flow, cfg *Config) (Flow, error) {
 
 		router["operand"] = "@webhook.status"
 		router["cases"] = []any{case0}
+
+		// drop any localized arguments for the rewritten case or for cases we just dropped - the old translations
+		// referred to text/category values that no longer apply to the numeric HTTP-status check
+		if localization != nil {
+			caseUUIDs := []uuids.UUID{GetObjectUUID(case0)}
+			for _, c := range cases[1:] {
+				caseUUIDs = append(caseUUIDs, GetObjectUUID(c))
+			}
+
+			for _, lang := range localization.Languages() {
+				lt := localization.GetLanguageTranslation(lang)
+				for _, caseUUID := range caseUUIDs {
+					if caseUUID != "" {
+						lt.DeleteTranslation(caseUUID, "arguments")
+					}
+				}
+			}
+		}
 	}
 
 	return f, nil

--- a/flows/definition/migrations/14.x.go
+++ b/flows/definition/migrations/14.x.go
@@ -10,12 +10,52 @@ import (
 )
 
 func init() {
+	registerMigration(semver.MustParse("14.5.0"), Migrate14_5_0)
 	registerMigration(semver.MustParse("14.4.0"), Migrate14_4_0)
 	registerMigration(semver.MustParse("14.3.1"), Migrate14_3_1)
 	registerMigration(semver.MustParse("14.3.0"), Migrate14_3_0)
 	registerMigration(semver.MustParse("14.2.0"), Migrate14_2_0)
 	registerMigration(semver.MustParse("14.1.0"), Migrate14_1_0)
 	registerMigration(semver.MustParse("14.0.0"), Migrate14_0_0)
+}
+
+// Migrate14_5_0 normalises webhook and resthook split routers to the canonical shape: operand @webhook.status with a
+// single has_number_between [200, 299] case targeting the Success category. Editors don't expose the operand or case
+// configuration for these node types, but historical migrations (notably 13.3.0's blind @webhook → @webhook.json
+// rename) and an early version of temba-components left some flows splitting on @webhook.json.status with a has_text
+// case, which routes 2xx responses to Failure whenever the response body lacks a top-level "status" field.
+//
+// @version 14_5_0 "14.5.0"
+func Migrate14_5_0(f Flow, cfg *Config) (Flow, error) {
+	webhookActions := []string{"call_webhook", "call_resthook"}
+
+	for _, node := range f.Nodes() {
+		actions := node.Actions()
+		router := node.Router()
+
+		if len(actions) != 1 || !slices.Contains(webhookActions, actions[0].Type()) || router == nil || router.Type() != "switch" {
+			continue
+		}
+
+		cases, _ := router["cases"].([]any)
+		if len(cases) == 0 {
+			continue
+		}
+		case0, _ := cases[0].(map[string]any)
+		if case0 == nil {
+			continue
+		}
+
+		// rewrite the first case to the canonical HTTP-status check (preserving its UUID and target category) and
+		// drop any further cases - the editor only ever emits a single Success case
+		case0["type"] = "has_number_between"
+		case0["arguments"] = []any{"200", "299"}
+
+		router["operand"] = "@webhook.status"
+		router["cases"] = []any{case0}
+	}
+
+	return f, nil
 }
 
 // Migrate14_4_0 removes the all_urns field from send_msg actions.

--- a/flows/definition/migrations/specdata/templates.json
+++ b/flows/definition/migrations/specdata/templates.json
@@ -1,4 +1,101 @@
 {
+    "14.5.0": {
+        "actions": {
+            "add_contact_groups": [
+                ".groups[*].name_match"
+            ],
+            "add_contact_urn": [
+                ".path"
+            ],
+            "add_input_labels": [
+                ".labels[*].name_match"
+            ],
+            "call_classifier": [
+                ".input"
+            ],
+            "call_llm": [
+                ".input",
+                ".instructions"
+            ],
+            "call_resthook": [],
+            "call_webhook": [
+                ".body",
+                ".headers.*",
+                ".url"
+            ],
+            "enter_flow": [],
+            "open_ticket": [
+                ".assignee.email",
+                ".note"
+            ],
+            "play_audio": [
+                ".audio_url"
+            ],
+            "remove_contact_groups": [
+                ".groups[*].name_match"
+            ],
+            "request_optin": [],
+            "say_msg": [
+                ".text"
+            ],
+            "send_broadcast": [
+                ".attachments[*]",
+                ".contact_query",
+                ".groups[*].name_match",
+                ".legacy_vars[*]",
+                ".quick_replies[*]",
+                ".template_variables[*]",
+                ".text"
+            ],
+            "send_email": [
+                ".addresses[*]",
+                ".body",
+                ".subject"
+            ],
+            "send_msg": [
+                ".attachments[*]",
+                ".quick_replies[*]",
+                ".template_variables[*]",
+                ".text"
+            ],
+            "set_contact_channel": [],
+            "set_contact_field": [
+                ".value"
+            ],
+            "set_contact_language": [
+                ".language"
+            ],
+            "set_contact_name": [
+                ".name"
+            ],
+            "set_contact_status": [],
+            "set_contact_timezone": [
+                ".timezone"
+            ],
+            "set_run_local": [
+                ".value"
+            ],
+            "set_run_result": [
+                ".value"
+            ],
+            "start_session": [
+                ".contact_query",
+                ".groups[*].name_match",
+                ".legacy_vars[*]"
+            ],
+            "transfer_airtime": []
+        },
+        "routers": {
+            "random": [
+                ".operand",
+                ".cases[*].arguments[*]"
+            ],
+            "switch": [
+                ".operand",
+                ".cases[*].arguments[*]"
+            ]
+        }
+    },
     "14.4.0": {
         "actions": {
             "add_contact_groups": [

--- a/flows/definition/migrations/testdata/migrations/14.5.0.json
+++ b/flows/definition/migrations/testdata/migrations/14.5.0.json
@@ -355,6 +355,147 @@
         }
     },
     {
+        "description": "flow with localized case arguments has stale translations dropped",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {
+                "spa": {
+                    "ff810df6-23c2-4dff-9be1-eebffae2bb9d": {
+                        "arguments": [
+                            "exito"
+                        ]
+                    },
+                    "0c3e8410-2316-4bcd-acf6-c5a8a37c5ad0": {
+                        "arguments": [
+                            "fracaso"
+                        ]
+                    }
+                }
+            },
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "headers": {},
+                            "type": "call_webhook",
+                            "url": "http://temba.io/",
+                            "method": "GET"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.json.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_only_text",
+                                "arguments": [
+                                    "success"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            },
+                            {
+                                "uuid": "0c3e8410-2316-4bcd-acf6-c5a8a37c5ad0",
+                                "type": "has_only_text",
+                                "arguments": [
+                                    "failure"
+                                ],
+                                "category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.5.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {
+                "spa": {}
+            },
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "headers": {},
+                            "type": "call_webhook",
+                            "url": "http://temba.io/",
+                            "method": "GET"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
         "description": "non-webhook switch router is not touched",
         "original": {
             "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",

--- a/flows/definition/migrations/testdata/migrations/14.5.0.json
+++ b/flows/definition/migrations/testdata/migrations/14.5.0.json
@@ -1,0 +1,444 @@
+[
+    {
+        "description": "flow with resthook split on @webhook.json.status",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "type": "call_resthook",
+                            "resthook": "new-registration"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.json.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_text",
+                                "arguments": [],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.5.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "type": "call_resthook",
+                            "resthook": "new-registration"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "description": "flow with webhook split on @webhook.json.status and extra case",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "headers": {},
+                            "type": "call_webhook",
+                            "url": "http://temba.io/",
+                            "method": "GET"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.json.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_text",
+                                "arguments": [],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            },
+                            {
+                                "uuid": "0c3e8410-2316-4bcd-acf6-c5a8a37c5ad0",
+                                "type": "has_only_text",
+                                "arguments": [
+                                    "failure"
+                                ],
+                                "category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.5.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "headers": {},
+                            "type": "call_webhook",
+                            "url": "http://temba.io/",
+                            "method": "GET"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "description": "flow with already-canonical webhook split is unchanged",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "headers": {},
+                            "type": "call_webhook",
+                            "url": "http://temba.io/",
+                            "method": "GET"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.5.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "headers": {},
+                            "type": "call_webhook",
+                            "url": "http://temba.io/",
+                            "method": "GET"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "description": "non-webhook switch router is not touched",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@input.text",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_text",
+                                "arguments": [],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "All Responses",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            }
+                        ],
+                        "default_category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                        "wait": {
+                            "type": "msg"
+                        }
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.5.0",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@input.text",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_text",
+                                "arguments": [],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "All Responses",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            }
+                        ],
+                        "default_category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                        "wait": {
+                            "type": "msg"
+                        }
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_ara.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_ara.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "14.4.0",
+    "spec_version": "14.5.0",
     "language": "ara",
     "type": "messaging",
     "revision": 16,

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_kin.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_kin.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "14.4.0",
+    "spec_version": "14.5.0",
     "language": "kin",
     "type": "messaging",
     "revision": 16,

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_spa.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_spa.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "14.4.0",
+    "spec_version": "14.5.0",
     "language": "spa",
     "type": "messaging",
     "revision": 16,


### PR DESCRIPTION
## Summary
- Add flow migration `14.5.0` that rewrites every `call_webhook` / `call_resthook` switch router to the canonical shape: operand `@webhook.status`, single `has_number_between [200, 299]` case targeting the Success category.
- Editors don't expose the operand or case for these node types, so any deviation is migration debris and can be safely overwritten. Two known sources of debris:
  1. **13.3.0** rewrote every `@webhook` expression to `@webhook.json` (preserving the old "body" meaning), which silently corrupted any pre-13.3 router that split on `@webhook.status` (meaning a `status` field in the JSON body at the time) into `@webhook.json.status`. The 14.1.0 cleanup only handled `@results.*` operands, so these were missed.
  2. An early version of `split_by_resthook` in temba-components emitted `@webhook.json.status` + `has_text []` for every newly created resthook node (fixed in [temba-components#1018](https://github.com/nyaruka/temba-components/pull/1018)).
- In both cases the symptom is the same: a 2xx HTTP response with no top-level `status` key in the body routes to Failure.

The case UUID and its target category UUID are preserved across the rewrite; additional cases are dropped (the editor only ever emits one).

## Test plan
- [x] `go test ./flows/definition/migrations/` passes (4 new test cases in `testdata/migrations/14.5.0.json` cover: legacy resthook, legacy webhook with an extra case, already-canonical no-op, unrelated switch router)
- [x] `go test ./...` passes
- [x] Snapshots regenerated for the spec version bump