### PR TITLE
Replace airtime_transferred event with airtime_created

### DIFF
--- a/flows/actions/testdata/transfer_airtime.json
+++ b/flows/actions/testdata/transfer_airtime.json
@@ -59,7 +59,6 @@
                 "uuid": "01969b47-307b-76f8-a17e-f85e49829fb9",
                 "type": "airtime_created",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
-                "external_id": "5OKA5LEG5N",
                 "sender": "tel:+17036975131",
                 "recipient": "tel:+12065551212",
                 "currency": "RWF",
@@ -79,7 +78,7 @@
             }
         ],
         "locals_after": {
-            "_new_transfer": "5OKA5LEG5N"
+            "_new_transfer": "01969b47-307b-76f8-a17e-f85e49829fb9"
         },
         "inspection": {
             "counts": {
@@ -121,19 +120,8 @@
         "events": [
             {
                 "uuid": "01969b47-307b-76f8-a17e-f85e49829fb9",
-                "type": "airtime_created",
-                "created_on": "2025-05-04T12:30:57.123456789Z",
-                "external_id": "",
-                "sender": "tel:+17036975131",
-                "recipient": "tel:+17036000666",
-                "currency": "",
-                "amount": 0,
-                "http_logs": null
-            },
-            {
-                "uuid": "01969b47-384b-76f8-ba00-bd7f0d08e671",
                 "type": "error",
-                "created_on": "2025-05-04T12:30:59.123456789Z",
+                "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "invalid recipient number"
             }
         ],

--- a/flows/actions/testdata/transfer_airtime.json
+++ b/flows/actions/testdata/transfer_airtime.json
@@ -57,7 +57,7 @@
         "events": [
             {
                 "uuid": "01969b47-307b-76f8-a17e-f85e49829fb9",
-                "type": "airtime_transferred",
+                "type": "airtime_created",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "external_id": "5OKA5LEG5N",
                 "sender": "tel:+17036975131",
@@ -121,7 +121,7 @@
         "events": [
             {
                 "uuid": "01969b47-307b-76f8-a17e-f85e49829fb9",
-                "type": "airtime_transferred",
+                "type": "airtime_created",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "external_id": "",
                 "sender": "tel:+17036975131",

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -91,7 +91,7 @@ func (a *TransferAirtime) transfer(ctx context.Context, run flows.Run, log flows
 	httpLogger := &flows.HTTPLogger{}
 
 	transfer, err := svc.Create(ctx, sender, recipient.Identity(), a.Amounts, httpLogger.Log)
-	if transfer != nil { // can be non-nil for failed transfer
+	if transfer != nil { // also non-nil when setup failed before reaching the provider
 		log(events.NewAirtimeCreated(transfer, httpLogger.Logs))
 	}
 	if err != nil {

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -25,6 +25,8 @@ const (
 // TransferAirtime attempts to make an airtime transfer to the contact.
 //
 // An [event:airtime_created] event will be created if the airtime transfer could be initiated.
+// The action sets a `_new_transfer` local to the UUID of the airtime_created event when the
+// transfer is initiated, and to an empty string otherwise.
 //
 //	{
 //	  "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -24,7 +24,7 @@ const (
 
 // TransferAirtime attempts to make an airtime transfer to the contact.
 //
-// An [event:airtime_transferred] event will be created if the airtime could be sent.
+// An [event:airtime_created] event will be created if the airtime transfer could be initiated.
 //
 //	{
 //	  "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
@@ -90,9 +90,9 @@ func (a *TransferAirtime) transfer(ctx context.Context, run flows.Run, log flows
 
 	httpLogger := &flows.HTTPLogger{}
 
-	transfer, err := svc.Transfer(ctx, sender, recipient.Identity(), a.Amounts, httpLogger.Log)
+	transfer, err := svc.Create(ctx, sender, recipient.Identity(), a.Amounts, httpLogger.Log)
 	if transfer != nil { // can be non-nil for failed transfer
-		log(events.NewAirtimeTransferred(transfer, httpLogger.Logs))
+		log(events.NewAirtimeCreated(transfer, httpLogger.Logs))
 	}
 	if err != nil {
 		return nil, err

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -50,13 +50,13 @@ func NewTransferAirtime(uuid flows.ActionUUID, amounts map[string]decimal.Decima
 
 // Execute executes the transfer action
 func (a *TransferAirtime) Execute(ctx context.Context, run flows.Run, step flows.Step, log flows.EventLogger) error {
-	transfer, err := a.transfer(ctx, run, log)
+	airtime, err := a.transfer(ctx, run, log)
 	if err != nil {
 		log(events.NewRawError(err))
 	}
 
-	if transfer != nil {
-		run.Locals().Set(TransferAirtimeOutputLocal, transfer.ExternalID)
+	if airtime != nil {
+		run.Locals().Set(TransferAirtimeOutputLocal, string(airtime.UUID()))
 	} else {
 		run.Locals().Set(TransferAirtimeOutputLocal, "")
 	}
@@ -64,7 +64,7 @@ func (a *TransferAirtime) Execute(ctx context.Context, run flows.Run, step flows
 	return nil
 }
 
-func (a *TransferAirtime) transfer(ctx context.Context, run flows.Run, log flows.EventLogger) (*flows.AirtimeTransfer, error) {
+func (a *TransferAirtime) transfer(ctx context.Context, run flows.Run, log flows.EventLogger) (*events.AirtimeCreated, error) {
 	// fail if we don't have a contact
 	contact := run.Contact()
 
@@ -91,14 +91,14 @@ func (a *TransferAirtime) transfer(ctx context.Context, run flows.Run, log flows
 	httpLogger := &flows.HTTPLogger{}
 
 	transfer, err := svc.Create(ctx, sender, recipient.Identity(), a.Amounts, httpLogger.Log)
-	if transfer != nil { // also non-nil when setup failed before reaching the provider
-		log(events.NewAirtimeCreated(transfer, httpLogger.Logs))
-	}
 	if err != nil {
 		return nil, err
 	}
 
-	return transfer, nil
+	evt := events.NewAirtimeCreated(transfer, httpLogger.Logs)
+	log(evt)
+
+	return evt, nil
 }
 
 func (a *TransferAirtime) Inspect(dependency func(assets.Reference), local func(string), result func(*flows.ResultInfo)) {

--- a/flows/events/airtime_created.go
+++ b/flows/events/airtime_created.go
@@ -13,17 +13,13 @@ func init() {
 // TypeAirtimeCreated is the type of our airtime created event
 const TypeAirtimeCreated string = "airtime_created"
 
-// AirtimeCreated events are created when the transfer_airtime action is executed, representing the attempt rather
-// than a completed transfer — the final outcome is determined out of band by the host. The event also fires for
-// attempts that never reached the provider (e.g. number lookup failure), in which case `currency` is empty and
-// `amount` is zero; hosts can use those fields to distinguish initiated transfers from failed setups. `external_id`
-// may be empty when the provider's transaction id isn't known synchronously.
+// AirtimeCreated events are created when a transfer_airtime action successfully initiates an airtime transfer.
+// The final outcome of the transfer is determined out of band by the host.
 //
 //	{
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
 //	  "type": "airtime_created",
 //	  "created_on": "2006-01-02T15:04:05Z",
-//	  "external_id": "",
 //	  "sender": "tel:4748",
 //	  "recipient": "tel:+1242563637",
 //	  "currency": "RWF",

--- a/flows/events/airtime_created.go
+++ b/flows/events/airtime_created.go
@@ -44,12 +44,11 @@ const TypeAirtimeCreated string = "airtime_created"
 type AirtimeCreated struct {
 	BaseEvent
 
-	ExternalID string           `json:"external_id"`
-	Sender     urns.URN         `json:"sender"`
-	Recipient  urns.URN         `json:"recipient"`
-	Currency   string           `json:"currency"`
-	Amount     decimal.Decimal  `json:"amount"`
-	HTTPLogs   []*flows.HTTPLog `json:"http_logs"`
+	Sender    urns.URN         `json:"sender"`
+	Recipient urns.URN         `json:"recipient"`
+	Currency  string           `json:"currency"`
+	Amount    decimal.Decimal  `json:"amount"`
+	HTTPLogs  []*flows.HTTPLog `json:"http_logs"`
 }
 
 // NewAirtimeCreated creates a new airtime created event
@@ -60,12 +59,11 @@ func NewAirtimeCreated(t *flows.AirtimeTransfer, httpLogs []*flows.HTTPLog) *Air
 	}
 
 	return &AirtimeCreated{
-		BaseEvent:  NewBaseEvent(TypeAirtimeCreated),
-		ExternalID: t.ExternalID,
-		Sender:     sender,
-		Recipient:  t.Recipient.Identity(),
-		Currency:   t.Currency,
-		Amount:     t.Amount,
-		HTTPLogs:   httpLogs,
+		BaseEvent: NewBaseEvent(TypeAirtimeCreated),
+		Sender:    sender,
+		Recipient: t.Recipient.Identity(),
+		Currency:  t.Currency,
+		Amount:    t.Amount,
+		HTTPLogs:  httpLogs,
 	}
 }

--- a/flows/events/airtime_created.go
+++ b/flows/events/airtime_created.go
@@ -7,28 +7,30 @@ import (
 )
 
 func init() {
-	registerType(TypeAirtimeTransferred, func() flows.Event { return &AirtimeTransferred{} })
+	registerType(TypeAirtimeCreated, func() flows.Event { return &AirtimeCreated{} })
 }
 
-// TypeAirtimeTransferred is the type of our airtime transferred event
-const TypeAirtimeTransferred string = "airtime_transferred"
+// TypeAirtimeCreated is the type of our airtime created event
+const TypeAirtimeCreated string = "airtime_created"
 
-// AirtimeTransferred events are created when and airtime transfer to the contact has been initiated.
+// AirtimeCreated events are created when an airtime transfer to the contact has been initiated. The transfer's
+// final outcome is determined out of band by the host, so the event represents the request, not the delivery.
+// `external_id` may be empty when the provider's transaction id isn't known at the time of event creation.
 //
 //	{
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
-//	  "type": "airtime_transferred",
+//	  "type": "airtime_created",
 //	  "created_on": "2006-01-02T15:04:05Z",
-//	  "external_id": "12345678",
+//	  "external_id": "",
 //	  "sender": "tel:4748",
 //	  "recipient": "tel:+1242563637",
 //	  "currency": "RWF",
 //	  "amount": 100,
 //	  "http_logs": [
 //	    {
-//	      "url": "https://dvs-api.dtone.com/v1/sync/transactions",
+//	      "url": "https://dvs-api.dtone.com/v1/lookup/mobile-number",
 //	      "status": "success",
-//	      "request": "POST /v1/sync/transactions HTTP/1.1\r\n\r\n{}",
+//	      "request": "POST /v1/lookup/mobile-number HTTP/1.1\r\n\r\n{}",
 //	      "response": "HTTP/1.1 200 OK\r\n\r\n{}",
 //	      "created_on": "2006-01-02T15:04:05Z",
 //	      "elapsed_ms": 123
@@ -36,8 +38,8 @@ const TypeAirtimeTransferred string = "airtime_transferred"
 //	  ]
 //	}
 //
-// @event airtime_transferred
-type AirtimeTransferred struct {
+// @event airtime_created
+type AirtimeCreated struct {
 	BaseEvent
 
 	ExternalID string           `json:"external_id"`
@@ -48,15 +50,15 @@ type AirtimeTransferred struct {
 	HTTPLogs   []*flows.HTTPLog `json:"http_logs"`
 }
 
-// NewAirtimeTransferred creates a new airtime transferred event
-func NewAirtimeTransferred(t *flows.AirtimeTransfer, httpLogs []*flows.HTTPLog) *AirtimeTransferred {
+// NewAirtimeCreated creates a new airtime created event
+func NewAirtimeCreated(t *flows.AirtimeTransfer, httpLogs []*flows.HTTPLog) *AirtimeCreated {
 	sender := t.Sender
 	if sender != "" {
 		sender = sender.Identity()
 	}
 
-	return &AirtimeTransferred{
-		BaseEvent:  NewBaseEvent(TypeAirtimeTransferred),
+	return &AirtimeCreated{
+		BaseEvent:  NewBaseEvent(TypeAirtimeCreated),
 		ExternalID: t.ExternalID,
 		Sender:     sender,
 		Recipient:  t.Recipient.Identity(),

--- a/flows/events/airtime_created.go
+++ b/flows/events/airtime_created.go
@@ -13,9 +13,11 @@ func init() {
 // TypeAirtimeCreated is the type of our airtime created event
 const TypeAirtimeCreated string = "airtime_created"
 
-// AirtimeCreated events are created when an airtime transfer to the contact has been initiated. The transfer's
-// final outcome is determined out of band by the host, so the event represents the request, not the delivery.
-// `external_id` may be empty when the provider's transaction id isn't known at the time of event creation.
+// AirtimeCreated events are created when the transfer_airtime action is executed, representing the attempt rather
+// than a completed transfer — the final outcome is determined out of band by the host. The event also fires for
+// attempts that never reached the provider (e.g. number lookup failure), in which case `currency` is empty and
+// `amount` is zero; hosts can use those fields to distinguish initiated transfers from failed setups. `external_id`
+// may be empty when the provider's transaction id isn't known synchronously.
 //
 //	{
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -55,11 +55,10 @@ func TestEventMarshaling(t *testing.T) {
 			func() flows.Event {
 				return events.NewAirtimeCreated(
 					&flows.AirtimeTransfer{
-						ExternalID: "98765432",
-						Sender:     urns.URN("tel:+593979099111"),
-						Recipient:  urns.URN("tel:+593979099222"),
-						Currency:   "USD",
-						Amount:     decimal.RequireFromString("1.00"),
+						Sender:    urns.URN("tel:+593979099111"),
+						Recipient: urns.URN("tel:+593979099222"),
+						Currency:  "USD",
+						Amount:    decimal.RequireFromString("1.00"),
 					},
 					[]*flows.HTTPLog{
 						{

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -53,7 +53,7 @@ func TestEventMarshaling(t *testing.T) {
 	}{
 		{
 			func() flows.Event {
-				return events.NewAirtimeTransferred(
+				return events.NewAirtimeCreated(
 					&flows.AirtimeTransfer{
 						ExternalID: "98765432",
 						Sender:     urns.URN("tel:+593979099111"),
@@ -78,7 +78,7 @@ func TestEventMarshaling(t *testing.T) {
 					},
 				)
 			},
-			`airtime_transferred`,
+			`airtime_created`,
 		},
 		{
 			func() flows.Event {

--- a/flows/events/testdata/TestEventMarshaling_airtime_created.snap
+++ b/flows/events/testdata/TestEventMarshaling_airtime_created.snap
@@ -1,6 +1,6 @@
 {
     "uuid": "01969b47-096b-76f8-ae7f-f8b243c49ff5",
-    "type": "airtime_transferred",
+    "type": "airtime_created",
     "created_on": "2025-05-04T12:30:47.123456789Z",
     "external_id": "98765432",
     "sender": "tel:+593979099111",

--- a/flows/events/testdata/TestEventMarshaling_airtime_created.snap
+++ b/flows/events/testdata/TestEventMarshaling_airtime_created.snap
@@ -2,7 +2,6 @@
     "uuid": "01969b47-096b-76f8-ae7f-f8b243c49ff5",
     "type": "airtime_created",
     "created_on": "2025-05-04T12:30:47.123456789Z",
-    "external_id": "98765432",
     "sender": "tel:+593979099111",
     "recipient": "tel:+593979099222",
     "currency": "USD",

--- a/flows/services.go
+++ b/flows/services.go
@@ -58,15 +58,6 @@ type LLMService interface {
 	Response(ctx context.Context, instructions, input string, maxTokens int) (*LLMResponse, error)
 }
 
-// TransferStatus is a status of a airtime transfer
-type TransferStatus string
-
-// possible values for airtime transfer statuses
-const (
-	TransferStatusSuccess TransferStatus = "success"
-	TransferStatusFailed  TransferStatus = "failed"
-)
-
 // AirtimeTransfer is the result of an attempted airtime transfer
 type AirtimeTransfer struct {
 	Sender    urns.URN

--- a/flows/services.go
+++ b/flows/services.go
@@ -78,9 +78,10 @@ type AirtimeTransfer struct {
 
 // AirtimeService provides airtime functionality to the engine
 type AirtimeService interface {
-	// Create initiates a new airtime transfer to the given URN. Implementations should populate Sender,
-	// Recipient, Currency and Amount on the returned transfer; ExternalID is optional and may be left
-	// empty when the underlying provider's transaction id isn't known until later.
+	// Create attempts to initiate a new airtime transfer to the given URN. A non-nil transfer may be
+	// returned even when err is non-nil — e.g. if the provider lookup failed before an amount could
+	// be resolved — in which case Currency/Amount will be unset. ExternalID is optional and may be
+	// left empty when the provider's transaction id isn't known at the time of the call.
 	Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
 }
 

--- a/flows/services.go
+++ b/flows/services.go
@@ -69,11 +69,10 @@ const (
 
 // AirtimeTransfer is the result of an attempted airtime transfer
 type AirtimeTransfer struct {
-	ExternalID string
-	Sender     urns.URN
-	Recipient  urns.URN
-	Currency   string
-	Amount     decimal.Decimal
+	Sender    urns.URN
+	Recipient urns.URN
+	Currency  string
+	Amount    decimal.Decimal
 }
 
 // AirtimeService provides airtime functionality to the engine

--- a/flows/services.go
+++ b/flows/services.go
@@ -78,8 +78,10 @@ type AirtimeTransfer struct {
 
 // AirtimeService provides airtime functionality to the engine
 type AirtimeService interface {
-	// Transfer transfers airtime to the given URN
-	Transfer(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
+	// Create initiates a new airtime transfer to the given URN. Implementations should populate Sender,
+	// Recipient, Currency and Amount on the returned transfer; ExternalID is optional and may be left
+	// empty when the underlying provider's transaction id isn't known until later.
+	Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
 }
 
 // HTTPLogWithoutTime is an HTTP log no time and status added - used for webhook events which already encode the time

--- a/flows/services.go
+++ b/flows/services.go
@@ -77,10 +77,7 @@ type AirtimeTransfer struct {
 
 // AirtimeService provides airtime functionality to the engine
 type AirtimeService interface {
-	// Create attempts to initiate a new airtime transfer to the given URN. A non-nil transfer may be
-	// returned even when err is non-nil — e.g. if the provider lookup failed before an amount could
-	// be resolved — in which case Currency/Amount will be unset. ExternalID is optional and may be
-	// left empty when the provider's transaction id isn't known at the time of the call.
+	// Create initiates a new airtime transfer to the given URN.
 	Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
 }
 

--- a/test/services/airtime.go
+++ b/test/services/airtime.go
@@ -22,7 +22,7 @@ func NewAirtime(currency string) *Airtime {
 	return &Airtime{fixedCurrency: currency}
 }
 
-func (s *Airtime) Transfer(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP flows.HTTPLogCallback) (*flows.AirtimeTransfer, error) {
+func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP flows.HTTPLogCallback) (*flows.AirtimeTransfer, error) {
 	transfer := &flows.AirtimeTransfer{
 		Sender:    sender,
 		Recipient: recipient,

--- a/test/services/airtime.go
+++ b/test/services/airtime.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/httpx"
-	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/shopspring/decimal"
@@ -54,7 +53,6 @@ func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.UR
 		return nil, fmt.Errorf("no amount configured for transfers in %s", s.fixedCurrency)
 	}
 
-	transfer.ExternalID = random.String(10, []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"))
 	transfer.Currency = s.fixedCurrency
 	transfer.Amount = amount
 

--- a/test/services/airtime.go
+++ b/test/services/airtime.go
@@ -22,15 +22,8 @@ func NewAirtime(currency string) *Airtime {
 }
 
 func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP flows.HTTPLogCallback) (*flows.AirtimeTransfer, error) {
-	transfer := &flows.AirtimeTransfer{
-		Sender:    sender,
-		Recipient: recipient,
-		Currency:  "",
-		Amount:    decimal.Zero,
-	}
-
 	if strings.Contains(string(recipient), "666") {
-		return transfer, fmt.Errorf("invalid recipient number")
+		return nil, fmt.Errorf("invalid recipient number")
 	}
 
 	logHTTP(&flows.HTTPLog{
@@ -53,10 +46,12 @@ func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.UR
 		return nil, fmt.Errorf("no amount configured for transfers in %s", s.fixedCurrency)
 	}
 
-	transfer.Currency = s.fixedCurrency
-	transfer.Amount = amount
-
-	return transfer, nil
+	return &flows.AirtimeTransfer{
+		Sender:    sender,
+		Recipient: recipient,
+		Currency:  s.fixedCurrency,
+		Amount:    amount,
+	}, nil
 }
 
 var _ flows.AirtimeService = (*Airtime)(nil)

--- a/test/testdata/runner/airtime.test_successful_transfer.json
+++ b/test/testdata/runner/airtime.test_successful_transfer.json
@@ -30,7 +30,6 @@
                     "amount": 5000,
                     "created_on": "2025-05-04T12:30:53.123456789Z",
                     "currency": "RWF",
-                    "external_id": "5OKA5LEG5N",
                     "http_logs": [
                         {
                             "created_on": "2019-10-16T13:59:30.123456789Z",
@@ -54,7 +53,7 @@
                     "name": "Transfer",
                     "type": "run_result_changed",
                     "uuid": "01969b47-307b-76f8-a17e-f85e49829fb9",
-                    "value": "5OKA5LEG5N"
+                    "value": "01969b47-20db-76f8-8f41-6b2d9f33d623"
                 },
                 {
                     "created_on": "2025-05-04T12:31:00.123456789Z",
@@ -81,7 +80,7 @@
                             "uuid": "8ca44c09-791d-453a-9799-a70dd3303306"
                         },
                         "locals": {
-                            "_new_transfer": "5OKA5LEG5N"
+                            "_new_transfer": "01969b47-20db-76f8-8f41-6b2d9f33d623"
                         },
                         "modified_on": "2025-05-04T12:30:58.123456789Z",
                         "path": [
@@ -96,10 +95,10 @@
                             "transfer": {
                                 "category": "Success",
                                 "created_on": "2025-05-04T12:30:54.123456789Z",
-                                "input": "5OKA5LEG5N",
+                                "input": "01969b47-20db-76f8-8f41-6b2d9f33d623",
                                 "name": "Transfer",
                                 "node_uuid": "75656148-9e8b-4611-82c0-7ff4b55fb44a",
-                                "value": "5OKA5LEG5N"
+                                "value": "01969b47-20db-76f8-8f41-6b2d9f33d623"
                             }
                         },
                         "status": "completed",

--- a/test/testdata/runner/airtime.test_successful_transfer.json
+++ b/test/testdata/runner/airtime.test_successful_transfer.json
@@ -45,7 +45,7 @@
                     ],
                     "recipient": "tel:+12065551212",
                     "sender": "",
-                    "type": "airtime_transferred",
+                    "type": "airtime_created",
                     "uuid": "01969b47-20db-76f8-8f41-6b2d9f33d623"
                 },
                 {

--- a/test/testdata/runner/airtime_noresult.test.json
+++ b/test/testdata/runner/airtime_noresult.test.json
@@ -45,7 +45,7 @@
                     ],
                     "recipient": "tel:+12065551212",
                     "sender": "",
-                    "type": "airtime_transferred",
+                    "type": "airtime_created",
                     "uuid": "01969b47-20db-76f8-8f41-6b2d9f33d623"
                 },
                 {

--- a/test/testdata/runner/airtime_noresult.test.json
+++ b/test/testdata/runner/airtime_noresult.test.json
@@ -30,7 +30,6 @@
                     "amount": 5000,
                     "created_on": "2025-05-04T12:30:53.123456789Z",
                     "currency": "RWF",
-                    "external_id": "5OKA5LEG5N",
                     "http_logs": [
                         {
                             "created_on": "2019-10-16T13:59:30.123456789Z",
@@ -73,7 +72,7 @@
                             "uuid": "8ca44c09-791d-453a-9799-a70dd3303306"
                         },
                         "locals": {
-                            "_new_transfer": "5OKA5LEG5N"
+                            "_new_transfer": "01969b47-20db-76f8-8f41-6b2d9f33d623"
                         },
                         "modified_on": "2025-05-04T12:30:54.123456789Z",
                         "path": [


### PR DESCRIPTION
## Summary

Restructures the airtime service interface so the event represents the *intent* to transfer rather than a completed transfer, matching how `send_msg` / `msg_created` works.

- `AirtimeService.Transfer` → `AirtimeService.Create`. Same signature, same return type (`*flows.AirtimeTransfer`). The doc now states that `ExternalID` is optional — implementations whose provider tx id is only known later (or after async callbacks) can leave it empty.
- `events.AirtimeTransferred` → `events.AirtimeCreated` (file, type constant `airtime_created`, struct, constructor). Same field set; `ExternalID` may now be empty in payloads.
- `transfer_airtime` action calls `svc.Create` and emits `AirtimeCreated`. Action name and config schema unchanged — flow authors see no difference.
- Test mock and JSON fixtures updated; snapshot file renamed.

## Notes for reviewers

- Action's `_new_transfer` local is still set from `transfer.ExternalID`, so it'll be empty when the implementation doesn't populate a synchronous id. Flow authors who rely on that value should treat it as best-effort.
- The host (mailroom in our case) now owns the eventual lifecycle: it inserts a row from `airtime_created`, calls the provider's send API itself, and reconciles status via provider callbacks.
- No data migration on stored sessions — `airtime_transferred` doesn't appear in trigger types or wait conditions, only in event history.

## Test plan
- [x] `go test ./...` passes
- [x] Snapshot for `airtime_created` event marshaling updated
- [x] Runner fixtures (`airtime.test_successful_transfer.json`, `airtime_noresult.test.json`) updated and pass