### PR TITLE
Re-add ExternalID to airtime transfer for the provider transaction id

### DIFF
--- a/flows/actions/testdata/transfer_airtime.json
+++ b/flows/actions/testdata/transfer_airtime.json
@@ -59,6 +59,7 @@
                 "uuid": "01969b47-307b-76f8-a17e-f85e49829fb9",
                 "type": "airtime_created",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
+                "external_id": "5OKA5LEG5N",
                 "sender": "tel:+17036975131",
                 "recipient": "tel:+12065551212",
                 "currency": "RWF",

--- a/flows/events/airtime_created.go
+++ b/flows/events/airtime_created.go
@@ -14,12 +14,14 @@ func init() {
 const TypeAirtimeCreated string = "airtime_created"
 
 // AirtimeCreated events are created when a transfer_airtime action successfully initiates an airtime transfer.
-// The final outcome of the transfer is determined out of band by the host.
+// The final outcome of the transfer is determined out of band by the host. `external_id` carries the
+// provider's transaction id when it's known at initiation time, otherwise it's empty.
 //
 //	{
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
 //	  "type": "airtime_created",
 //	  "created_on": "2006-01-02T15:04:05Z",
+//	  "external_id": "2237512891",
 //	  "sender": "tel:4748",
 //	  "recipient": "tel:+1242563637",
 //	  "currency": "RWF",
@@ -40,11 +42,12 @@ const TypeAirtimeCreated string = "airtime_created"
 type AirtimeCreated struct {
 	BaseEvent
 
-	Sender    urns.URN         `json:"sender"`
-	Recipient urns.URN         `json:"recipient"`
-	Currency  string           `json:"currency"`
-	Amount    decimal.Decimal  `json:"amount"`
-	HTTPLogs  []*flows.HTTPLog `json:"http_logs"`
+	ExternalID string           `json:"external_id"`
+	Sender     urns.URN         `json:"sender"`
+	Recipient  urns.URN         `json:"recipient"`
+	Currency   string           `json:"currency"`
+	Amount     decimal.Decimal  `json:"amount"`
+	HTTPLogs   []*flows.HTTPLog `json:"http_logs"`
 }
 
 // NewAirtimeCreated creates a new airtime created event
@@ -55,11 +58,12 @@ func NewAirtimeCreated(t *flows.AirtimeTransfer, httpLogs []*flows.HTTPLog) *Air
 	}
 
 	return &AirtimeCreated{
-		BaseEvent: NewBaseEvent(TypeAirtimeCreated),
-		Sender:    sender,
-		Recipient: t.Recipient.Identity(),
-		Currency:  t.Currency,
-		Amount:    t.Amount,
-		HTTPLogs:  httpLogs,
+		BaseEvent:  NewBaseEvent(TypeAirtimeCreated),
+		ExternalID: t.ExternalID,
+		Sender:     sender,
+		Recipient:  t.Recipient.Identity(),
+		Currency:   t.Currency,
+		Amount:     t.Amount,
+		HTTPLogs:   httpLogs,
 	}
 }

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -55,10 +55,11 @@ func TestEventMarshaling(t *testing.T) {
 			func() flows.Event {
 				return events.NewAirtimeCreated(
 					&flows.AirtimeTransfer{
-						Sender:    urns.URN("tel:+593979099111"),
-						Recipient: urns.URN("tel:+593979099222"),
-						Currency:  "USD",
-						Amount:    decimal.RequireFromString("1.00"),
+						ExternalID: "98765432",
+						Sender:     urns.URN("tel:+593979099111"),
+						Recipient:  urns.URN("tel:+593979099222"),
+						Currency:   "USD",
+						Amount:     decimal.RequireFromString("1.00"),
 					},
 					[]*flows.HTTPLog{
 						{

--- a/flows/events/testdata/TestEventMarshaling_airtime_created.snap
+++ b/flows/events/testdata/TestEventMarshaling_airtime_created.snap
@@ -2,6 +2,7 @@
     "uuid": "01969b47-096b-76f8-ae7f-f8b243c49ff5",
     "type": "airtime_created",
     "created_on": "2025-05-04T12:30:47.123456789Z",
+    "external_id": "98765432",
     "sender": "tel:+593979099111",
     "recipient": "tel:+593979099222",
     "currency": "USD",

--- a/flows/services.go
+++ b/flows/services.go
@@ -60,10 +60,11 @@ type LLMService interface {
 
 // AirtimeTransfer is the result of an attempted airtime transfer
 type AirtimeTransfer struct {
-	Sender    urns.URN
-	Recipient urns.URN
-	Currency  string
-	Amount    decimal.Decimal
+	ExternalID string // provider transaction id, when known after initiation
+	Sender     urns.URN
+	Recipient  urns.URN
+	Currency   string
+	Amount     decimal.Decimal
 }
 
 // AirtimeService provides airtime functionality to the engine

--- a/test/services/airtime.go
+++ b/test/services/airtime.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/shopspring/decimal"
@@ -47,10 +48,11 @@ func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.UR
 	}
 
 	return &flows.AirtimeTransfer{
-		Sender:    sender,
-		Recipient: recipient,
-		Currency:  s.fixedCurrency,
-		Amount:    amount,
+		ExternalID: random.String(10, []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")),
+		Sender:     sender,
+		Recipient:  recipient,
+		Currency:   s.fixedCurrency,
+		Amount:     amount,
 	}, nil
 }
 

--- a/test/testdata/runner/airtime.test_successful_transfer.json
+++ b/test/testdata/runner/airtime.test_successful_transfer.json
@@ -30,6 +30,7 @@
                     "amount": 5000,
                     "created_on": "2025-05-04T12:30:53.123456789Z",
                     "currency": "RWF",
+                    "external_id": "5OKA5LEG5N",
                     "http_logs": [
                         {
                             "created_on": "2019-10-16T13:59:30.123456789Z",

--- a/test/testdata/runner/airtime_noresult.test.json
+++ b/test/testdata/runner/airtime_noresult.test.json
@@ -30,6 +30,7 @@
                     "amount": 5000,
                     "created_on": "2025-05-04T12:30:53.123456789Z",
                     "currency": "RWF",
+                    "external_id": "5OKA5LEG5N",
                     "http_logs": [
                         {
                             "created_on": "2019-10-16T13:59:30.123456789Z",


### PR DESCRIPTION
## Summary

Re-adds the `ExternalID` field to `flows.AirtimeTransfer` and `events.AirtimeCreated`, scoped to "the provider's transaction id when it's known at initiation time."

Context: this field was previously removed in #1517 because under the old `auto_confirm: true` design it was ambiguous (empty might mean "no transfer attempted" or "provider id not synchronous"). With airtime providers that surface a synchronous transaction id at create time (e.g. DT One's `auto_confirm: false` path), the ambiguity goes away — `ExternalID` is always populated on successful initiation. Hosts want it on the event so the dynamo history record carries it without needing a postgres lookup.

## Notes for reviewers

- `AirtimeTransfer` is the goflow-facing return value from `AirtimeService.Create`. Implementations populate `ExternalID` when their API returns a sync id; otherwise leave it empty.
- The action's `_new_transfer` local stays the event UUID — no flow-author-facing change.
- Test mock generates a random string so the round-trip is exercised end-to-end.

## Test plan
- [x] `go test ./...` passes
- [x] Fixtures regenerated with `-update` (event marshaling snapshot, transfer_airtime action testdata, runner airtime fixtures)