### PR TITLE
Add Confirm to AirtimeService interface

### DIFF
--- a/flows/services.go
+++ b/flows/services.go
@@ -69,8 +69,18 @@ type AirtimeTransfer struct {
 
 // AirtimeService provides airtime functionality to the engine
 type AirtimeService interface {
-	// Create initiates a new airtime transfer to the given URN.
+	// Create initiates a new airtime transfer to the given URN. For providers with a two-step lifecycle,
+	// this submits the transaction in an unconfirmed state and returns its identifier in ExternalID; the
+	// host then calls Confirm to actually trigger the send. For providers that initiate immediately, this
+	// method does the send and Confirm is a no-op.
 	Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
+
+	// Confirm completes initiation of a transfer previously surfaced by Create. The externalID is the
+	// provider's transaction id (the same value Create returned on AirtimeTransfer.ExternalID). Hosts
+	// typically call Confirm after the session commits, so the airtime is only actually sent once the
+	// surrounding work is durably recorded. Implementations whose Create method already triggers the
+	// send should make Confirm a no-op.
+	Confirm(ctx context.Context, externalID string, logHTTP HTTPLogCallback) error
 }
 
 // HTTPLogWithoutTime is an HTTP log no time and status added - used for webhook events which already encode the time

--- a/flows/services.go
+++ b/flows/services.go
@@ -79,6 +79,16 @@ type AirtimeService interface {
 	// Confirm after the session commits, so the airtime is only actually sent once the surrounding work
 	// is durably recorded. Implementations whose Create already triggers the send should make Confirm a
 	// no-op.
+	//
+	// The transfer argument is the value Create returned. Implementations are expected to use whichever
+	// fields they need (typically ExternalID) to address the provider transaction. Confirm should only be
+	// invoked for transfers that Create returned without error; hosts should not call Confirm on a
+	// partially-populated transfer left over from a failed Create.
+	//
+	// Confirm is not required to be idempotent — implementations may return an error on a duplicate
+	// confirmation. Hosts that need at-most-once delivery semantics should ensure Confirm is called at
+	// most once per transfer. On error, the airtime was not sent; hosts are responsible for surfacing
+	// that to their users.
 	Confirm(ctx context.Context, transfer *AirtimeTransfer, logHTTP HTTPLogCallback) error
 }
 

--- a/flows/services.go
+++ b/flows/services.go
@@ -75,12 +75,11 @@ type AirtimeService interface {
 	// method does the send and Confirm is a no-op.
 	Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
 
-	// Confirm completes initiation of a transfer previously surfaced by Create. The externalID is the
-	// provider's transaction id (the same value Create returned on AirtimeTransfer.ExternalID). Hosts
-	// typically call Confirm after the session commits, so the airtime is only actually sent once the
-	// surrounding work is durably recorded. Implementations whose Create method already triggers the
-	// send should make Confirm a no-op.
-	Confirm(ctx context.Context, externalID string, logHTTP HTTPLogCallback) error
+	// Confirm completes initiation of a transfer previously surfaced by Create. Hosts typically call
+	// Confirm after the session commits, so the airtime is only actually sent once the surrounding work
+	// is durably recorded. Implementations whose Create already triggers the send should make Confirm a
+	// no-op.
+	Confirm(ctx context.Context, transfer *AirtimeTransfer, logHTTP HTTPLogCallback) error
 }
 
 // HTTPLogWithoutTime is an HTTP log no time and status added - used for webhook events which already encode the time

--- a/test/services/airtime.go
+++ b/test/services/airtime.go
@@ -57,7 +57,7 @@ func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.UR
 }
 
 // Confirm is a no-op for the test service — Create returned the transfer ready to go.
-func (s *Airtime) Confirm(ctx context.Context, externalID string, logHTTP flows.HTTPLogCallback) error {
+func (s *Airtime) Confirm(ctx context.Context, transfer *flows.AirtimeTransfer, logHTTP flows.HTTPLogCallback) error {
 	return nil
 }
 

--- a/test/services/airtime.go
+++ b/test/services/airtime.go
@@ -56,4 +56,9 @@ func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.UR
 	}, nil
 }
 
+// Confirm is a no-op for the test service — Create returned the transfer ready to go.
+func (s *Airtime) Confirm(ctx context.Context, externalID string, logHTTP flows.HTTPLogCallback) error {
+	return nil
+}
+
 var _ flows.AirtimeService = (*Airtime)(nil)

--- a/test/services/airtime_test.go
+++ b/test/services/airtime_test.go
@@ -1,0 +1,32 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/test/services"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAirtimeService(t *testing.T) {
+	ctx := context.Background()
+	svc := services.NewAirtime("USD")
+
+	transfer, err := svc.Create(ctx, urns.URN("tel:+12025550100"), urns.URN("tel:+12025550101"), map[string]decimal.Decimal{
+		"USD": decimal.RequireFromString("3"),
+	}, func(*flows.HTTPLog) {})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, transfer.ExternalID)
+	assert.Equal(t, "USD", transfer.Currency)
+
+	// Confirm is a no-op on this mock — returns nil without touching the transfer
+	err = svc.Confirm(ctx, transfer, func(*flows.HTTPLog) {})
+	assert.NoError(t, err)
+
+	// recipients containing "666" cause Create to fail (used by other tests)
+	_, err = svc.Create(ctx, urns.NilURN, urns.URN("tel:+1666"), map[string]decimal.Decimal{"USD": decimal.RequireFromString("3")}, func(*flows.HTTPLog) {})
+	assert.EqualError(t, err, "invalid recipient number")
+}


### PR DESCRIPTION
## Summary

Adds a `Confirm` method to `flows.AirtimeService` so hosts that want airtime delivery to happen only after a surrounding commit have a contracted way to express that.

- Implementations that need a two-step lifecycle (e.g. DT One via `auto_confirm: false`) put the actual provider trigger in `Confirm`.
- Implementations whose `Create` already initiates the send make `Confirm` a no-op.
- `Confirm` is not called by goflow itself — it's part of the contract that the host (mailroom in this repo's case) invokes post-commit. Keeping it on the goflow interface avoids hosts having to define their own provider-wrapper interfaces just to add this one method.

## Notes for reviewers

- Test mock implements a no-op `Confirm` since its `Create` returns the transfer ready to go.
- No action/engine change — goflow doesn't invoke `Confirm`.

## Test plan
- [x] `go test ./...` passes