### PR TITLE
Let AirtimeService.Create receive the pre-allocated event UUID

### DIFF
--- a/flows/actions/testdata/transfer_airtime.json
+++ b/flows/actions/testdata/transfer_airtime.json
@@ -120,9 +120,9 @@
         },
         "events": [
             {
-                "uuid": "01969b47-307b-76f8-a17e-f85e49829fb9",
+                "uuid": "01969b47-3463-76f8-ba00-bd7f0d08e671",
                 "type": "error",
-                "created_on": "2025-05-04T12:30:57.123456789Z",
+                "created_on": "2025-05-04T12:30:58.123456789Z",
                 "text": "invalid recipient number"
             }
         ],

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -92,12 +92,15 @@ func (a *TransferAirtime) transfer(ctx context.Context, run flows.Run, log flows
 
 	httpLogger := &flows.HTTPLogger{}
 
-	transfer, err := svc.Create(ctx, sender, recipient.Identity(), a.Amounts, httpLogger.Log)
+	// pre-allocate the event UUID so the service can pass it through to the provider as a stable reference
+	transferUUID := flows.NewEventUUID()
+
+	transfer, err := svc.Create(ctx, transferUUID, sender, recipient.Identity(), a.Amounts, httpLogger.Log)
 	if err != nil {
 		return nil, err
 	}
 
-	evt := events.NewAirtimeCreated(transfer, httpLogger.Logs)
+	evt := events.NewAirtimeCreated(transferUUID, transfer, httpLogger.Logs)
 	log(evt)
 
 	return evt, nil

--- a/flows/events/airtime_created.go
+++ b/flows/events/airtime_created.go
@@ -50,15 +50,15 @@ type AirtimeCreated struct {
 	HTTPLogs   []*flows.HTTPLog `json:"http_logs"`
 }
 
-// NewAirtimeCreated creates a new airtime created event
-func NewAirtimeCreated(t *flows.AirtimeTransfer, httpLogs []*flows.HTTPLog) *AirtimeCreated {
+// NewAirtimeCreated creates a new airtime created event with the given pre-allocated UUID
+func NewAirtimeCreated(uuid flows.EventUUID, t *flows.AirtimeTransfer, httpLogs []*flows.HTTPLog) *AirtimeCreated {
 	sender := t.Sender
 	if sender != "" {
 		sender = sender.Identity()
 	}
 
 	return &AirtimeCreated{
-		BaseEvent:  NewBaseEvent(TypeAirtimeCreated),
+		BaseEvent:  NewBaseEventWithUUID(uuid, TypeAirtimeCreated),
 		ExternalID: t.ExternalID,
 		Sender:     sender,
 		Recipient:  t.Recipient.Identity(),

--- a/flows/events/base.go
+++ b/flows/events/base.go
@@ -33,7 +33,14 @@ type BaseEvent struct {
 
 // NewBaseEvent creates a new base event
 func NewBaseEvent(typ string) BaseEvent {
-	return BaseEvent{UUID_: flows.NewEventUUID(), Type_: typ, CreatedOn_: dates.Now()}
+	return NewBaseEventWithUUID(flows.NewEventUUID(), typ)
+}
+
+// NewBaseEventWithUUID creates a new base event with the given pre-allocated UUID. Used when the caller
+// needs to know the event's UUID before constructing the event (e.g. to pass it to an outbound provider
+// call so that callbacks can be correlated back to the event).
+func NewBaseEventWithUUID(uuid flows.EventUUID, typ string) BaseEvent {
+	return BaseEvent{UUID_: uuid, Type_: typ, CreatedOn_: dates.Now()}
 }
 
 // UUID returns the UUID of this event

--- a/flows/events/base_test.go
+++ b/flows/events/base_test.go
@@ -54,6 +54,7 @@ func TestEventMarshaling(t *testing.T) {
 		{
 			func() flows.Event {
 				return events.NewAirtimeCreated(
+					flows.NewEventUUID(),
 					&flows.AirtimeTransfer{
 						ExternalID: "98765432",
 						Sender:     urns.URN("tel:+593979099111"),

--- a/flows/events/testdata/TestEventMarshaling_airtime_created.snap
+++ b/flows/events/testdata/TestEventMarshaling_airtime_created.snap
@@ -1,5 +1,5 @@
 {
-    "uuid": "01969b47-096b-76f8-ae7f-f8b243c49ff5",
+    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
     "type": "airtime_created",
     "created_on": "2025-05-04T12:30:47.123456789Z",
     "external_id": "98765432",
@@ -16,7 +16,7 @@
             "elapsed_ms": 12,
             "retries": 0,
             "status": "success",
-            "created_on": "2025-05-04T12:30:45.123456789Z"
+            "created_on": "2025-05-04T12:30:46.123456789Z"
         }
     ]
 }

--- a/flows/services.go
+++ b/flows/services.go
@@ -73,7 +73,12 @@ type AirtimeService interface {
 	// this submits the transaction in an unconfirmed state and returns its identifier in ExternalID; the
 	// host then calls Confirm to actually trigger the send. For providers that initiate immediately, this
 	// method does the send and Confirm is a no-op.
-	Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
+	//
+	// transferUUID is pre-allocated by the caller and is the UUID that will be assigned to the resulting
+	// airtime_created event; implementations may pass it to the provider as their own reference (e.g.
+	// DT One's external_id field) so that subsequent provider callbacks can be correlated back to the
+	// event/transfer by the host without needing the provider's transaction id.
+	Create(ctx context.Context, transferUUID EventUUID, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP HTTPLogCallback) (*AirtimeTransfer, error)
 
 	// Confirm completes initiation of a transfer previously surfaced by Create. Hosts typically call
 	// Confirm after the session commits, so the airtime is only actually sent once the surrounding work

--- a/test/services/airtime.go
+++ b/test/services/airtime.go
@@ -22,7 +22,7 @@ func NewAirtime(currency string) *Airtime {
 	return &Airtime{fixedCurrency: currency}
 }
 
-func (s *Airtime) Create(ctx context.Context, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP flows.HTTPLogCallback) (*flows.AirtimeTransfer, error) {
+func (s *Airtime) Create(ctx context.Context, transferUUID flows.EventUUID, sender urns.URN, recipient urns.URN, amounts map[string]decimal.Decimal, logHTTP flows.HTTPLogCallback) (*flows.AirtimeTransfer, error) {
 	if strings.Contains(string(recipient), "666") {
 		return nil, fmt.Errorf("invalid recipient number")
 	}

--- a/test/services/airtime_test.go
+++ b/test/services/airtime_test.go
@@ -15,7 +15,8 @@ func TestAirtimeService(t *testing.T) {
 	ctx := context.Background()
 	svc := services.NewAirtime("USD")
 
-	transfer, err := svc.Create(ctx, urns.URN("tel:+12025550100"), urns.URN("tel:+12025550101"), map[string]decimal.Decimal{
+	uuid := flows.NewEventUUID()
+	transfer, err := svc.Create(ctx, uuid, urns.URN("tel:+12025550100"), urns.URN("tel:+12025550101"), map[string]decimal.Decimal{
 		"USD": decimal.RequireFromString("3"),
 	}, func(*flows.HTTPLog) {})
 	assert.NoError(t, err)
@@ -27,6 +28,6 @@ func TestAirtimeService(t *testing.T) {
 	assert.NoError(t, err)
 
 	// recipients containing "666" cause Create to fail (used by other tests)
-	_, err = svc.Create(ctx, urns.NilURN, urns.URN("tel:+1666"), map[string]decimal.Decimal{"USD": decimal.RequireFromString("3")}, func(*flows.HTTPLog) {})
+	_, err = svc.Create(ctx, uuid, urns.NilURN, urns.URN("tel:+1666"), map[string]decimal.Decimal{"USD": decimal.RequireFromString("3")}, func(*flows.HTTPLog) {})
 	assert.EqualError(t, err, "invalid recipient number")
 }


### PR DESCRIPTION
## Summary

Threads a pre-allocated event UUID into `AirtimeService.Create` so that implementations can pass it through to the provider as their own reference (e.g. DT One's `external_id` request field). Hosts can then correlate provider status callbacks back to the airtime_created event by UUID, without depending on the provider's transaction id.

- New `NewBaseEventWithUUID(uuid, typ)` helper on `BaseEvent`; `NewBaseEvent` delegates to it.
- `events.NewAirtimeCreated(uuid, transfer, httpLogs)` takes the UUID as a first arg.
- `transfer_airtime` action pre-allocates `transferUUID := flows.NewEventUUID()` and threads it through both `svc.Create(...)` and `events.NewAirtimeCreated(...)`.
- Test mock and fixtures updated.

## Notes for reviewers

- Backwards-incompatible for any external `AirtimeService` implementation (mailroom is the only known one; will be updated to match).
- The `_new_transfer` action local is still the event UUID — same value as before, just now also known to the provider call.

## Test plan
- [x] `go test ./...` passes
- [x] Fixtures regenerated with `-update`