### PR TITLE
Replace transient event step attachments with a step description struct

### DIFF
--- a/cmd/docgen/docs/html_renderers.go
+++ b/cmd/docgen/docs/html_renderers.go
@@ -440,7 +440,7 @@ func eventsForAction(action flows.Action, msgSession flows.Session, voiceSession
 
 	eventList := make([]events.Event, 0)
 	eventLog := func(e events.Event) {
-		e.SetStep(step)
+		e.SetStep(&events.Step{Flow: run.FlowReference(), Node: step.NodeUUID()})
 		eventList = append(eventList, e)
 	}
 

--- a/core/events/base.go
+++ b/core/events/base.go
@@ -23,7 +23,7 @@ type BaseEvent struct {
 	CreatedOn_ time.Time `json:"created_on"          validate:"required"`
 
 	// can be used by callers to locate events but not persisted
-	Step_ Step `json:"-"`
+	Step_ *Step `json:"-"`
 
 	// not set by engine but can be set by callers for storage of events
 	User_ *assets.UserReference `json:"_user,omitempty"`
@@ -51,11 +51,11 @@ func (e *BaseEvent) Type() string { return e.Type_ }
 // CreatedOn returns the created on time of this event
 func (e *BaseEvent) CreatedOn() time.Time { return e.CreatedOn_ }
 
-// Step returns the step in the path where this event occurred
-func (e *BaseEvent) Step() Step { return e.Step_ }
+// Step returns the step in a flow at which this event occurred (if any)
+func (e *BaseEvent) Step() *Step { return e.Step_ }
 
-// SetStep sets the UUID of the step in the path where this event occurred
-func (e *BaseEvent) SetStep(s Step) { e.Step_ = s }
+// SetStep sets the step in a flow at which this event occurred
+func (e *BaseEvent) SetStep(s *Step) { e.Step_ = s }
 
 // SetUser can be used by callers to set the user associated with this event
 func (e *BaseEvent) SetUser(u *assets.UserReference, via string) {

--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
-	"github.com/nyaruka/goflow/flows/definition"
-	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/services/webhooks"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
@@ -502,7 +500,7 @@ func TestEventMarshaling(t *testing.T) {
 	// check setting of user reference field and non marshaling of steps
 	var evt events.Event = events.NewTicketClosed(ticket.UUID())
 	evt.SetUser(user.Reference(), "ui")
-	evt.SetStep(engine.NewStep(nil, definition.NewNode("72ecb927-db78-4acf-b947-db2f29bf6662", nil, nil, nil), time.Now()))
+	evt.SetStep(&events.Step{Flow: assets.NewFlowReference("50c3706e-fedb-42c0-8eab-dda3335714b7", "Registration"), Node: "72ecb927-db78-4acf-b947-db2f29bf6662"})
 
 	eventJSON, err := jsonx.MarshalPretty(evt)
 	assert.NoError(t, err)

--- a/core/events/event.go
+++ b/core/events/event.go
@@ -15,13 +15,11 @@ type EventUUID uuids.UUID
 // NewEventUUID generates a new UUID for an event
 func NewEventUUID() EventUUID { return EventUUID(uuids.NewV7()) }
 
-// Step is the location in a flow run where an event occurred. It is implemented by the engine's run step type -
-// this narrow interface exists so that events don't have to depend on the engine's run types.
-type Step interface {
-	UUID() core.StepUUID
-	NodeUUID() core.NodeUUID
-	ExitUUID() core.ExitUUID
-	ArrivedOn() time.Time
+// Step describes the step in a flow at which an event occurred. It is set by the engine on the events
+// it generates during a sprint for the benefit of callers, but is not persisted with events.
+type Step struct {
+	Flow *assets.FlowReference
+	Node core.NodeUUID
 }
 
 // Event describes a state change
@@ -30,8 +28,8 @@ type Event interface {
 
 	UUID() EventUUID
 	CreatedOn() time.Time
-	Step() Step
-	SetStep(Step)
+	Step() *Step
+	SetStep(*Step)
 	SetUser(*assets.UserReference, string)
 }
 

--- a/core/uuids.go
+++ b/core/uuids.go
@@ -5,11 +5,5 @@ import "github.com/nyaruka/gocommon/uuids"
 // NodeUUID is a UUID of a flow node
 type NodeUUID uuids.UUID
 
-// ExitUUID is the UUID of a node exit
-type ExitUUID uuids.UUID
-
-// StepUUID is the UUID of a run step
-type StepUUID uuids.UUID
-
 // InputUUID is the UUID of an input
 type InputUUID uuids.UUID

--- a/flows/definition/exit.go
+++ b/flows/definition/exit.go
@@ -11,16 +11,16 @@ import (
 )
 
 type exit struct {
-	uuid        core.ExitUUID
+	uuid        flows.ExitUUID
 	destination core.NodeUUID
 }
 
 // NewExit creates a new exit
-func NewExit(uuid core.ExitUUID, destination core.NodeUUID) flows.Exit {
+func NewExit(uuid flows.ExitUUID, destination core.NodeUUID) flows.Exit {
 	return &exit{uuid: uuid, destination: destination}
 }
 
-func (e *exit) UUID() core.ExitUUID            { return e.uuid }
+func (e *exit) UUID() flows.ExitUUID           { return e.uuid }
 func (e *exit) DestinationUUID() core.NodeUUID { return e.destination }
 
 // LocalizationUUID gets the UUID which identifies this object for localization
@@ -31,8 +31,8 @@ func (e *exit) LocalizationUUID() uuids.UUID { return uuids.UUID(e.uuid) }
 //------------------------------------------------------------------------------------------
 
 type exitEnvelope struct {
-	UUID            core.ExitUUID `json:"uuid"                       validate:"required,uuid"`
-	DestinationUUID core.NodeUUID `json:"destination_uuid,omitempty" validate:"omitempty,uuid"`
+	UUID            flows.ExitUUID `json:"uuid"                       validate:"required,uuid"`
+	DestinationUUID core.NodeUUID  `json:"destination_uuid,omitempty" validate:"omitempty,uuid"`
 }
 
 // UnmarshalJSON unmarshals a node exit from the given JSON

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -284,12 +284,12 @@ func TestNewFlow(t *testing.T) {
 						routers.NewCategory(
 							flows.CategoryUUID("97b9451c-2856-475b-af38-32af68100897"),
 							"Yes",
-							core.ExitUUID("023a5c10-d74a-4fad-9560-990caead8170"),
+							flows.ExitUUID("023a5c10-d74a-4fad-9560-990caead8170"),
 						),
 						routers.NewCategory(
 							flows.CategoryUUID("8fd08f1c-8f4e-42c1-af6c-df2db2e0eda6"),
 							"No",
-							core.ExitUUID("8943c032-2a91-456c-8080-2a249f1b420c"),
+							flows.ExitUUID("8943c032-2a91-456c-8080-2a249f1b420c"),
 						),
 					},
 					"@input.text",
@@ -300,11 +300,11 @@ func TestNewFlow(t *testing.T) {
 				),
 				[]flows.Exit{
 					definition.NewExit(
-						core.ExitUUID("023a5c10-d74a-4fad-9560-990caead8170"),
+						flows.ExitUUID("023a5c10-d74a-4fad-9560-990caead8170"),
 						core.NodeUUID("baaf9085-1198-4b41-9a1c-cc51c6dbec99"),
 					),
 					definition.NewExit(
-						core.ExitUUID("8943c032-2a91-456c-8080-2a249f1b420c"),
+						flows.ExitUUID("8943c032-2a91-456c-8080-2a249f1b420c"),
 						core.NodeUUID("baaf9085-1198-4b41-9a1c-cc51c6dbec99"),
 					),
 				},
@@ -322,7 +322,7 @@ func TestNewFlow(t *testing.T) {
 				},
 				nil, // no router
 				[]flows.Exit{
-					definition.NewExit(core.ExitUUID("3e077111-7b62-4407-b8a4-4fddaf0d2f24"), ""),
+					definition.NewExit(flows.ExitUUID("3e077111-7b62-4407-b8a4-4fddaf0d2f24"), ""),
 				},
 			),
 		},

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -279,7 +279,7 @@ func (s *session) tryToResume(ctx context.Context, sprint *sprint, waitingRun *r
 	sprint.logFlow(waitingRun.Flow())
 
 	logEvent := func(e events.Event) {
-		e.SetStep(step)
+		e.SetStep(eventStep(step))
 		sprint.logEvent(e)
 	}
 
@@ -329,7 +329,7 @@ func (s *session) findResumeExit(sprint *sprint, run *run, isTimeout bool) (flow
 		return nil, "", err
 	}
 	logEvent := func(e events.Event) {
-		e.SetStep(step)
+		e.SetStep(eventStep(step))
 		sprint.logEvent(e)
 	}
 
@@ -466,7 +466,7 @@ func (s *session) continueUntilWait(ctx context.Context, sprint *sprint, current
 func (s *session) visitNode(ctx context.Context, sprint *sprint, r *run, node flows.Node, trigger flows.Trigger) (flows.Step, flows.Exit, string, error) {
 	step := r.CreateStep(node)
 	logEvent := func(e events.Event) {
-		e.SetStep(step)
+		e.SetStep(eventStep(step))
 		sprint.logEvent(e)
 	}
 
@@ -519,7 +519,7 @@ func (s *session) visitNode(ctx context.Context, sprint *sprint, r *run, node fl
 
 // picks the exit to use on the given node
 func (s *session) pickNodeExit(sprint *sprint, r *run, node flows.Node, step flows.Step, isTimeout bool, logEvent events.EventLogger) (flows.Exit, string, error) {
-	var exitUUID core.ExitUUID
+	var exitUUID flows.ExitUUID
 	var operand string
 	var err error
 
@@ -574,7 +574,7 @@ func failRun(sp *sprint, r *run, step flows.Step, text string) {
 	if text != "" {
 		evt := events.NewFailure(text)
 		if step != nil {
-			evt.SetStep(step)
+			evt.SetStep(eventStep(step))
 		}
 
 		sp.logEvent(evt)

--- a/flows/engine/sprint.go
+++ b/flows/engine/sprint.go
@@ -31,7 +31,7 @@ func (s *segment) Time() time.Time         { return s.time }
 type segmentEnvelope struct {
 	FlowUUID        assets.FlowUUID `json:"flow_uuid"`
 	NodeUUID        core.NodeUUID   `json:"node_uuid"`
-	ExitUUID        core.ExitUUID   `json:"exit_uuid"`
+	ExitUUID        flows.ExitUUID  `json:"exit_uuid"`
 	Operand         string          `json:"operand,omitempty"`
 	DestinationUUID core.NodeUUID   `json:"destination_uuid,omitempty"`
 	Time            time.Time       `json:"time"`

--- a/flows/engine/step.go
+++ b/flows/engine/step.go
@@ -6,15 +6,16 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/core"
+	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 )
 
 type step struct {
-	uuid      core.StepUUID
+	uuid      flows.StepUUID
 	nodeUUID  core.NodeUUID
-	exitUUID  core.ExitUUID
+	exitUUID  flows.ExitUUID
 	arrivedOn time.Time
 
 	run flows.Run // transient
@@ -23,7 +24,7 @@ type step struct {
 // NewStep creates a new step
 func NewStep(r flows.Run, n flows.Node, arrivedOn time.Time) flows.Step {
 	return &step{
-		uuid:      core.StepUUID(uuids.NewV4()),
+		uuid:      flows.StepUUID(uuids.NewV4()),
 		nodeUUID:  n.UUID(),
 		arrivedOn: arrivedOn,
 
@@ -31,13 +32,13 @@ func NewStep(r flows.Run, n flows.Node, arrivedOn time.Time) flows.Step {
 	}
 }
 
-func (s *step) UUID() core.StepUUID     { return s.uuid }
-func (s *step) NodeUUID() core.NodeUUID { return s.nodeUUID }
-func (s *step) ExitUUID() core.ExitUUID { return s.exitUUID }
-func (s *step) ArrivedOn() time.Time    { return s.arrivedOn }
-func (s *step) Run() flows.Run          { return s.run }
+func (s *step) UUID() flows.StepUUID     { return s.uuid }
+func (s *step) NodeUUID() core.NodeUUID  { return s.nodeUUID }
+func (s *step) ExitUUID() flows.ExitUUID { return s.exitUUID }
+func (s *step) ArrivedOn() time.Time     { return s.arrivedOn }
+func (s *step) Run() flows.Run           { return s.run }
 
-func (s *step) Leave(exit core.ExitUUID) {
+func (s *step) Leave(exit flows.ExitUUID) {
 	s.exitUUID = exit
 }
 
@@ -70,10 +71,10 @@ func (p Path) ToXValue(env envs.Environment) types.XValue {
 //------------------------------------------------------------------------------------------
 
 type stepEnvelope struct {
-	UUID      core.StepUUID `json:"uuid" validate:"required,uuid"`
-	NodeUUID  core.NodeUUID `json:"node_uuid" validate:"required,uuid"`
-	ExitUUID  core.ExitUUID `json:"exit_uuid,omitempty" validate:"omitempty,uuid"`
-	ArrivedOn time.Time     `json:"arrived_on"`
+	UUID      flows.StepUUID `json:"uuid" validate:"required,uuid"`
+	NodeUUID  core.NodeUUID  `json:"node_uuid" validate:"required,uuid"`
+	ExitUUID  flows.ExitUUID `json:"exit_uuid,omitempty" validate:"omitempty,uuid"`
+	ArrivedOn time.Time      `json:"arrived_on"`
 }
 
 // UnmarshalJSON unmarshals a run step from the given JSON
@@ -100,4 +101,9 @@ func (s *step) MarshalJSON() ([]byte, error) {
 		ExitUUID:  s.exitUUID,
 		ArrivedOn: s.arrivedOn,
 	})
+}
+
+// creates the step description set on events generated at the given step
+func eventStep(s flows.Step) *events.Step {
+	return &events.Step{Flow: s.Run().FlowReference(), Node: s.NodeUUID()}
 }

--- a/flows/engine/step_test.go
+++ b/flows/engine/step_test.go
@@ -26,10 +26,10 @@ func TestStep(t *testing.T) {
 	d := time.Date(2018, 10, 26, 14, 50, 30, 1234567890, time.UTC)
 	step := engine.NewStep(nil, node, d)
 
-	assert.Equal(t, core.StepUUID("c00e5d67-c275-4389-aded-7d8b151cbd5b"), step.UUID())
+	assert.Equal(t, flows.StepUUID("c00e5d67-c275-4389-aded-7d8b151cbd5b"), step.UUID())
 	assert.Equal(t, core.NodeUUID("5fb4f555-7662-4c4c-8387-226e359526e4"), step.NodeUUID())
 	assert.Equal(t, d, step.ArrivedOn())
-	assert.Equal(t, core.ExitUUID(""), step.ExitUUID())
+	assert.Equal(t, flows.ExitUUID(""), step.ExitUUID())
 
 	// test use in expressions
 	env := envs.NewBuilder().Build()

--- a/flows/info_test.go
+++ b/flows/info_test.go
@@ -19,13 +19,13 @@ func TestNewResultSpecs(t *testing.T) {
 		core.NodeUUID("1fb823c3-599a-41e9-b59b-658266af3466"),
 		nil,
 		nil,
-		[]flows.Exit{definition.NewExit(core.ExitUUID("3c158842-24f3-4a40-bea4-7522952c0131"), "")},
+		[]flows.Exit{definition.NewExit(flows.ExitUUID("3c158842-24f3-4a40-bea4-7522952c0131"), "")},
 	)
 	node2 := definition.NewNode(
 		core.NodeUUID("0ba673a3-63b3-46f9-9246-9c727cf2917f"),
 		nil,
 		nil,
-		[]flows.Exit{definition.NewExit(core.ExitUUID("434ac29c-abe6-4bd7-b29b-740d517b6bb5"), "")},
+		[]flows.Exit{definition.NewExit(flows.ExitUUID("434ac29c-abe6-4bd7-b29b-740d517b6bb5"), "")},
 	)
 
 	extracted := []flows.ExtractedResult{

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -34,6 +34,12 @@ type CategoryUUID uuids.UUID
 // ActionUUID is the UUID of an action
 type ActionUUID uuids.UUID
 
+// ExitUUID is the UUID of a node exit
+type ExitUUID uuids.UUID
+
+// StepUUID is the UUID of a run step
+type StepUUID uuids.UUID
+
 // FlowAssets provides access to flow assets
 type FlowAssets interface {
 	Get(assets.FlowUUID) (Flow, error)
@@ -127,7 +133,7 @@ type Category interface {
 
 	UUID() CategoryUUID
 	Name() string
-	ExitUUID() core.ExitUUID
+	ExitUUID() ExitUUID
 }
 
 // Router is a router on a note which can pick an exit
@@ -139,8 +145,8 @@ type Router interface {
 	ResultName() string
 
 	AllowTimeout() bool
-	Route(Run, Step, events.EventLogger) (core.ExitUUID, string, error)
-	RouteTimeout(Run, Step, events.EventLogger) (core.ExitUUID, error)
+	Route(Run, Step, events.EventLogger) (ExitUUID, string, error)
+	RouteTimeout(Run, Step, events.EventLogger) (ExitUUID, error)
 
 	Validate(Flow, []Exit) error
 	Inspect(func(*ResultInfo), func(assets.Reference))
@@ -150,7 +156,7 @@ type Router interface {
 
 // Exit is a route out of a node and optionally to another node
 type Exit interface {
-	UUID() core.ExitUUID
+	UUID() ExitUUID
 	DestinationUUID() core.NodeUUID
 }
 
@@ -232,9 +238,13 @@ type Input interface {
 // Step is a single step in the path thru a flow
 type Step interface {
 	Contextable
-	events.Step
 
-	Leave(core.ExitUUID)
+	UUID() StepUUID
+	NodeUUID() core.NodeUUID
+	ExitUUID() ExitUUID
+	ArrivedOn() time.Time
+
+	Leave(ExitUUID)
 	Run() Run
 }
 

--- a/flows/routers/base.go
+++ b/flows/routers/base.go
@@ -118,7 +118,7 @@ func (r *baseRouter) isValidCategory(uuid flows.CategoryUUID) bool {
 	return false
 }
 
-func (r *baseRouter) isValidExit(uuid core.ExitUUID, exits []flows.Exit) bool {
+func (r *baseRouter) isValidExit(uuid flows.ExitUUID, exits []flows.Exit) bool {
 	for _, e := range exits {
 		if e.UUID() == uuid {
 			return true
@@ -128,7 +128,7 @@ func (r *baseRouter) isValidExit(uuid core.ExitUUID, exits []flows.Exit) bool {
 }
 
 // RouteTimeout routes in the case that this router's wait timed out
-func (r *baseRouter) RouteTimeout(run flows.Run, step flows.Step, logEvent events.EventLogger) (core.ExitUUID, error) {
+func (r *baseRouter) RouteTimeout(run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, error) {
 	if !r.AllowTimeout() {
 		return "", errors.New("can't call route timeout on router with no timeout")
 	}
@@ -136,7 +136,7 @@ func (r *baseRouter) RouteTimeout(run flows.Run, step flows.Step, logEvent event
 	return r.routeToCategory(run, step, r.wait.Timeout().CategoryUUID(), "", "", nil, logEvent)
 }
 
-func (r *baseRouter) routeToCategory(run flows.Run, step flows.Step, categoryUUID flows.CategoryUUID, match string, operand string, extra *types.XObject, logEvent events.EventLogger) (core.ExitUUID, error) {
+func (r *baseRouter) routeToCategory(run flows.Run, step flows.Step, categoryUUID flows.CategoryUUID, match string, operand string, extra *types.XObject, logEvent events.EventLogger) (flows.ExitUUID, error) {
 	// router failed to pick a category
 	if categoryUUID == "" {
 		return "", nil

--- a/flows/routers/category.go
+++ b/flows/routers/category.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/uuids"
-	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 )
@@ -13,17 +12,17 @@ import (
 type Category struct {
 	uuid     flows.CategoryUUID
 	name     string
-	exitUUID core.ExitUUID
+	exitUUID flows.ExitUUID
 }
 
 // NewCategory creates a new category
-func NewCategory(uuid flows.CategoryUUID, name string, exit core.ExitUUID) *Category {
+func NewCategory(uuid flows.CategoryUUID, name string, exit flows.ExitUUID) *Category {
 	return &Category{uuid: uuid, name: name, exitUUID: exit}
 }
 
 func (c *Category) UUID() flows.CategoryUUID { return c.uuid }
 func (c *Category) Name() string             { return c.name }
-func (c *Category) ExitUUID() core.ExitUUID  { return c.exitUUID }
+func (c *Category) ExitUUID() flows.ExitUUID { return c.exitUUID }
 
 // LocalizationUUID gets the UUID which identifies this object for localization
 func (c *Category) LocalizationUUID() uuids.UUID { return uuids.UUID(c.uuid) }
@@ -37,7 +36,7 @@ var _ flows.Category = (*Category)(nil)
 type categoryEnvelope struct {
 	UUID     flows.CategoryUUID `json:"uuid"                validate:"required,uuid"`
 	Name     string             `json:"name,omitempty"      validate:"required,result_category"`
-	ExitUUID core.ExitUUID      `json:"exit_uuid,omitempty" validate:"required,uuid"`
+	ExitUUID flows.ExitUUID     `json:"exit_uuid,omitempty" validate:"required,uuid"`
 }
 
 // ReadCategory unmarshals a router category from the given JSON

--- a/flows/routers/random.go
+++ b/flows/routers/random.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/random"
-	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
@@ -36,7 +35,7 @@ func (r *Random) Validate(flow flows.Flow, exits []flows.Exit) error {
 }
 
 // Route determines which exit to take from a node
-func (r *Random) Route(run flows.Run, step flows.Step, logEvent events.EventLogger) (core.ExitUUID, string, error) {
+func (r *Random) Route(run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, string, error) {
 	// pick a random category
 	rand := random.Decimal()
 	categoryNum := rand.Mul(decimal.New(int64(len(r.categories)), 0)).IntPart()

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
-	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
@@ -105,7 +104,7 @@ func (r *Switch) Validate(flow flows.Flow, exits []flows.Exit) error {
 }
 
 // Route determines which exit to take from a node
-func (r *Switch) Route(run flows.Run, step flows.Step, log events.EventLogger) (core.ExitUUID, string, error) {
+func (r *Switch) Route(run flows.Run, step flows.Step, log events.EventLogger) (flows.ExitUUID, string, error) {
 	env := run.Session().MergedEnvironment()
 
 	// first evaluate our operand


### PR DESCRIPTION
Previously the engine attached the actual run path step object to the events it generates, so that callers could locate events in the flow that produced them. That attachment was transient (never persisted) but required a step interface at the events level, and callers had to navigate engine types to get to what they actually need — the flow and node where the event occurred.

Now `events.Step` is a plain struct:

```go
// Step describes the step in a flow at which an event occurred. It is set by the engine on the events
// it generates during a sprint for the benefit of callers, but is not persisted with events.
type Step struct {
    Flow *assets.FlowReference
    Node core.NodeUUID
}
```

For callers that means field reads instead of engine type navigation:

```go
// before
flow := e.Step().Run().Flow()
node := e.Step().NodeUUID()

// after
flowRef := e.Step().Flow
node := e.Step().Node
```

Other changes:

* the engine's step interface (`flows.Step`) returns wholly to the `flows` package — the narrow events-level step interface is gone
* `StepUUID` and `ExitUUID` move back to `flows` — they aren't part of any event payload so don't belong in `core`