### PR TITLE
Add typing_started and typing_stopped event types

### DIFF
--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -478,6 +478,18 @@ func TestEventMarshaling(t *testing.T) {
 		},
 		{
 			func() events.Event {
+				return events.NewTypingStarted(events.TypingDirectionIncoming)
+			},
+			`typing_started_incoming`,
+		},
+		{
+			func() events.Event {
+				return events.NewTypingStarted(events.TypingDirectionOutgoing)
+			},
+			`typing_started_outgoing`,
+		},
+		{
+			func() events.Event {
 				return events.NewWaitTimedOut()
 			},
 			`wait_timed_out`,

--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -490,6 +490,18 @@ func TestEventMarshaling(t *testing.T) {
 		},
 		{
 			func() events.Event {
+				return events.NewTypingStopped(events.TypingDirectionIncoming)
+			},
+			`typing_stopped_incoming`,
+		},
+		{
+			func() events.Event {
+				return events.NewTypingStopped(events.TypingDirectionOutgoing)
+			},
+			`typing_stopped_outgoing`,
+		},
+		{
+			func() events.Event {
 				return events.NewWaitTimedOut()
 			},
 			`wait_timed_out`,

--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -478,25 +478,25 @@ func TestEventMarshaling(t *testing.T) {
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStarted(events.TypingDirectionIncoming)
+				return events.NewTypingStarted(events.DirectionIncoming)
 			},
 			`typing_started_incoming`,
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStarted(events.TypingDirectionOutgoing)
+				return events.NewTypingStarted(events.DirectionOutgoing)
 			},
 			`typing_started_outgoing`,
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStopped(events.TypingDirectionIncoming)
+				return events.NewTypingStopped(events.DirectionIncoming)
 			},
 			`typing_stopped_incoming`,
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStopped(events.TypingDirectionOutgoing)
+				return events.NewTypingStopped(events.DirectionOutgoing)
 			},
 			`typing_stopped_outgoing`,
 		},

--- a/core/events/event.go
+++ b/core/events/event.go
@@ -3,17 +3,34 @@ package events
 import (
 	"time"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/utils"
 )
 
+func init() {
+	utils.RegisterValidatorAlias("direction", "eq=incoming|eq=outgoing", func(validator.FieldError) string {
+		return "is not a valid direction"
+	})
+}
+
 // EventUUID is the UUID of an event
 type EventUUID uuids.UUID
 
 // NewEventUUID generates a new UUID for an event
 func NewEventUUID() EventUUID { return EventUUID(uuids.NewV7()) }
+
+// Direction is the direction of an event relative to the contact, e.g. an incoming typing indicator is
+// the contact typing, an outgoing one is a user typing.
+type Direction string
+
+// possible direction values
+const (
+	DirectionIncoming Direction = "incoming"
+	DirectionOutgoing Direction = "outgoing"
+)
 
 // Step describes the step in a flow at which an event occurred. It is set by the engine on the events
 // it generates during a sprint for the benefit of callers, but is not persisted with events.

--- a/core/events/testdata/TestEventMarshaling_typing_started_incoming.snap
+++ b/core/events/testdata/TestEventMarshaling_typing_started_incoming.snap
@@ -1,0 +1,6 @@
+{
+    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+    "type": "typing_started",
+    "created_on": "2025-05-04T12:30:46.123456789Z",
+    "direction": "incoming"
+}

--- a/core/events/testdata/TestEventMarshaling_typing_started_outgoing.snap
+++ b/core/events/testdata/TestEventMarshaling_typing_started_outgoing.snap
@@ -1,0 +1,6 @@
+{
+    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+    "type": "typing_started",
+    "created_on": "2025-05-04T12:30:46.123456789Z",
+    "direction": "outgoing"
+}

--- a/core/events/testdata/TestEventMarshaling_typing_stopped_incoming.snap
+++ b/core/events/testdata/TestEventMarshaling_typing_stopped_incoming.snap
@@ -1,0 +1,6 @@
+{
+    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+    "type": "typing_stopped",
+    "created_on": "2025-05-04T12:30:46.123456789Z",
+    "direction": "incoming"
+}

--- a/core/events/testdata/TestEventMarshaling_typing_stopped_outgoing.snap
+++ b/core/events/testdata/TestEventMarshaling_typing_stopped_outgoing.snap
@@ -1,0 +1,6 @@
+{
+    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+    "type": "typing_stopped",
+    "created_on": "2025-05-04T12:30:46.123456789Z",
+    "direction": "outgoing"
+}

--- a/core/events/typing_started.go
+++ b/core/events/typing_started.go
@@ -1,0 +1,44 @@
+package events
+
+func init() {
+	registerType(TypeTypingStarted, func() Event { return &TypingStarted{} })
+}
+
+// TypeTypingStarted is the type of our typing started event
+const TypeTypingStarted string = "typing_started"
+
+// TypingDirection is the direction of a typing indicator
+type TypingDirection string
+
+// possible values for typing directions
+const (
+	TypingDirectionIncoming TypingDirection = "incoming" // the contact is typing
+	TypingDirectionOutgoing TypingDirection = "outgoing" // a user is typing
+)
+
+// TypingStarted events are created when the contact (direction of incoming) or a user (direction of outgoing)
+// starts typing.
+//
+//	{
+//	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+//	  "type": "typing_started",
+//	  "created_on": "2019-01-02T15:04:05Z",
+//	  "direction": "incoming"
+//	}
+//
+// @event typing_started
+type TypingStarted struct {
+	BaseEvent
+
+	Direction TypingDirection `json:"direction" validate:"required,eq=incoming|eq=outgoing"`
+}
+
+// NewTypingStarted returns a new typing started event
+func NewTypingStarted(direction TypingDirection) *TypingStarted {
+	return &TypingStarted{
+		BaseEvent: NewBaseEvent(TypeTypingStarted),
+		Direction: direction,
+	}
+}
+
+var _ Event = (*TypingStarted)(nil)

--- a/core/events/typing_started.go
+++ b/core/events/typing_started.go
@@ -7,15 +7,6 @@ func init() {
 // TypeTypingStarted is the type of our typing started event
 const TypeTypingStarted string = "typing_started"
 
-// TypingDirection is the direction of a typing indicator
-type TypingDirection string
-
-// possible values for typing directions
-const (
-	TypingDirectionIncoming TypingDirection = "incoming" // the contact is typing
-	TypingDirectionOutgoing TypingDirection = "outgoing" // a user is typing
-)
-
 // TypingStarted events are created when the contact (direction of incoming) or a user (direction of outgoing)
 // starts typing.
 //
@@ -30,11 +21,11 @@ const (
 type TypingStarted struct {
 	BaseEvent
 
-	Direction TypingDirection `json:"direction" validate:"required,eq=incoming|eq=outgoing"`
+	Direction Direction `json:"direction" validate:"required,direction"`
 }
 
 // NewTypingStarted returns a new typing started event
-func NewTypingStarted(direction TypingDirection) *TypingStarted {
+func NewTypingStarted(direction Direction) *TypingStarted {
 	return &TypingStarted{
 		BaseEvent: NewBaseEvent(TypeTypingStarted),
 		Direction: direction,

--- a/core/events/typing_stopped.go
+++ b/core/events/typing_stopped.go
@@ -1,0 +1,35 @@
+package events
+
+func init() {
+	registerType(TypeTypingStopped, func() Event { return &TypingStopped{} })
+}
+
+// TypeTypingStopped is the type of our typing stopped event
+const TypeTypingStopped string = "typing_stopped"
+
+// TypingStopped events are created when the contact (direction of incoming) or a user (direction of outgoing)
+// stops typing.
+//
+//	{
+//	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+//	  "type": "typing_stopped",
+//	  "created_on": "2019-01-02T15:04:05Z",
+//	  "direction": "incoming"
+//	}
+//
+// @event typing_stopped
+type TypingStopped struct {
+	BaseEvent
+
+	Direction TypingDirection `json:"direction" validate:"required,eq=incoming|eq=outgoing"`
+}
+
+// NewTypingStopped returns a new typing stopped event
+func NewTypingStopped(direction TypingDirection) *TypingStopped {
+	return &TypingStopped{
+		BaseEvent: NewBaseEvent(TypeTypingStopped),
+		Direction: direction,
+	}
+}
+
+var _ Event = (*TypingStopped)(nil)

--- a/core/events/typing_stopped.go
+++ b/core/events/typing_stopped.go
@@ -21,11 +21,11 @@ const TypeTypingStopped string = "typing_stopped"
 type TypingStopped struct {
 	BaseEvent
 
-	Direction TypingDirection `json:"direction" validate:"required,eq=incoming|eq=outgoing"`
+	Direction Direction `json:"direction" validate:"required,direction"`
 }
 
 // NewTypingStopped returns a new typing stopped event
-func NewTypingStopped(direction TypingDirection) *TypingStopped {
+func NewTypingStopped(direction Direction) *TypingStopped {
 	return &TypingStopped{
 		BaseEvent: NewBaseEvent(TypeTypingStopped),
 		Direction: direction,


### PR DESCRIPTION
Adds new `typing_started` and `typing_stopped` event types to record typing indicators from either side of a chat session:

```json
{
  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
  "type": "typing_started",
  "created_on": "2019-01-02T15:04:05Z",
  "direction": "incoming"
}
```

The `direction` field is `incoming` when the contact is typing and `outgoing` when a user is typing, validated as one of those two values. Includes marshaling tests for both events in both directions.