### PR TITLE
Move remaining asset wrappers and Group from flows into core

### DIFF
--- a/cmd/flowrunner/main_test.go
+++ b/cmd/flowrunner/main_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,8 +68,8 @@ func TestPrintEvent(t *testing.T) {
 		{events.NewBroadcastCreated(core.BroadcastTranslations{"eng": {Text: "hello"}}, "eng", nil, nil, "", nil, nil, nil), `🔉 broadcasted 'hello' to ...`},
 		{events.NewContactFieldChanged(sa.Fields().Get("gender").Reference(), core.NewValue(types.NewXText("M"), nil, nil, "", "", "")), `✏️ field 'gender' changed to 'M'`},
 		{events.NewContactFieldChanged(sa.Fields().Get("gender").Reference(), nil), `✏️ field 'gender' cleared`},
-		{events.NewContactGroupsChanged(flows.GroupReferences([]*flows.Group{sa.Groups().Get("b7cf0d83-f1c9-411c-96fd-c511a4cfa86d")}), nil), `👪 added to 'Testers'`},
-		{events.NewContactGroupsChanged(nil, flows.GroupReferences([]*flows.Group{sa.Groups().Get("b7cf0d83-f1c9-411c-96fd-c511a4cfa86d")})), `👪 removed from 'Testers'`},
+		{events.NewContactGroupsChanged(core.GroupReferences([]*core.Group{sa.Groups().Get("b7cf0d83-f1c9-411c-96fd-c511a4cfa86d")}), nil), `👪 added to 'Testers'`},
+		{events.NewContactGroupsChanged(nil, core.GroupReferences([]*core.Group{sa.Groups().Get("b7cf0d83-f1c9-411c-96fd-c511a4cfa86d")})), `👪 removed from 'Testers'`},
 		{events.NewContactLanguageChanged("eng"), `🌐 language changed to 'eng'`},
 		{events.NewContactNameChanged("Jim"), `📛 name changed to 'Jim'`},
 		{events.NewContactTimezoneChanged(session.Environment().Timezone()), `🕑 timezone changed to 'America/Guayaquil'`},

--- a/cmd/flowrunner/main_test.go
+++ b/cmd/flowrunner/main_test.go
@@ -80,7 +80,7 @@ func TestPrintEvent(t *testing.T) {
 		{events.NewError("this didn't work", ""), `⚠️ this didn't work`},
 		{events.NewFailure("This really didn't work"), `🛑 This really didn't work`},
 		{events.NewRunStarted(session.Runs()[0].FlowReference(), session.Runs()[0].UUID(), "", false), `↪️ entered flow 'Registration'`},
-		{events.NewInputLabelsAdded("2a786bbc-2314-4d57-a0c9-b66e1642e5e2", flows.LabelReferences([]*flows.Label{sa.Labels().FindByName("Spam")})), `🏷️ labeled with 'Spam'`},
+		{events.NewInputLabelsAdded("2a786bbc-2314-4d57-a0c9-b66e1642e5e2", core.LabelReferences([]*core.Label{sa.Labels().FindByName("Spam")})), `🏷️ labeled with 'Spam'`},
 		{events.NewMsgWait(nil, expiresOn, nil), `⏳ waiting for message...`},
 		{events.NewMsgWait(&timeout, expiresOn, nil), `⏳ waiting for message (3 sec timeout, type /timeout to simulate)...`},
 	}

--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/nyaruka/goflow/core/hints"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/services/webhooks"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
@@ -147,7 +146,7 @@ func TestEventMarshaling(t *testing.T) {
 		{
 			func() events.Event {
 				return events.NewContactGroupsChanged(
-					flows.GroupReferences([]*flows.Group{session.Assets().Groups().FindByName("Customers")}),
+					core.GroupReferences([]*core.Group{session.Assets().Groups().FindByName("Customers")}),
 					nil,
 				)
 			},

--- a/core/field.go
+++ b/core/field.go
@@ -1,4 +1,4 @@
-package flows
+package core
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/nyaruka/goflow/assets"
-	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
 )
@@ -35,13 +34,16 @@ func (f *Field) Reference() *assets.FieldReference {
 // FieldValue represents a field and a set of values for that field
 type FieldValue struct {
 	field *Field
-	*core.Value
+	*Value
 }
 
 // NewFieldValue creates a new field value
-func NewFieldValue(field *Field, value *core.Value) *FieldValue {
+func NewFieldValue(field *Field, value *Value) *FieldValue {
 	return &FieldValue{field: field, Value: value}
 }
+
+// Field returns the field this value is for
+func (v *FieldValue) Field() *Field { return v.field }
 
 // ToXValue returns a representation of this object for use in expressions
 func (v *FieldValue) ToXValue(env envs.Environment) types.XValue {
@@ -117,8 +119,8 @@ func (v *FieldValue) QueryValue() any {
 type FieldValues map[string]*FieldValue
 
 // NewFieldValues creates a new field value map
-func NewFieldValues(a SessionAssets, values map[string]*core.Value, missing assets.MissingCallback) FieldValues {
-	allFields := a.Fields().All()
+func NewFieldValues(fields *FieldAssets, values map[string]*Value, missing assets.MissingCallback) FieldValues {
+	allFields := fields.All()
 	fieldValues := make(FieldValues, len(allFields))
 	for _, field := range allFields {
 		value := values[field.Key()]
@@ -137,7 +139,7 @@ func NewFieldValues(a SessionAssets, values map[string]*core.Value, missing asse
 }
 
 // Clone returns a clone of this set of field values
-func (f FieldValues) clone() FieldValues {
+func (f FieldValues) Clone() FieldValues {
 	clone := make(FieldValues, len(f))
 	for k, v := range f {
 		clone[k] = v
@@ -146,7 +148,7 @@ func (f FieldValues) clone() FieldValues {
 }
 
 // Get gets the value set for the given field
-func (f FieldValues) Get(field *Field) *core.Value {
+func (f FieldValues) Get(field *Field) *Value {
 	fieldVal := f[field.Key()]
 	if fieldVal != nil {
 		return fieldVal.Value
@@ -155,7 +157,7 @@ func (f FieldValues) Get(field *Field) *core.Value {
 }
 
 // Set sets the value for the given field (can be null to clear it)
-func (f FieldValues) Set(field *Field, value *core.Value) {
+func (f FieldValues) Set(field *Field, value *Value) {
 	var fv *FieldValue
 	if value != nil && !value.Text.Empty() {
 		fv = NewFieldValue(field, value)
@@ -164,7 +166,7 @@ func (f FieldValues) Set(field *Field, value *core.Value) {
 }
 
 // Parse parses a raw string field value into the different possible types
-func (f FieldValues) Parse(env envs.Environment, fields *FieldAssets, field *Field, rawValue string) *core.Value {
+func (f FieldValues) Parse(env envs.Environment, fields *FieldAssets, field *Field, rawValue string) *Value {
 	if rawValue == "" {
 		return nil
 	}
@@ -228,7 +230,7 @@ func (f FieldValues) Parse(env envs.Environment, fields *FieldAssets, field *Fie
 		}
 	}
 
-	return &core.Value{
+	return &Value{
 		Text:     asText,
 		Datetime: asDateTime,
 		Number:   asNumber,

--- a/core/field_test.go
+++ b/core/field_test.go
@@ -1,4 +1,4 @@
-package flows_test
+package core_test
 
 import (
 	"testing"
@@ -7,7 +7,6 @@ import (
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/test"
 
 	"github.com/stretchr/testify/assert"
@@ -24,10 +23,10 @@ func TestFieldValues(t *testing.T) {
 	age := fields.Get("age")
 
 	// can have no values for any fields
-	flows.NewFieldValues(session.Assets(), map[string]*core.Value{}, assets.PanicOnMissing)
+	core.NewFieldValues(session.Assets().Fields(), map[string]*core.Value{}, assets.PanicOnMissing)
 
 	// can have a value but not in the right type for that field (age below)
-	fieldVals := flows.NewFieldValues(session.Assets(), map[string]*core.Value{
+	fieldVals := core.NewFieldValues(session.Assets().Fields(), map[string]*core.Value{
 		"gender": core.NewValue(types.NewXText("Male"), nil, nil, envs.LocationPath(""), envs.LocationPath(""), envs.LocationPath("")),
 		"age":    core.NewValue(types.NewXText("nan"), nil, nil, envs.LocationPath(""), envs.LocationPath(""), envs.LocationPath("")),
 	}, assets.PanicOnMissing)
@@ -67,7 +66,7 @@ func TestFieldValueParse(t *testing.T) {
 	nilLocPath := envs.LocationPath("")
 
 	tcs := []struct {
-		field    *flows.Field
+		field    *core.Field
 		value    string
 		expected *core.Value
 	}{

--- a/core/global.go
+++ b/core/global.go
@@ -1,4 +1,4 @@
-package flows
+package core
 
 import (
 	"fmt"

--- a/core/global_test.go
+++ b/core/global_test.go
@@ -1,4 +1,4 @@
-package flows_test
+package core_test
 
 import (
 	"testing"
@@ -8,7 +8,6 @@ import (
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/test"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,7 @@ func TestGlobals(t *testing.T) {
 	ga1 := static.NewGlobal("org_name", "Org Name", "U-Report")
 	ga2 := static.NewGlobal("access_token", "Access Token", "674372272")
 
-	ga := flows.NewGlobalAssets([]assets.Global{ga1, ga2})
+	ga := core.NewGlobalAssets([]assets.Global{ga1, ga2})
 
 	g1 := ga.Get("org_name")
 

--- a/core/group.go
+++ b/core/group.go
@@ -1,12 +1,10 @@
-package flows
+package core
 
 import (
 	"strings"
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/contactql"
-	"github.com/nyaruka/goflow/contactql/parse"
-	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
 )
@@ -16,21 +14,12 @@ type Group struct {
 	assets.Group
 
 	parsedQuery *contactql.ContactQuery
-	resolver    contactql.Resolver
 }
 
-// NewGroup returns a new group object from the given group asset
-func NewGroup(env envs.Environment, fields *core.FieldAssets, asset assets.Group) (*Group, error) {
-	if asset.Query() != "" {
-		query, err := parse.Query(env, asset.Query(), fields)
-		if err != nil {
-			return nil, err
-		}
-
-		return &Group{Group: asset, parsedQuery: query, resolver: fields}, nil
-	}
-
-	return &Group{Group: asset}, nil
+// NewGroup returns a new group object from the given group asset and - if it's query based - its parsed
+// query. Parsing is the caller's responsibility so that this package doesn't depend on query parsing.
+func NewGroup(asset assets.Group, query *contactql.ContactQuery) *Group {
+	return &Group{Group: asset, parsedQuery: query}
 }
 
 // Asset returns the underlying asset
@@ -40,12 +29,12 @@ func (g *Group) Asset() assets.Group { return g.Group }
 func (g *Group) UsesQuery() bool { return g.Query() != "" }
 
 // CheckQueryBasedMembership returns whether the given contact belongs in a query based group
-func (g *Group) CheckQueryBasedMembership(env envs.Environment, contact *Contact) bool {
+func (g *Group) CheckQueryBasedMembership(env envs.Environment, status ContactStatus, contact contactql.Queryable) bool {
 	if !g.UsesQuery() {
 		panic("can't check membership on a non-query based group")
 	}
 
-	if contact.Status() != core.ContactStatusActive {
+	if status != ContactStatusActive {
 		return false
 	}
 
@@ -79,11 +68,11 @@ type GroupList struct {
 }
 
 // NewGroupList creates a new group list
-func NewGroupList(a SessionAssets, refs []*assets.GroupReference, missing assets.MissingCallback) *GroupList {
+func NewGroupList(groupAssets *GroupAssets, refs []*assets.GroupReference, missing assets.MissingCallback) *GroupList {
 	groups := make([]*Group, 0, len(refs))
 
 	for _, ref := range refs {
-		group := a.Groups().Get(ref.UUID)
+		group := groupAssets.Get(ref.UUID)
 		if group == nil {
 			missing(ref, nil)
 		} else {
@@ -93,15 +82,15 @@ func NewGroupList(a SessionAssets, refs []*assets.GroupReference, missing assets
 	return &GroupList{groups: groups}
 }
 
-// returns a clone of this group list
-func (l *GroupList) clone() *GroupList {
+// Clone returns a clone of this group list
+func (l *GroupList) Clone() *GroupList {
 	groups := make([]*Group, len(l.groups))
 	copy(groups, l.groups)
 	return &GroupList{groups: groups}
 }
 
-// returns this group list as a slice of group references
-func (l *GroupList) references() []*assets.GroupReference {
+// References returns this group list as a slice of group references
+func (l *GroupList) References() []*assets.GroupReference {
 	refs := make([]*assets.GroupReference, len(l.groups))
 	for i, group := range l.groups {
 		refs[i] = group.Reference()
@@ -170,22 +159,15 @@ type GroupAssets struct {
 }
 
 // NewGroupAssets creates a new set of group assets
-func NewGroupAssets(env envs.Environment, fields *core.FieldAssets, groups []assets.Group) (*GroupAssets, []assets.Group) {
-	broken := make([]assets.Group, 0)
+func NewGroupAssets(groups []*Group) *GroupAssets {
 	s := &GroupAssets{
-		all:    make([]*Group, 0, len(groups)),
+		all:    groups,
 		byUUID: make(map[assets.GroupUUID]*Group, len(groups)),
 	}
-	for _, asset := range groups {
-		group, err := NewGroup(env, fields, asset)
-		if err != nil {
-			broken = append(broken, asset)
-		} else {
-			s.all = append(s.all, group)
-			s.byUUID[group.UUID()] = group
-		}
+	for _, group := range groups {
+		s.byUUID[group.UUID()] = group
 	}
-	return s, broken
+	return s
 }
 
 // All returns all the groups

--- a/core/group_test.go
+++ b/core/group_test.go
@@ -1,13 +1,13 @@
-package flows_test
+package core_test
 
 import (
 	"testing"
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
+	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/nyaruka/goflow/test"
 
@@ -64,13 +64,13 @@ func TestGroupList(t *testing.T) {
 	}
 
 	// create empty
-	groups := flows.NewGroupList(sa, nil, missing)
+	groups := core.NewGroupList(sa.Groups(), nil, missing)
 
 	assert.Equal(t, 0, groups.Count())
 	assert.Equal(t, 0, len(missingRefs))
 
 	// create with some references
-	groups = flows.NewGroupList(sa, []*assets.GroupReference{
+	groups = core.NewGroupList(sa.Groups(), []*assets.GroupReference{
 		assets.NewGroupReference("990e1392-1f49-40c5-9662-f39609324bf9", "Testers"),
 		assets.NewGroupReference("f4f4b78e-f072-42e2-987d-f5c13da3166d", "Males"),
 		assets.NewGroupReference("7cb12d0e-e163-492c-95b1-28549cd04fe4", "I don't exist"),

--- a/core/label.go
+++ b/core/label.go
@@ -1,4 +1,4 @@
-package flows
+package core
 
 import (
 	"strings"

--- a/core/location.go
+++ b/core/location.go
@@ -1,4 +1,4 @@
-package flows
+package core
 
 import (
 	"regexp"

--- a/core/resthook.go
+++ b/core/resthook.go
@@ -1,4 +1,4 @@
-package flows
+package core
 
 import (
 	"github.com/nyaruka/goflow/assets"

--- a/core/template.go
+++ b/core/template.go
@@ -1,4 +1,4 @@
-package flows
+package core
 
 import (
 	"fmt"
@@ -7,7 +7,6 @@ import (
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/goflow/assets"
-	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/utils"
 )
 
@@ -33,7 +32,7 @@ func (t *Template) Reference() *assets.TemplateReference {
 }
 
 // FindTranslation finds the matching translation for the passed in channel and languages (in priority order)
-func (t *Template) FindTranslation(channel *core.Channel, locales []i18n.Locale) *TemplateTranslation {
+func (t *Template) FindTranslation(channel *Channel, locales []i18n.Locale) *TemplateTranslation {
 	// find all translations for this channel
 	candidates := make(map[string]*TemplateTranslation)
 	candidateLocales := make([]string, 0, 5)
@@ -52,22 +51,22 @@ func (t *Template) FindTranslation(channel *core.Channel, locales []i18n.Locale)
 }
 
 // Templating generates a templating object for the passed in translation and variables
-func (t *Template) Templating(tt *TemplateTranslation, vars []string) *core.MsgTemplating {
+func (t *Template) Templating(tt *TemplateTranslation, vars []string) *MsgTemplating {
 	// cross-reference with asset to get variable types and pad out any missing variables
-	variables := make([]*core.TemplatingVariable, len(tt.Variables()))
+	variables := make([]*TemplatingVariable, len(tt.Variables()))
 	for i, v := range tt.Variables() {
 		value := ""
 		if i < len(vars) {
 			value = vars[i]
 		}
-		variables[i] = &core.TemplatingVariable{Type: v.Type(), Value: value}
+		variables[i] = &TemplatingVariable{Type: v.Type(), Value: value}
 	}
 
 	// create a list of components that have variables
-	components := make([]*core.TemplatingComponent, 0, len(tt.Components()))
+	components := make([]*TemplatingComponent, 0, len(tt.Components()))
 	for _, comp := range tt.Components() {
 		if len(comp.Variables()) > 0 {
-			components = append(components, &core.TemplatingComponent{
+			components = append(components, &TemplatingComponent{
 				Type:      comp.Type(),
 				Name:      comp.Name(),
 				Variables: comp.Variables(),
@@ -75,7 +74,7 @@ func (t *Template) Templating(tt *TemplateTranslation, vars []string) *core.MsgT
 		}
 	}
 
-	return core.NewMsgTemplating(t.Reference(), components, variables)
+	return NewMsgTemplating(t.Reference(), components, variables)
 }
 
 // TemplateTranslation represents a single translation for a template
@@ -92,10 +91,10 @@ func NewTemplateTranslation(t assets.TemplateTranslation) *TemplateTranslation {
 func (t *TemplateTranslation) Asset() assets.TemplateTranslation { return t.TemplateTranslation }
 
 // Preview returns message content which will act as a preview of a message sent with this template
-func (t *TemplateTranslation) Preview(vars []*core.TemplatingVariable) *core.MsgContent {
+func (t *TemplateTranslation) Preview(vars []*TemplatingVariable) *MsgContent {
 	var text []string
 	var attachments []utils.Attachment
-	var quickReplies []core.QuickReply
+	var quickReplies []QuickReply
 
 	for _, comp := range t.Components() {
 		content := comp.Content()
@@ -113,12 +112,12 @@ func (t *TemplateTranslation) Preview(vars []*core.TemplatingVariable) *core.Msg
 			if comp.Type() == "header/text" || comp.Type() == "body/text" || comp.Type() == "footer/text" {
 				text = append(text, content)
 			} else if strings.HasPrefix(comp.Type(), "button/") {
-				quickReplies = append(quickReplies, core.QuickReply{Text: stringsx.TruncateEllipsis(content, core.MaxQuickReplyTextLength)})
+				quickReplies = append(quickReplies, QuickReply{Text: stringsx.TruncateEllipsis(content, MaxQuickReplyTextLength)})
 			}
 		}
 	}
 
-	return &core.MsgContent{Text: strings.Join(text, "\n\n"), Attachments: attachments, QuickReplies: quickReplies}
+	return &MsgContent{Text: strings.Join(text, "\n\n"), Attachments: attachments, QuickReplies: quickReplies}
 }
 
 // TemplateAssets is our type for all the templates in an environment

--- a/core/template_test.go
+++ b/core/template_test.go
@@ -1,4 +1,4 @@
-package flows_test
+package core_test
 
 import (
 	"fmt"
@@ -9,7 +9,6 @@ import (
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
 	"github.com/nyaruka/goflow/core"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/stretchr/testify/assert"
@@ -27,8 +26,8 @@ func TestFindTranslation(t *testing.T) {
 	tt3 := static.NewTemplateTranslation(channel1Ref, i18n.Locale("spa-ES"), []*static.TemplateComponent{}, []*static.TemplateVariable{})
 	tt4 := static.NewTemplateTranslation(channel2Ref, i18n.Locale("kin"), []*static.TemplateComponent{}, []*static.TemplateVariable{})
 
-	template := flows.NewTemplate(static.NewTemplate("c520cbda-e118-440f-aaf6-c0485088384f", "greeting", []*static.TemplateTranslation{tt1, tt2, tt3, tt4}))
-	tas := flows.NewTemplateAssets([]assets.Template{template})
+	template := core.NewTemplate(static.NewTemplate("c520cbda-e118-440f-aaf6-c0485088384f", "greeting", []*static.TemplateTranslation{tt1, tt2, tt3, tt4}))
+	tas := core.NewTemplateAssets([]assets.Template{template})
 
 	tcs := []struct {
 		channel  *core.Channel
@@ -57,7 +56,7 @@ func TestFindTranslation(t *testing.T) {
 	template = tas.Get(assets.TemplateUUID("c520cbda-e118-440f-aaf6-c0485088384f"))
 	assert.NotNil(t, template)
 	assert.Equal(t, assets.NewTemplateReference("c520cbda-e118-440f-aaf6-c0485088384f", "greeting"), template.Reference())
-	assert.Equal(t, (*assets.TemplateReference)(nil), (*flows.Template)(nil).Reference())
+	assert.Equal(t, (*assets.TemplateReference)(nil), (*core.Template)(nil).Reference())
 }
 
 func TestTemplating(t *testing.T) {
@@ -369,14 +368,14 @@ func TestTemplating(t *testing.T) {
 		tplAsset := &static.Template{}
 		jsonx.MustUnmarshal(tc.template, tplAsset)
 
-		tpl := flows.NewTemplate(tplAsset)
+		tpl := core.NewTemplate(tplAsset)
 		trans := tpl.FindTranslation(channel, []i18n.Locale{"eng"})
 		if assert.NotNil(t, trans, "%d: translation not found", i) {
 			// check templating
 			templating := tpl.Templating(trans, tc.variables)
 
 			if assert.Equal(t, tc.expectedTemplating, templating, "%d: preview mismatch", i) {
-				actualPreview := flows.NewTemplateTranslation(trans).Preview(templating.Variables)
+				actualPreview := core.NewTemplateTranslation(trans).Preview(templating.Variables)
 				assert.Equal(t, tc.expectedPreview, actualPreview, "%d: preview mismatch", i)
 			}
 		}

--- a/flows/actions/add_input_labels.go
+++ b/flows/actions/add_input_labels.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/flows"
 )
@@ -56,7 +57,7 @@ func (a *AddInputLabels) Execute(ctx context.Context, run flows.Run, step flows.
 	labels := resolveLabels(run, a.Labels, log)
 
 	if len(labels) > 0 {
-		log(events.NewInputLabelsAdded(input.UUID(), flows.LabelReferences(labels)))
+		log(events.NewInputLabelsAdded(input.UUID(), core.LabelReferences(labels)))
 	}
 
 	return nil

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -327,12 +327,12 @@ func resolveGroups(run flows.Run, references []*assets.GroupReference, log event
 }
 
 // helper function for actions that have a set of label references that must be resolved to actual labels
-func resolveLabels(run flows.Run, references []*assets.LabelReference, log events.EventLogger) []*flows.Label {
+func resolveLabels(run flows.Run, references []*assets.LabelReference, log events.EventLogger) []*core.Label {
 	labelAssets := run.Session().Assets().Labels()
-	labels := make([]*flows.Label, 0, len(references))
+	labels := make([]*core.Label, 0, len(references))
 
 	for _, ref := range references {
-		var label *flows.Label
+		var label *core.Label
 
 		if ref.Variable() {
 			// is an expression that evaluates to an existing label's name

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -292,12 +292,12 @@ func (a *createMsgAction) Inspect(dependency func(assets.Reference), local func(
 }
 
 // helper function for actions that have a set of group references that must be resolved to actual groups
-func resolveGroups(run flows.Run, references []*assets.GroupReference, log events.EventLogger) []*flows.Group {
+func resolveGroups(run flows.Run, references []*assets.GroupReference, log events.EventLogger) []*core.Group {
 	groupAssets := run.Session().Assets().Groups()
-	groups := make([]*flows.Group, 0, len(references))
+	groups := make([]*core.Group, 0, len(references))
 
 	for _, ref := range references {
-		var group *flows.Group
+		var group *core.Group
 
 		if ref.Variable() {
 			// is an expression that evaluates to an existing group's name

--- a/flows/actions/remove_contact_groups.go
+++ b/flows/actions/remove_contact_groups.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/modifiers"
@@ -58,7 +59,7 @@ func (a *RemoveContactGroups) Validate() error {
 
 // Execute runs the action
 func (a *RemoveContactGroups) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	var groups []*flows.Group
+	var groups []*core.Group
 
 	if a.AllGroups {
 		for _, group := range run.Session().Assets().Groups().All() {

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -79,7 +79,7 @@ func (a *SendMsg) Execute(ctx context.Context, run flows.Run, step flows.Step, l
 
 	sa := run.Session().Assets()
 
-	var template *flows.Template
+	var template *core.Template
 	var templateVariables []string
 	if a.Template != nil {
 		template = sa.Templates().Get(a.Template.UUID)

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -39,7 +39,7 @@ type Contact struct {
 	createdOn  time.Time
 	lastSeenOn *time.Time
 	urns       core.URNList
-	groups     *GroupList
+	groups     *core.GroupList
 	fields     core.FieldValues
 	tickets    *core.TicketList
 
@@ -69,7 +69,7 @@ func NewContact(
 		return nil, err
 	}
 
-	groupList := NewGroupList(sa, groups, missing)
+	groupList := core.NewGroupList(sa.Groups(), groups, missing)
 	fieldValues := core.NewFieldValues(sa.Fields(), fields, missing)
 	ticketsList := core.NewTicketList(tickets)
 
@@ -101,7 +101,7 @@ func NewEmptyContact(sa SessionAssets, name string, language i18n.Language, time
 		createdOn:  dates.Now(),
 		lastSeenOn: nil,
 		urns:       core.URNList{},
-		groups:     NewGroupList(sa, nil, assets.IgnoreMissing),
+		groups:     core.NewGroupList(sa.Groups(), nil, assets.IgnoreMissing),
 		fields:     make(core.FieldValues),
 		tickets:    core.NewTicketList(nil),
 		assets:     sa,
@@ -120,7 +120,7 @@ func (c *Contact) Clone() *Contact {
 		createdOn:  c.createdOn,
 		lastSeenOn: c.lastSeenOn,
 		urns:       c.urns.Clone(),
-		groups:     c.groups.clone(),
+		groups:     c.groups.Clone(),
 		fields:     c.fields.Clone(),
 		tickets:    core.NewTicketList(nil), // tickets not included
 		assets:     c.assets,
@@ -302,7 +302,7 @@ func (c *Contact) SetAffinity(urn urns.URN, ch *core.Channel) bool {
 func (c *Contact) Fields() core.FieldValues { return c.fields }
 
 // Groups returns the groups that this contact belongs to
-func (c *Contact) Groups() *GroupList { return c.groups }
+func (c *Contact) Groups() *core.GroupList { return c.groups }
 
 // Tickets returns the tickets for this contact
 func (c *Contact) Tickets() *core.TicketList { return c.tickets }
@@ -487,16 +487,16 @@ func (c *Contact) UpdatePreferredChannel(channel *core.Channel) bool {
 }
 
 // ReevaluateQueryBasedGroups reevaluates membership of all query based groups for this contact
-func (c *Contact) ReevaluateQueryBasedGroups(env envs.Environment) ([]*Group, []*Group) {
-	added := make([]*Group, 0)
-	removed := make([]*Group, 0)
+func (c *Contact) ReevaluateQueryBasedGroups(env envs.Environment) ([]*core.Group, []*core.Group) {
+	added := make([]*core.Group, 0)
+	removed := make([]*core.Group, 0)
 
 	for _, group := range c.assets.Groups().All() {
 		if !group.UsesQuery() {
 			continue
 		}
 
-		qualifies := group.CheckQueryBasedMembership(env, c)
+		qualifies := group.CheckQueryBasedMembership(env, c.Status(), c)
 
 		if qualifies {
 			if c.groups.Add(group) {
@@ -616,7 +616,7 @@ func (e *ContactEnvelope) Unmarshal(sa SessionAssets, missing assets.MissingCall
 		}
 	}
 
-	c.groups = NewGroupList(sa, e.Groups, missing)
+	c.groups = core.NewGroupList(sa.Groups(), e.Groups, missing)
 	c.fields = core.NewFieldValues(sa.Fields(), e.Fields, missing)
 
 	tickets := make([]*core.Ticket, len(e.Tickets))
@@ -638,7 +638,7 @@ func (c *Contact) Marshal() *ContactEnvelope {
 		CreatedOn:  c.createdOn,
 		LastSeenOn: c.lastSeenOn,
 		URNs:       c.urns.Encode(),
-		Groups:     c.groups.references(),
+		Groups:     c.groups.References(),
 	}
 
 	if c.timezone != nil {

--- a/flows/contact.go
+++ b/flows/contact.go
@@ -40,7 +40,7 @@ type Contact struct {
 	lastSeenOn *time.Time
 	urns       core.URNList
 	groups     *GroupList
-	fields     FieldValues
+	fields     core.FieldValues
 	tickets    *core.TicketList
 
 	// transient fields
@@ -70,7 +70,7 @@ func NewContact(
 	}
 
 	groupList := NewGroupList(sa, groups, missing)
-	fieldValues := NewFieldValues(sa, fields, missing)
+	fieldValues := core.NewFieldValues(sa.Fields(), fields, missing)
 	ticketsList := core.NewTicketList(tickets)
 
 	return &Contact{
@@ -102,7 +102,7 @@ func NewEmptyContact(sa SessionAssets, name string, language i18n.Language, time
 		lastSeenOn: nil,
 		urns:       core.URNList{},
 		groups:     NewGroupList(sa, nil, assets.IgnoreMissing),
-		fields:     make(FieldValues),
+		fields:     make(core.FieldValues),
 		tickets:    core.NewTicketList(nil),
 		assets:     sa,
 	}
@@ -121,7 +121,7 @@ func (c *Contact) Clone() *Contact {
 		lastSeenOn: c.lastSeenOn,
 		urns:       c.urns.Clone(),
 		groups:     c.groups.clone(),
-		fields:     c.fields.clone(),
+		fields:     c.fields.Clone(),
 		tickets:    core.NewTicketList(nil), // tickets not included
 		assets:     c.assets,
 	}
@@ -299,7 +299,7 @@ func (c *Contact) SetAffinity(urn urns.URN, ch *core.Channel) bool {
 }
 
 // Fields returns this contact's field values
-func (c *Contact) Fields() FieldValues { return c.fields }
+func (c *Contact) Fields() core.FieldValues { return c.fields }
 
 // Groups returns the groups that this contact belongs to
 func (c *Contact) Groups() *GroupList { return c.groups }
@@ -617,7 +617,7 @@ func (e *ContactEnvelope) Unmarshal(sa SessionAssets, missing assets.MissingCall
 	}
 
 	c.groups = NewGroupList(sa, e.Groups, missing)
-	c.fields = NewFieldValues(sa, e.Fields, missing)
+	c.fields = core.NewFieldValues(sa.Fields(), e.Fields, missing)
 
 	tickets := make([]*core.Ticket, len(e.Tickets))
 	for i, t := range e.Tickets {
@@ -648,7 +648,7 @@ func (c *Contact) Marshal() *ContactEnvelope {
 	e.Fields = make(map[string]*core.Value)
 	for _, v := range c.fields {
 		if v != nil {
-			e.Fields[v.field.Key()] = v.Value
+			e.Fields[v.Field().Key()] = v.Value
 		}
 	}
 

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -15,16 +15,16 @@ type sessionAssets struct {
 
 	campaigns *core.CampaignAssets
 	channels  *core.ChannelAssets
-	fields    *flows.FieldAssets
+	fields    *core.FieldAssets
 	flows     flows.FlowAssets
-	globals   *flows.GlobalAssets
+	globals   *core.GlobalAssets
 	groups    *flows.GroupAssets
-	labels    *flows.LabelAssets
+	labels    *core.LabelAssets
 	llms      *core.LLMAssets
-	locations *flows.LocationAssets
+	locations *core.LocationAssets
 	optIns    *core.OptInAssets
-	resthooks *flows.ResthookAssets
-	templates *flows.TemplateAssets
+	resthooks *core.ResthookAssets
+	templates *core.TemplateAssets
 	topics    *core.TopicAssets
 	users     *core.UserAssets
 }
@@ -86,7 +86,7 @@ func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfi
 		return nil, err
 	}
 
-	fieldAssets := flows.NewFieldAssets(fields)
+	fieldAssets := core.NewFieldAssets(fields)
 	groupAssets, _ := flows.NewGroupAssets(env, fieldAssets, groups)
 
 	return &sessionAssets{
@@ -95,34 +95,34 @@ func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfi
 		channels:  core.NewChannelAssets(channels),
 		fields:    fieldAssets,
 		flows:     definition.NewFlowAssets(source, migrationConfig),
-		globals:   flows.NewGlobalAssets(globals),
+		globals:   core.NewGlobalAssets(globals),
 		groups:    groupAssets,
-		labels:    flows.NewLabelAssets(labels),
+		labels:    core.NewLabelAssets(labels),
 		llms:      core.NewLLMAssets(llms),
-		locations: flows.NewLocationAssets(locations),
+		locations: core.NewLocationAssets(locations),
 		optIns:    core.NewOptInAssets(optIns),
-		resthooks: flows.NewResthookAssets(resthooks),
-		templates: flows.NewTemplateAssets(templates),
+		resthooks: core.NewResthookAssets(resthooks),
+		templates: core.NewTemplateAssets(templates),
 		topics:    core.NewTopicAssets(topics),
 		users:     core.NewUserAssets(users),
 	}, nil
 }
 
-func (s *sessionAssets) Source() assets.Source            { return s.source }
-func (s *sessionAssets) Campaigns() *core.CampaignAssets  { return s.campaigns }
-func (s *sessionAssets) Channels() *core.ChannelAssets    { return s.channels }
-func (s *sessionAssets) Fields() *flows.FieldAssets       { return s.fields }
-func (s *sessionAssets) Flows() flows.FlowAssets          { return s.flows }
-func (s *sessionAssets) Globals() *flows.GlobalAssets     { return s.globals }
-func (s *sessionAssets) Groups() *flows.GroupAssets       { return s.groups }
-func (s *sessionAssets) Labels() *flows.LabelAssets       { return s.labels }
-func (s *sessionAssets) LLMs() *core.LLMAssets            { return s.llms }
-func (s *sessionAssets) Locations() *flows.LocationAssets { return s.locations }
-func (s *sessionAssets) OptIns() *core.OptInAssets        { return s.optIns }
-func (s *sessionAssets) Resthooks() *flows.ResthookAssets { return s.resthooks }
-func (s *sessionAssets) Templates() *flows.TemplateAssets { return s.templates }
-func (s *sessionAssets) Topics() *core.TopicAssets        { return s.topics }
-func (s *sessionAssets) Users() *core.UserAssets          { return s.users }
+func (s *sessionAssets) Source() assets.Source           { return s.source }
+func (s *sessionAssets) Campaigns() *core.CampaignAssets { return s.campaigns }
+func (s *sessionAssets) Channels() *core.ChannelAssets   { return s.channels }
+func (s *sessionAssets) Fields() *core.FieldAssets       { return s.fields }
+func (s *sessionAssets) Flows() flows.FlowAssets         { return s.flows }
+func (s *sessionAssets) Globals() *core.GlobalAssets     { return s.globals }
+func (s *sessionAssets) Groups() *flows.GroupAssets      { return s.groups }
+func (s *sessionAssets) Labels() *core.LabelAssets       { return s.labels }
+func (s *sessionAssets) LLMs() *core.LLMAssets           { return s.llms }
+func (s *sessionAssets) Locations() *core.LocationAssets { return s.locations }
+func (s *sessionAssets) OptIns() *core.OptInAssets       { return s.optIns }
+func (s *sessionAssets) Resthooks() *core.ResthookAssets { return s.resthooks }
+func (s *sessionAssets) Templates() *core.TemplateAssets { return s.templates }
+func (s *sessionAssets) Topics() *core.TopicAssets       { return s.topics }
+func (s *sessionAssets) Users() *core.UserAssets         { return s.users }
 
 // Resolver methods used by contactql
 

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/contactql"
+	"github.com/nyaruka/goflow/contactql/parse"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
@@ -18,7 +20,7 @@ type sessionAssets struct {
 	fields    *core.FieldAssets
 	flows     flows.FlowAssets
 	globals   *core.GlobalAssets
-	groups    *flows.GroupAssets
+	groups    *core.GroupAssets
 	labels    *core.LabelAssets
 	llms      *core.LLMAssets
 	locations *core.LocationAssets
@@ -87,7 +89,20 @@ func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfi
 	}
 
 	fieldAssets := core.NewFieldAssets(fields)
-	groupAssets, _ := flows.NewGroupAssets(env, fieldAssets, groups)
+
+	// parse queries of any query based groups, skipping those which fail to parse
+	parsedGroups := make([]*core.Group, 0, len(groups))
+	for _, asset := range groups {
+		var query *contactql.ContactQuery
+		if asset.Query() != "" {
+			var err error
+			if query, err = parse.Query(env, asset.Query(), fieldAssets); err != nil {
+				continue
+			}
+		}
+		parsedGroups = append(parsedGroups, core.NewGroup(asset, query))
+	}
+	groupAssets := core.NewGroupAssets(parsedGroups)
 
 	return &sessionAssets{
 		source:    source,
@@ -114,7 +129,7 @@ func (s *sessionAssets) Channels() *core.ChannelAssets   { return s.channels }
 func (s *sessionAssets) Fields() *core.FieldAssets       { return s.fields }
 func (s *sessionAssets) Flows() flows.FlowAssets         { return s.flows }
 func (s *sessionAssets) Globals() *core.GlobalAssets     { return s.globals }
-func (s *sessionAssets) Groups() *flows.GroupAssets      { return s.groups }
+func (s *sessionAssets) Groups() *core.GroupAssets       { return s.groups }
 func (s *sessionAssets) Labels() *core.LabelAssets       { return s.labels }
 func (s *sessionAssets) LLMs() *core.LLMAssets           { return s.llms }
 func (s *sessionAssets) Locations() *core.LocationAssets { return s.locations }

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -565,7 +565,7 @@ func (s *session) ensureQueryBasedGroups(logEvent events.EventLogger) {
 
 	// add groups changed event for the groups we were added/removed to/from
 	if len(added) > 0 || len(removed) > 0 {
-		logEvent(events.NewContactGroupsChanged(flows.GroupReferences(added), flows.GroupReferences(removed)))
+		logEvent(events.NewContactGroupsChanged(core.GroupReferences(added), core.GroupReferences(removed)))
 	}
 }
 

--- a/flows/environment_test.go
+++ b/flows/environment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
+	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/engine"
@@ -89,7 +90,7 @@ func TestLocationResolver(t *testing.T) {
 	kigali := resolver.LookupLocation("Rwanda > Kigali City")
 	assert.Equal(t, "Kigali City", kigali.Name())
 
-	matches := resolver.FindLocationsFuzzy(env, "gisozi town", flows.LocationLevelWard, nil)
+	matches := resolver.FindLocationsFuzzy(env, "gisozi town", core.LocationLevelWard, nil)
 	assert.Equal(t, 1, len(matches))
 	assert.Equal(t, "Gisozi", matches[0].Name())
 }

--- a/flows/group.go
+++ b/flows/group.go
@@ -20,7 +20,7 @@ type Group struct {
 }
 
 // NewGroup returns a new group object from the given group asset
-func NewGroup(env envs.Environment, fields *FieldAssets, asset assets.Group) (*Group, error) {
+func NewGroup(env envs.Environment, fields *core.FieldAssets, asset assets.Group) (*Group, error) {
 	if asset.Query() != "" {
 		query, err := parse.Query(env, asset.Query(), fields)
 		if err != nil {
@@ -170,7 +170,7 @@ type GroupAssets struct {
 }
 
 // NewGroupAssets creates a new set of group assets
-func NewGroupAssets(env envs.Environment, fields *FieldAssets, groups []assets.Group) (*GroupAssets, []assets.Group) {
+func NewGroupAssets(env envs.Environment, fields *core.FieldAssets, groups []assets.Group) (*GroupAssets, []assets.Group) {
 	broken := make([]assets.Group, 0)
 	s := &GroupAssets{
 		all:    make([]*Group, 0, len(groups)),

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -57,7 +57,7 @@ type SessionAssets interface {
 	Fields() *core.FieldAssets
 	Flows() FlowAssets
 	Globals() *core.GlobalAssets
-	Groups() *GroupAssets
+	Groups() *core.GroupAssets
 	Labels() *core.LabelAssets
 	LLMs() *core.LLMAssets
 	Locations() *core.LocationAssets

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -54,16 +54,16 @@ type SessionAssets interface {
 
 	Campaigns() *core.CampaignAssets
 	Channels() *core.ChannelAssets
-	Fields() *FieldAssets
+	Fields() *core.FieldAssets
 	Flows() FlowAssets
-	Globals() *GlobalAssets
+	Globals() *core.GlobalAssets
 	Groups() *GroupAssets
-	Labels() *LabelAssets
+	Labels() *core.LabelAssets
 	LLMs() *core.LLMAssets
-	Locations() *LocationAssets
+	Locations() *core.LocationAssets
 	OptIns() *core.OptInAssets
-	Resthooks() *ResthookAssets
-	Templates() *TemplateAssets
+	Resthooks() *core.ResthookAssets
+	Templates() *core.TemplateAssets
 	Topics() *core.TopicAssets
 	Users() *core.UserAssets
 }

--- a/flows/modifiers/base.go
+++ b/flows/modifiers/base.go
@@ -67,7 +67,7 @@ func ReevaluateGroups(env envs.Environment, contact *flows.Contact, log events.E
 
 	// add groups changed event for the groups we were added/removed to/from
 	if len(added) > 0 || len(removed) > 0 {
-		log(events.NewContactGroupsChanged(flows.GroupReferences(added), flows.GroupReferences(removed)))
+		log(events.NewContactGroupsChanged(core.GroupReferences(added), core.GroupReferences(removed)))
 	}
 }
 

--- a/flows/modifiers/base_test.go
+++ b/flows/modifiers/base_test.go
@@ -184,7 +184,7 @@ func TestConstructors(t *testing.T) {
 			}`,
 		},
 		{
-			modifiers.NewGroups([]*flows.Group{testers}, modifiers.GroupsAdd),
+			modifiers.NewGroups([]*core.Group{testers}, modifiers.GroupsAdd),
 			`{
 				"type": "groups",
 				"groups": [

--- a/flows/modifiers/field.go
+++ b/flows/modifiers/field.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
@@ -25,12 +26,12 @@ const TypeField string = "field"
 type Field struct {
 	baseModifier
 
-	field *flows.Field
+	field *core.Field
 	value string
 }
 
 // NewField creates a new field modifier
-func NewField(field *flows.Field, value string) *Field {
+func NewField(field *core.Field, value string) *Field {
 	return &Field{
 		baseModifier: newBaseModifier(TypeField),
 		field:        field,
@@ -80,7 +81,7 @@ func readField(sa flows.SessionAssets, data []byte, missing assets.MissingCallba
 		return nil, err
 	}
 
-	var field *flows.Field
+	var field *core.Field
 	if e.Field != nil {
 		field = sa.Fields().Get(e.Field.Key)
 		if field == nil {

--- a/flows/modifiers/groups.go
+++ b/flows/modifiers/groups.go
@@ -33,12 +33,12 @@ const (
 type Groups struct {
 	baseModifier
 
-	groups       []*flows.Group
+	groups       []*core.Group
 	modification GroupsModification
 }
 
 // NewGroups creates a new groups modifier
-func NewGroups(groups []*flows.Group, modification GroupsModification) *Groups {
+func NewGroups(groups []*core.Group, modification GroupsModification) *Groups {
 	return &Groups{
 		baseModifier: newBaseModifier(TypeGroups),
 		groups:       groups,
@@ -53,7 +53,7 @@ func (m *Groups) Apply(ctx context.Context, eng flows.Engine, env envs.Environme
 		return false, nil
 	}
 
-	diff := make([]*flows.Group, 0, len(m.groups))
+	diff := make([]*core.Group, 0, len(m.groups))
 
 	if m.modification == GroupsAdd {
 		for _, group := range m.groups {
@@ -73,7 +73,7 @@ func (m *Groups) Apply(ctx context.Context, eng flows.Engine, env envs.Environme
 
 		// only generate event if contact's groups change
 		if len(diff) > 0 {
-			log(events.NewContactGroupsChanged(flows.GroupReferences(diff), nil))
+			log(events.NewContactGroupsChanged(core.GroupReferences(diff), nil))
 			return true, nil
 		}
 
@@ -95,7 +95,7 @@ func (m *Groups) Apply(ctx context.Context, eng flows.Engine, env envs.Environme
 
 		// only generate event if contact's groups change
 		if len(diff) > 0 {
-			log(events.NewContactGroupsChanged(nil, flows.GroupReferences(diff)))
+			log(events.NewContactGroupsChanged(nil, core.GroupReferences(diff)))
 			return true, nil
 		}
 	}
@@ -122,7 +122,7 @@ func readGroups(sa flows.SessionAssets, data []byte, missing assets.MissingCallb
 		return nil, err
 	}
 
-	groups := make([]*flows.Group, 0, len(e.Groups))
+	groups := make([]*core.Group, 0, len(e.Groups))
 	for _, groupRef := range e.Groups {
 		group := sa.Groups().Get(groupRef.UUID)
 		if group == nil {

--- a/flows/routers/cases/tests.go
+++ b/flows/routers/cases/tests.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/functions"
 	"github.com/nyaruka/goflow/excellent/types"
-	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 
 	"github.com/shopspring/decimal"
@@ -566,7 +565,7 @@ func HasState(env envs.Environment, text *types.XText) types.XValue {
 		return types.NewXErrorf("can't find locations in environment which is not location enabled")
 	}
 
-	states := locations.FindLocationsFuzzy(env, text.Native(), flows.LocationLevelState, nil)
+	states := locations.FindLocationsFuzzy(env, text.Native(), core.LocationLevelState, nil)
 	if len(states) > 0 {
 		return NewTrueResult(types.NewXText(string(states[0].Path())))
 	}
@@ -603,9 +602,9 @@ func HasDistrict(env envs.Environment, args ...types.XValue) types.XValue {
 		stateText = types.XTextEmpty
 	}
 
-	states := locations.FindLocationsFuzzy(env, stateText.Native(), flows.LocationLevelState, nil)
+	states := locations.FindLocationsFuzzy(env, stateText.Native(), core.LocationLevelState, nil)
 	if len(states) > 0 {
-		districts := locations.FindLocationsFuzzy(env, text.Native(), flows.LocationLevelDistrict, states[0])
+		districts := locations.FindLocationsFuzzy(env, text.Native(), core.LocationLevelDistrict, states[0])
 		if len(districts) > 0 {
 			return NewTrueResult(types.NewXText(string(districts[0].Path())))
 		}
@@ -613,7 +612,7 @@ func HasDistrict(env envs.Environment, args ...types.XValue) types.XValue {
 
 	// try without a parent state - it's ok as long as we get a single match
 	if stateText.Empty() {
-		districts := locations.FindLocationsFuzzy(env, text.Native(), flows.LocationLevelDistrict, nil)
+		districts := locations.FindLocationsFuzzy(env, text.Native(), core.LocationLevelDistrict, nil)
 		if len(districts) == 1 {
 			return NewTrueResult(types.NewXText(string(districts[0].Path())))
 		}
@@ -663,11 +662,11 @@ func HasWard(env envs.Environment, args ...types.XValue) types.XValue {
 		districtText = types.XTextEmpty
 	}
 
-	states := locations.FindLocationsFuzzy(env, stateText.Native(), flows.LocationLevelState, nil)
+	states := locations.FindLocationsFuzzy(env, stateText.Native(), core.LocationLevelState, nil)
 	if len(states) > 0 {
-		districts := locations.FindLocationsFuzzy(env, districtText.Native(), flows.LocationLevelDistrict, states[0])
+		districts := locations.FindLocationsFuzzy(env, districtText.Native(), core.LocationLevelDistrict, states[0])
 		if len(districts) > 0 {
-			wards := locations.FindLocationsFuzzy(env, text.Native(), flows.LocationLevelWard, districts[0])
+			wards := locations.FindLocationsFuzzy(env, text.Native(), core.LocationLevelWard, districts[0])
 			if len(wards) > 0 {
 				return NewTrueResult(types.NewXText(string(wards[0].Path())))
 			}
@@ -676,7 +675,7 @@ func HasWard(env envs.Environment, args ...types.XValue) types.XValue {
 
 	// try without a parent district - it's ok as long as we get a single match
 	if districtText.Empty() {
-		wards := locations.FindLocationsFuzzy(env, text.Native(), flows.LocationLevelWard, nil)
+		wards := locations.FindLocationsFuzzy(env, text.Native(), core.LocationLevelWard, nil)
 		if len(wards) == 1 {
 			return NewTrueResult(types.NewXText(string(wards[0].Path())))
 		}


### PR DESCRIPTION
Continues the re-org (#1523, #1527, #1529) in two commits:

**Remaining asset wrappers** — `Field` (with `FieldValue`/`FieldValues` and the location-aware value parsing), `Global`, `Label`, `Location` (+ the `LocationLevel*` constants), `Resthook` and `Template`/`TemplateTranslation` move to `core` with their `*Assets` collections. `Field` was previously blocked on the contactql coupling that #1529 removed — `FieldAssets` still doubles as the `contactql.Resolver` for group query validation, now against the light package. API adjustments follow the established pattern:

* `NewFieldValues` takes `*core.FieldAssets` instead of full session assets
* `FieldValues.Clone()` exported (called from `flows.Contact`), and `FieldValue` gains a `Field()` accessor

**Group, with parsing hoisted to the engine** — `core.NewGroup(asset, query)` now takes an already-parsed `*contactql.ContactQuery`, and the engine parses group queries when building session assets (still skipping groups whose queries fail to parse). This is the payoff of the #1529 split: `core` imports the light `contactql` package for evaluation, and its dependency graph — and therefore that of `core/events` and its consumers — still contains zero ANTLR.

Notes for review:

* `CheckQueryBasedMembership(env, status, queryable)` is a transient signature — it takes a status + `contactql.Queryable` instead of `*flows.Contact` because `Contact` hasn't moved yet; it reverts to taking a contact when it does.
* The `Group.resolver` field is dropped — it was set at construction but never read (the parsed query carries its own resolver for evaluation).
* `NewGroupList` takes `*core.GroupAssets` and `GroupList.Clone()`/`References()` are exported, same narrowing/export pattern as previous stages.

With this, every asset wrapper lives in `core`, and `flows.SessionAssets` is effectively `core` asset access + `Flows()` + the contactql `Resolver`. The remaining stage moves `Contact` and introduces a `core.Assets` interface.