### PR TITLE
Add excellent.Template - a parsed, immutable representation of a template

### DIFF
--- a/excellent/template.go
+++ b/excellent/template.go
@@ -1,0 +1,146 @@
+package excellent
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/excellent/types"
+)
+
+// Template is a parsed representation of a template string, e.g. "Hi @contact.name!". It is immutable after parsing
+// and thus safe for concurrent use - parsing a template once and evaluating it many times is equivalent to passing
+// the original string to Evaluator.Template each time.
+type Template struct {
+	segments []templateSegment
+}
+
+// ParseTemplate parses the given template source. It never returns an error - a segment which is a malformed
+// expression is retained as-is and generates the same error when the template is evaluated.
+func ParseTemplate(src string) *Template {
+	t := &Template{}
+
+	// scan the source twice - once without unescaping so that text segments retain their original source including
+	// @@ sequences, and once with unescaping to get the values that text segments evaluate to.. the two scans always
+	// produce the same sequence of tokens, differing only in the text of BODY tokens
+	rawScanner := NewXScanner(strings.NewReader(src), nil)
+	rawScanner.SetUnescapeBody(false)
+	valScanner := NewXScanner(strings.NewReader(src), nil)
+
+	for {
+		tokenType, rawToken := rawScanner.Scan()
+		_, valToken := valScanner.Scan()
+
+		switch tokenType {
+		case EOF:
+			return t
+		case BODY:
+			t.segments = append(t.segments, &textSegment{src: rawToken, val: valToken})
+		case IDENTIFIER:
+			expression, err := Parse(rawToken, nil)
+			topLevel, _, _ := strings.Cut(rawToken, ".")
+			t.segments = append(t.segments, &expressionSegment{
+				src:        "@" + rawToken,
+				topLevel:   strings.ToLower(topLevel),
+				expression: expression,
+				err:        err,
+			})
+		case EXPRESSION:
+			expression, err := Parse(rawToken, nil)
+			t.segments = append(t.segments, &expressionSegment{
+				src:        "@(" + rawToken + ")",
+				expression: expression,
+				err:        err,
+			})
+		}
+	}
+}
+
+// String returns the original source of this template, reconstructed from the retained source of each segment.
+func (t *Template) String() string {
+	var buf strings.Builder
+	for _, s := range t.segments {
+		buf.WriteString(s.source())
+	}
+	return buf.String()
+}
+
+// Evaluate evaluates this template against the given context, producing the same output, warnings and error as
+// passing the original source to Evaluator.Template.
+func (t *Template) Evaluate(env envs.Environment, ctx *types.XObject, escaping Escaping) (string, []string, error) {
+	var buf strings.Builder
+	var warnings []string
+	errors := NewTemplateErrors()
+	topLevels := ctx.Properties()
+
+	for _, segment := range t.segments {
+		switch s := segment.(type) {
+		case *textSegment:
+			buf.WriteString(s.val)
+		case *expressionSegment:
+			// an identifier whose top-level isn't a property of the context is treated as literal text,
+			// e.g. the @gmail in an email address
+			if s.topLevel != "" && !slices.Contains(topLevels, s.topLevel) {
+				buf.WriteString(s.src)
+				continue
+			}
+
+			value, segWarnings := s.evaluate(env, ctx)
+			warnings = append(warnings, segWarnings...)
+
+			// if we got an error, add it to our list and move on
+			if types.IsXError(value) {
+				errors.Add(s.src, value.(error).Error())
+				continue
+			}
+
+			// if not, stringify value and append to the output
+			asText, _ := types.ToXText(env, value)
+			asString := asText.Native()
+
+			if escaping != nil {
+				asString = escaping(asString)
+			}
+
+			buf.WriteString(asString)
+		}
+	}
+
+	if errors.HasErrors() {
+		return buf.String(), warnings, errors
+	}
+	return buf.String(), warnings, nil
+}
+
+// a segment of a parsed template - either literal text or an expression
+type templateSegment interface {
+	source() string
+}
+
+// a segment of literal text
+type textSegment struct {
+	src string // original source, e.g. "hi @@there"
+	val string // unescaped value, e.g. "hi @there"
+}
+
+func (s *textSegment) source() string { return s.src }
+
+// a segment which is an expression, in either @identifier or @(...) form
+type expressionSegment struct {
+	src        string     // original source, e.g. "@contact.name" or "@(1 + 2)"
+	topLevel   string     // lowercased top-level of an @identifier segment, empty for @(...) segments
+	expression Expression // parsed expression, nil if source is malformed
+	err        error      // error from parsing if source is malformed
+}
+
+func (s *expressionSegment) source() string { return s.src }
+
+func (s *expressionSegment) evaluate(env envs.Environment, ctx *types.XObject) (types.XValue, []string) {
+	if s.err != nil {
+		return types.NewXError(s.err), nil
+	}
+
+	warnings := &Warnings{}
+	value := s.expression.Evaluate(env, NewScope(ctx, nil), warnings)
+	return value, warnings.all
+}

--- a/excellent/template_test.go
+++ b/excellent/template_test.go
@@ -1,0 +1,271 @@
+package excellent_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/excellent"
+	"github.com/nyaruka/goflow/excellent/functions"
+	"github.com/nyaruka/goflow/excellent/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// a mix of templates that exercise every segment kind - literal text, @@ escapes, @identifier and @(...) forms,
+// valid and invalid identifiers, malformed expressions, and evaluation errors
+var templateTestCases = []string{
+	``,
+	`hello world`,
+	`@string1`,
+	`@string1 world`,
+	`Hello @(title(string1))`,
+	`@(string1 & string2)`,
+	`@("hello\nworld")`,
+	`@("\"hello\nworld\"")`,
+	`@( "quoted )pa)ren" )`,
+	`@(  1  +  2  )`,
+	`@(title("hello"))`,
+	`@(title(hello))`,
+	`@string1.xxx`,
+	`@hello`,
+	`@hello.bar`,
+	`My email is foo@bar.com`,
+	`@`,
+	`@@`,
+	`@@string1`,
+	`@@@string1`,
+	`@@@@string1`,
+	`Hello @@string1 world`,
+	`@string1@string2`,
+	`@string1.@string2`,
+	`@string1.@string2.@string3`,
+	`@(string1`,
+	`@ (string1`,
+	`@ (string1)`,
+	`@((`,
+	`@('x')`,
+	`@(0 / )`,
+	`@(0 / )@('x')`,
+	`@(1.1.0)`,
+	`@array1`,
+	`@array1[0]`,
+	`@array1.0`,
+	`@(array1[0])`,
+	`@array2d.0.2`,
+	`@_special`,
+	`@汉字 chinese`,
+	`@(汉字)`,
+	`@😀`,
+	`@legacy and @legacy again`,
+	`@(1 / 0)`,
+	`@(err)`,
+	`1 + 2`,
+	"line1\nline2 @string1\n@@line3",
+}
+
+func makeTemplateContext() *types.XObject {
+	legacy := types.NewXText("old")
+	legacy.SetDeprecated("use something else")
+
+	return types.NewXObject(map[string]types.XValue{
+		"string1":  types.NewXText("foo"),
+		"string2":  types.NewXText("bar"),
+		"_special": types.NewXText("🐒"),
+		"汉字":       types.NewXText("simplified chinese"),
+		"int1":     types.NewXNumberFromInt(1),
+		"dec1":     types.RequireXNumberFromString("1.5"),
+		"words":    types.NewXText("one two three"),
+		"array1":   types.NewXArray(types.NewXText("one"), types.NewXText("two"), types.NewXText("three")),
+		"legacy":   legacy,
+		"err":      types.NewXError(fmt.Errorf("an error")),
+		"func":     functions.Lookup("upper"),
+		"thing": types.NewXObject(map[string]types.XValue{
+			"foo": types.NewXText("bar"),
+			"zed": types.NewXNumberFromInt(123),
+		}),
+	})
+}
+
+// asserts that parsing the given source round-trips exactly and that evaluating the parsed template produces
+// the same output, warnings and error as the existing evaluator
+func assertTemplateEquivalent(t *testing.T, env envs.Environment, ctx *types.XObject, src string, escaping excellent.Escaping) {
+	t.Helper()
+
+	template := excellent.ParseTemplate(src)
+	require.Equal(t, src, template.String(), "round trip mismatch for template %q", src)
+
+	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(env, ctx, src, escaping)
+	actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, escaping)
+
+	assert.Equal(t, expectedVal, actualVal, "output mismatch for template %q", src)
+	assert.Equal(t, expectedWarns, actualWarns, "warnings mismatch for template %q", src)
+
+	if expectedErr != nil {
+		require.Error(t, actualErr, "expected error for template %q", src)
+		assert.Equal(t, expectedErr.Error(), actualErr.Error(), "error mismatch for template %q", src)
+	} else {
+		assert.NoError(t, actualErr, "unexpected error for template %q", src)
+	}
+}
+
+func TestParseTemplate(t *testing.T) {
+	env := envs.NewBuilder().Build()
+	ctx := makeTemplateContext()
+
+	escaping := func(s string) string { return strings.ReplaceAll(s, `"`, `\"`) }
+
+	for _, src := range templateTestCases {
+		assertTemplateEquivalent(t, env, ctx, src, nil)
+		assertTemplateEquivalent(t, env, ctx, src, escaping)
+	}
+
+	// context with no matching properties means identifiers are treated as literal text
+	empty := types.NewXObject(map[string]types.XValue{})
+	assertTemplateEquivalent(t, env, empty, `Hello @string1 and @(string2)`, nil)
+}
+
+// tests that a template parsed once can be safely evaluated concurrently (run with -race).. note that contexts
+// are per-goroutine because XObject lazily initializes itself and so isn't itself safe for concurrent use
+func TestTemplateConcurrentUse(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
+	template := excellent.ParseTemplate(`Hello @string1, @thing.foo is @(int1 + 2) @@here`)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := makeTemplateContext()
+			for range 100 {
+				val, _, err := template.Evaluate(env, ctx, nil)
+				assert.NoError(t, err)
+				assert.Equal(t, `Hello foo, bar is 3 @here`, val)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// loads a corpus of template strings from the flow definitions in the repo's test fixtures
+func loadFixtureTemplates(tb testing.TB) []string {
+	paths, err := filepath.Glob("../test/testdata/runner/*.json")
+	require.NoError(tb, err)
+	require.NotEmpty(tb, paths)
+
+	seen := make(map[string]bool)
+	var templates []string
+
+	var collect func(v any)
+	collect = func(v any) {
+		switch typed := v.(type) {
+		case string:
+			if !seen[typed] {
+				seen[typed] = true
+				templates = append(templates, typed)
+			}
+		case map[string]any:
+			for _, item := range typed {
+				collect(item)
+			}
+		case []any:
+			for _, item := range typed {
+				collect(item)
+			}
+		}
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		require.NoError(tb, err)
+
+		var parsed any
+		require.NoError(tb, json.Unmarshal(data, &parsed))
+		collect(parsed)
+	}
+
+	return templates
+}
+
+func TestParseTemplateWithFixtures(t *testing.T) {
+	env := envs.NewBuilder().Build()
+	ctx := makeTemplateContext()
+
+	templates := loadFixtureTemplates(t)
+	require.Greater(t, len(templates), 1000) // sanity check that we loaded a real corpus
+
+	for _, src := range templates {
+		assertTemplateEquivalent(t, env, ctx, src, nil)
+	}
+}
+
+func FuzzParseTemplate(f *testing.F) {
+	for _, src := range templateTestCases {
+		f.Add(src)
+	}
+
+	env := envs.NewBuilder().Build()
+	ctx := makeTemplateContext()
+
+	f.Fuzz(func(t *testing.T, src string) {
+		// the scanner reads runes so it only round-trips valid UTF-8, and treats NUL as end of input
+		if !utf8.ValidString(src) || strings.ContainsRune(src, 0) {
+			t.Skip()
+		}
+
+		template := excellent.ParseTemplate(src)
+		if template.String() != src {
+			t.Fatalf("round trip mismatch: %q != %q", template.String(), src)
+		}
+
+		// skip evaluation of very large inputs to keep fuzzing fast
+		if len(src) > 1000 {
+			return
+		}
+
+		expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(env, ctx, src, nil)
+		actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, nil)
+
+		if actualVal != expectedVal {
+			t.Fatalf("output mismatch for %q: %q != %q", src, actualVal, expectedVal)
+		}
+		if !slices.Equal(actualWarns, expectedWarns) {
+			t.Fatalf("warnings mismatch for %q: %v != %v", src, actualWarns, expectedWarns)
+		}
+		if (actualErr != nil) != (expectedErr != nil) || (actualErr != nil && actualErr.Error() != expectedErr.Error()) {
+			t.Fatalf("error mismatch for %q: %v != %v", src, actualErr, expectedErr)
+		}
+	})
+}
+
+const benchmarkTemplate = `Hello @string1, @thing.foo is @(int1 + 2) @@here with @(upper(words))`
+
+func BenchmarkEvaluatorTemplate(b *testing.B) {
+	env := envs.NewBuilder().Build()
+	ctx := makeTemplateContext()
+	eval := excellent.NewEvaluator()
+
+	b.ResetTimer()
+	for range b.N {
+		eval.Template(env, ctx, benchmarkTemplate, nil)
+	}
+}
+
+func BenchmarkTemplateEvaluate(b *testing.B) {
+	env := envs.NewBuilder().Build()
+	ctx := makeTemplateContext()
+	template := excellent.ParseTemplate(benchmarkTemplate)
+
+	b.ResetTimer()
+	for range b.N {
+		template.Evaluate(env, ctx, nil)
+	}
+}


### PR DESCRIPTION
Adds `excellent.Template` - a template string parsed once into segments, which can then be evaluated many times. Pure addition; no existing call sites change.

- `ParseTemplate(src)` never returns an error - a segment which is a malformed expression is retained and surfaces the same error at evaluation time, matching current semantics. Since whether `@foo` is an expression or literal text depends on the context's top-level properties (only known at evaluation time), identifiers are parsed unconditionally and their top-level check is deferred to `Evaluate`, keeping templates context-agnostic.
- `String()` returns the original source byte-for-byte - segments retain their source (including `@@` escapes) rather than reconstructing from the AST.
- `Evaluate(env, ctx, escaping)` produces output, warnings and errors identical to `Evaluator.Template`.
- Immutable after construction, so safe for concurrent evaluation.

Tests:
- Round-trip and equivalence vs `Evaluator.Template` over a table of adversarial templates plus every string from the flow definitions in `test/testdata/runner` (>1000 unique).
- A fuzz target checking both properties (660k+ execs clean in a local run). It skips invalid UTF-8 and NUL since the rune-based scanner can't round-trip those (pre-existing scanner behavior).
- Concurrent evaluation of a shared template under `-race`. Contexts are per-goroutine because `XObject` lazily initializes and isn't itself concurrency-safe (also pre-existing, applies equally to the current evaluator).
- Benchmarks: parse-once-evaluate-N is ~8.5x faster than parsing per evaluation (12,731 → 1,494 ns/op, 292 → 36 allocs/op).