### PR TITLE
Add optional routing fields to typing events

### DIFF
--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -477,25 +477,25 @@ func TestEventMarshaling(t *testing.T) {
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStarted(events.DirectionIncoming)
+				return events.NewTypingStarted(events.DirectionIncoming, facebook.Reference(), urns.URN("facebook:1234567890"), "EX12345")
 			},
 			`typing_started_incoming`,
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStarted(events.DirectionOutgoing)
+				return events.NewTypingStarted(events.DirectionOutgoing, nil, urns.NilURN, "")
 			},
 			`typing_started_outgoing`,
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStopped(events.DirectionIncoming)
+				return events.NewTypingStopped(events.DirectionIncoming, facebook.Reference(), urns.URN("facebook:1234567890"), "EX12345")
 			},
 			`typing_stopped_incoming`,
 		},
 		{
 			func() events.Event {
-				return events.NewTypingStopped(events.DirectionOutgoing)
+				return events.NewTypingStopped(events.DirectionOutgoing, nil, urns.NilURN, "")
 			},
 			`typing_stopped_outgoing`,
 		},

--- a/core/events/testdata/TestEventMarshaling_typing_started_incoming.snap
+++ b/core/events/testdata/TestEventMarshaling_typing_started_incoming.snap
@@ -2,5 +2,11 @@
     "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
     "type": "typing_started",
     "created_on": "2025-05-04T12:30:46.123456789Z",
-    "direction": "incoming"
+    "direction": "incoming",
+    "channel": {
+        "uuid": "4bb288a0-7fca-4da1-abe8-59a593aff648",
+        "name": "Facebook Channel"
+    },
+    "urn": "facebook:1234567890",
+    "msg_external_id": "EX12345"
 }

--- a/core/events/testdata/TestEventMarshaling_typing_stopped_incoming.snap
+++ b/core/events/testdata/TestEventMarshaling_typing_stopped_incoming.snap
@@ -2,5 +2,11 @@
     "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
     "type": "typing_stopped",
     "created_on": "2025-05-04T12:30:46.123456789Z",
-    "direction": "incoming"
+    "direction": "incoming",
+    "channel": {
+        "uuid": "4bb288a0-7fca-4da1-abe8-59a593aff648",
+        "name": "Facebook Channel"
+    },
+    "urn": "facebook:1234567890",
+    "msg_external_id": "EX12345"
 }

--- a/core/events/typing_started.go
+++ b/core/events/typing_started.go
@@ -1,5 +1,10 @@
 package events
 
+import (
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+)
+
 func init() {
 	registerType(TypeTypingStarted, func() Event { return &TypingStarted{} })
 }
@@ -8,27 +13,37 @@ func init() {
 const TypeTypingStarted string = "typing_started"
 
 // TypingStarted events are created when the contact (direction of incoming) or a user (direction of outgoing)
-// starts typing.
+// starts typing. The optional channel, urn and msg_external_id fields identify where the contact last wrote from -
+// the source of incoming typing and the destination of outgoing typing.
 //
 //	{
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
 //	  "type": "typing_started",
 //	  "created_on": "2019-01-02T15:04:05Z",
-//	  "direction": "incoming"
+//	  "direction": "incoming",
+//	  "channel": {"uuid": "61602f3e-f603-4c70-8a8f-c477505bf4bf", "name": "Facebook"},
+//	  "urn": "tel:+12065551212",
+//	  "msg_external_id": "EX12345"
 //	}
 //
 // @event typing_started
 type TypingStarted struct {
 	BaseEvent
 
-	Direction Direction `json:"direction" validate:"required,direction"`
+	Direction     Direction                `json:"direction" validate:"required,direction"`
+	Channel       *assets.ChannelReference `json:"channel,omitempty"`
+	URN           urns.URN                 `json:"urn,omitempty" validate:"omitempty,urn"`
+	MsgExternalID string                   `json:"msg_external_id,omitempty"`
 }
 
 // NewTypingStarted returns a new typing started event
-func NewTypingStarted(direction Direction) *TypingStarted {
+func NewTypingStarted(direction Direction, channel *assets.ChannelReference, urn urns.URN, msgExternalID string) *TypingStarted {
 	return &TypingStarted{
-		BaseEvent: NewBaseEvent(TypeTypingStarted),
-		Direction: direction,
+		BaseEvent:     NewBaseEvent(TypeTypingStarted),
+		Direction:     direction,
+		Channel:       channel,
+		URN:           urn,
+		MsgExternalID: msgExternalID,
 	}
 }
 

--- a/core/events/typing_stopped.go
+++ b/core/events/typing_stopped.go
@@ -1,5 +1,10 @@
 package events
 
+import (
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/goflow/assets"
+)
+
 func init() {
 	registerType(TypeTypingStopped, func() Event { return &TypingStopped{} })
 }
@@ -8,27 +13,37 @@ func init() {
 const TypeTypingStopped string = "typing_stopped"
 
 // TypingStopped events are created when the contact (direction of incoming) or a user (direction of outgoing)
-// stops typing.
+// stops typing. The optional channel, urn and msg_external_id fields identify where the contact last wrote from -
+// the source of incoming typing and the destination of outgoing typing.
 //
 //	{
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
 //	  "type": "typing_stopped",
 //	  "created_on": "2019-01-02T15:04:05Z",
-//	  "direction": "incoming"
+//	  "direction": "incoming",
+//	  "channel": {"uuid": "61602f3e-f603-4c70-8a8f-c477505bf4bf", "name": "Facebook"},
+//	  "urn": "tel:+12065551212",
+//	  "msg_external_id": "EX12345"
 //	}
 //
 // @event typing_stopped
 type TypingStopped struct {
 	BaseEvent
 
-	Direction Direction `json:"direction" validate:"required,direction"`
+	Direction     Direction                `json:"direction" validate:"required,direction"`
+	Channel       *assets.ChannelReference `json:"channel,omitempty"`
+	URN           urns.URN                 `json:"urn,omitempty" validate:"omitempty,urn"`
+	MsgExternalID string                   `json:"msg_external_id,omitempty"`
 }
 
 // NewTypingStopped returns a new typing stopped event
-func NewTypingStopped(direction Direction) *TypingStopped {
+func NewTypingStopped(direction Direction, channel *assets.ChannelReference, urn urns.URN, msgExternalID string) *TypingStopped {
 	return &TypingStopped{
-		BaseEvent: NewBaseEvent(TypeTypingStopped),
-		Direction: direction,
+		BaseEvent:     NewBaseEvent(TypeTypingStopped),
+		Direction:     direction,
+		Channel:       channel,
+		URN:           urn,
+		MsgExternalID: msgExternalID,
 	}
 }
 


### PR DESCRIPTION
Adds optional `channel`, `urn` and `msg_external_id` fields to the `typing_started` and `typing_stopped` events so they can carry the routing information needed to relay typing indicators between chat frontends and messaging platforms:

* `channel` — reference to the chat channel
* `urn` — the contact URN on that channel
* `msg_external_id` — the platform's own ID of the newest incoming message (some platforms, e.g. WhatsApp, require referencing a message ID when sending a typing indicator)

Together these identify where the contact last wrote from — the destination for outgoing typing indicators and the source for incoming ones. All three are optional since a bare co-presence event doesn't need routing.

This lets these events serve as the single vocabulary for typing indicators end to end, in place of courier's separate chat-action strings.