### PR TITLE
Replace Contact.ResolveRoutes with singular ResolveRoute

### DIFF
--- a/core/contact.go
+++ b/core/contact.go
@@ -469,20 +469,15 @@ type Route struct {
 	Channel *Channel
 }
 
-// ResolveRoutes resolves possible URN/channel routes for sending
-func (c *Contact) ResolveRoutes(all bool) []Route {
-	routes := []Route{}
-
+// ResolveRoute resolves the first sendable URN/channel route for this contact, or nil if there is none
+func (c *Contact) ResolveRoute() *Route {
 	for _, u := range c.urns {
 		channel := c.assets.Channels().GetForURN(u, assets.ChannelRoleSend)
 		if channel != nil {
-			routes = append(routes, Route{URN: u.Identity(), Channel: channel})
-			if !all {
-				break
-			}
+			return &Route{URN: u.Identity(), Channel: channel}
 		}
 	}
-	return routes
+	return nil
 }
 
 // PreferredURN gets the preferred URN for this contact, i.e. the URN we would use for sending
@@ -497,9 +492,9 @@ func (c *Contact) PreferredURN() *URN {
 
 // PreferredChannel gets the preferred channel for this contact, i.e. the channel we would use for sending
 func (c *Contact) PreferredChannel() *Channel {
-	routes := c.ResolveRoutes(false)
-	if len(routes) > 0 {
-		return routes[0].Channel
+	route := c.ResolveRoute()
+	if route != nil {
+		return route.Channel
 	}
 	return nil
 }

--- a/flows/actions/request_optin.go
+++ b/flows/actions/request_optin.go
@@ -47,15 +47,10 @@ func NewRequestOptIn(uuid flows.ActionUUID, optIn *assets.OptInReference) *Reque
 // Execute creates the optin events
 func (a *RequestOptIn) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
 	optIn := run.Session().Assets().OptIns().Get(a.OptIn.UUID)
-	routes := run.Contact().ResolveRoutes(false)
+	route := run.Contact().ResolveRoute()
 
-	if len(routes) > 0 {
-		ch := routes[0].Channel
-		urn := routes[0].URN
-
-		if ch.HasFeature(assets.ChannelFeatureOptIns) {
-			log(events.NewOptInRequested(optIn.Reference(), ch.Reference(), urn))
-		}
+	if route != nil && route.Channel.HasFeature(assets.ChannelFeatureOptIns) {
+		log(events.NewOptInRequested(optIn.Reference(), route.Channel.Reference(), route.URN))
 	}
 
 	return nil

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -93,11 +93,10 @@ func (a *SendMsg) Execute(ctx context.Context, run flows.Run, step flows.Step, l
 		}
 	}
 
-	routes := run.Contact().ResolveRoutes(false)
+	route := run.Contact().ResolveRoute()
 	locale := currentLocale(run, lang)
 
-	// create a new message for each URN+channel route
-	for _, route := range routes {
+	if route != nil {
 		channelRef := assets.NewChannelReference(route.Channel.UUID(), route.Channel.Name())
 		var msg *core.MsgOut
 
@@ -120,11 +119,9 @@ func (a *SendMsg) Execute(ctx context.Context, run flows.Run, step flows.Step, l
 		}
 
 		log(events.NewMsgCreated(msg, "", ""))
-	}
-
-	// if we couldn't find a route, create a msg without a URN or channel and it's up to the caller
-	// to handle that as they want
-	if len(routes) == 0 {
+	} else {
+		// if we couldn't find a route, create a msg without a URN or channel and it's up to the caller
+		// to handle that as they want
 		msg := core.NewMsgOut(urns.NilURN, nil, content, nil, locale, core.UnsendableReasonNoRoute)
 		log(events.NewMsgCreated(msg, "", ""))
 	}


### PR DESCRIPTION
Replaces `Contact.ResolveRoutes(all bool) []Route` with `Contact.ResolveRoute() *Route`, which returns the first sendable URN/channel route or nil if the contact has none.

The `all` parameter only existed to support the `send_all` option on `send_msg` actions, which has since been removed — every remaining caller only needed the first route.

Callers updated:
- `Contact.PreferredChannel()` now reads the single route directly
- `send_msg` action: the per-route loop becomes a single route check, with the no-route fallback as its `else`
- `request_optin` action: collapsed to a single nil/feature check