### PR TITLE
Add contact_flow_changed event type

### DIFF
--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -145,6 +145,18 @@ func TestEventMarshaling(t *testing.T) {
 		},
 		{
 			func() events.Event {
+				return events.NewContactFlowChanged(assets.NewFlowReference("50c3706e-fedb-42c0-8eab-dda3335714b7", "Registration"))
+			},
+			`contact_flow_changed`,
+		},
+		{
+			func() events.Event {
+				return events.NewContactFlowChanged(nil) // flow being cleared
+			},
+			`contact_flow_changed_clear`,
+		},
+		{
+			func() events.Event {
 				return events.NewContactGroupsChanged(
 					core.GroupReferences([]*core.Group{session.Assets().Groups().FindByName("Customers")}),
 					nil,

--- a/core/events/contact_flow_changed.go
+++ b/core/events/contact_flow_changed.go
@@ -1,0 +1,39 @@
+package events
+
+import (
+	"github.com/nyaruka/goflow/assets"
+)
+
+func init() {
+	registerType(TypeContactFlowChanged, func() Event { return &ContactFlowChanged{} })
+}
+
+// TypeContactFlowChanged is the type of our contact flow changed event
+const TypeContactFlowChanged string = "contact_flow_changed"
+
+// ContactFlowChanged events are created when the current flow of the contact has been changed - i.e. the flow
+// in which the contact is currently waiting. The flow will be null if the contact is no longer in a flow.
+//
+//	{
+//	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+//	  "type": "contact_flow_changed",
+//	  "created_on": "2006-01-02T15:04:05Z",
+//	  "flow": {"uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7", "name": "Registration"}
+//	}
+//
+// @event contact_flow_changed
+type ContactFlowChanged struct {
+	BaseEvent
+
+	Flow *assets.FlowReference `json:"flow"`
+}
+
+// NewContactFlowChanged returns a new contact flow changed event
+func NewContactFlowChanged(flow *assets.FlowReference) *ContactFlowChanged {
+	return &ContactFlowChanged{
+		BaseEvent: NewBaseEvent(TypeContactFlowChanged),
+		Flow:      flow,
+	}
+}
+
+var _ Event = (*ContactFlowChanged)(nil)

--- a/core/events/testdata/TestEventMarshaling_contact_flow_changed.snap
+++ b/core/events/testdata/TestEventMarshaling_contact_flow_changed.snap
@@ -1,0 +1,9 @@
+{
+    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+    "type": "contact_flow_changed",
+    "created_on": "2025-05-04T12:30:46.123456789Z",
+    "flow": {
+        "uuid": "50c3706e-fedb-42c0-8eab-dda3335714b7",
+        "name": "Registration"
+    }
+}

--- a/core/events/testdata/TestEventMarshaling_contact_flow_changed_clear.snap
+++ b/core/events/testdata/TestEventMarshaling_contact_flow_changed_clear.snap
@@ -1,0 +1,6 @@
+{
+    "uuid": "01969b47-0583-76f8-ae7f-f8b243c49ff5",
+    "type": "contact_flow_changed",
+    "created_on": "2025-05-04T12:30:46.123456789Z",
+    "flow": null
+}


### PR DESCRIPTION
Adds a new `contact_flow_changed` event type with a single `flow` field - a flow reference, or `null` when the contact is no longer in a flow.

Like the other platform-only event types (`typing_started`, `contact_last_seen_changed`, etc) this is never created by the engine - it exists so that callers which track a contact's current flow can broadcast changes to it as events, e.g. for realtime UI updates.