### PR TITLE
Add template caching tied to session assets

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -117,7 +117,7 @@ func RunFlow(eng flows.Engine, assetsPath string, flowUUID assets.FlowUUID, init
 		return nil, err
 	}
 
-	sa, err := engine.NewSessionAssets(envs.NewBuilder().Build(), source, nil)
+	sa, err := engine.NewSessionAssets(envs.NewBuilder().Build(), source, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing assets: %w", err)
 	}

--- a/core/call_test.go
+++ b/core/call_test.go
@@ -34,7 +34,7 @@ func TestCall(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	vonage := sa.Channels().Get("3a05eaf5-cb1b-4246-bef1-f277419c83a7")

--- a/core/contact_test.go
+++ b/core/contact_test.go
@@ -49,7 +49,7 @@ func TestContact(t *testing.T) {
 
 	env := envs.NewBuilder().Build()
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	android := sa.Channels().Get("294a14d4-c998-41e5-a314-5941b97b89d7")
@@ -185,7 +185,7 @@ func TestContactURNs(t *testing.T) {
 
 	env := envs.NewBuilder().Build()
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	contact := core.NewEmptyContact(sa, "", i18n.NilLanguage, nil)
@@ -214,7 +214,7 @@ func TestReadContact(t *testing.T) {
 
 	env := envs.NewBuilder().Build()
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	// read minimal contact
@@ -229,7 +229,7 @@ func TestReadContact(t *testing.T) {
 }
 
 func TestReadContactWithMissingAssets(t *testing.T) {
-	sessionAssets, err := engine.NewSessionAssets(envs.NewBuilder().Build(), static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(envs.NewBuilder().Build(), static.NewEmptySource(), nil, nil)
 	require.NoError(t, err)
 
 	missingAssets := make([]assets.Reference, 0)
@@ -298,7 +298,7 @@ func TestReadContactWithMissingAssets(t *testing.T) {
 
 func TestContactFormat(t *testing.T) {
 	env := envs.NewBuilder().Build()
-	sa, _ := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
+	sa, _ := engine.NewSessionAssets(env, static.NewEmptySource(), nil, nil)
 
 	// name takes precedence if set
 	contact := core.NewEmptyContact(sa, "Joe", i18n.NilLanguage, nil)
@@ -337,7 +337,7 @@ func TestContactFormat(t *testing.T) {
 
 func TestContactSetPreferredChannel(t *testing.T) {
 	env := envs.NewBuilder().Build()
-	sa, _ := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
+	sa, _ := engine.NewSessionAssets(env, static.NewEmptySource(), nil, nil)
 	roles := []assets.ChannelRole{assets.ChannelRoleSend}
 	receive_roles := []assets.ChannelRole{assets.ChannelRoleReceive}
 
@@ -407,7 +407,7 @@ func TestContactSetPreferredChannel(t *testing.T) {
 
 func TestContactSetAffinity(t *testing.T) {
 	env := envs.NewBuilder().Build()
-	sa, _ := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
+	sa, _ := engine.NewSessionAssets(env, static.NewEmptySource(), nil, nil)
 	roles := []assets.ChannelRole{assets.ChannelRoleSend}
 
 	android := test.NewTelChannel("Android", "+250961111111", roles, nil, "RW", nil, false)
@@ -500,7 +500,7 @@ func TestReevaluateQueryBasedGroups(t *testing.T) {
 		}
 		env := envBuilder.Build()
 
-		sa, err := engine.NewSessionAssets(env, source, nil)
+		sa, err := engine.NewSessionAssets(env, source, nil, nil)
 		require.NoError(t, err)
 
 		contact, err := core.ReadContact(sa, tc.ContactBefore, assets.IgnoreMissing)

--- a/core/group_test.go
+++ b/core/group_test.go
@@ -49,7 +49,7 @@ func TestGroupList(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	// check we ignored broken group

--- a/core/msg_test.go
+++ b/core/msg_test.go
@@ -199,7 +199,7 @@ func TestBroadcastTranslations(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
-		sa, err := engine.NewSessionAssets(tc.env, static.NewEmptySource(), nil)
+		sa, err := engine.NewSessionAssets(tc.env, static.NewEmptySource(), nil, nil)
 		require.NoError(t, err)
 
 		contact := core.NewEmptyContact(sa, "Bob", tc.contactLanguage, nil)

--- a/core/optin_test.go
+++ b/core/optin_test.go
@@ -32,7 +32,7 @@ func TestOptIns(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	jotd := sa.OptIns().Get("248be71d-78e9-4d71-a6c4-9981d369e5cb")

--- a/core/ticket_test.go
+++ b/core/ticket_test.go
@@ -39,7 +39,7 @@ func TestTickets(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	weather := sa.Topics().Get("472a7a73-96cb-4736-b567-056d987cc5b4")

--- a/core/urn_test.go
+++ b/core/urn_test.go
@@ -57,7 +57,7 @@ func TestURN(t *testing.T) {
     }`))
 	require.NoError(t, err)
 
-	sessionAssets, err := engine.NewSessionAssets(env, source, nil)
+	sessionAssets, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	channels := sessionAssets.Channels()

--- a/excellent/cache.go
+++ b/excellent/cache.go
@@ -1,0 +1,28 @@
+package excellent
+
+import (
+	"sync"
+)
+
+// TemplateCache is a thread-safe content-addressed cache of parsed templates. Because a parsed template is a pure
+// function of its source and immutable, entries never go stale and the cache needs no invalidation - its lifetime
+// should instead be bound to that of the content the templates come from, e.g. a set of assets.
+type TemplateCache struct {
+	templates sync.Map // string -> *Template
+}
+
+// NewTemplateCache creates a new empty template cache
+func NewTemplateCache() *TemplateCache {
+	return &TemplateCache{}
+}
+
+// Get returns the parsed form of the given template source, parsing and caching it if not already cached.
+func (c *TemplateCache) Get(src string) *Template {
+	if t, ok := c.templates.Load(src); ok {
+		return t.(*Template)
+	}
+
+	// concurrent misses may both parse but LoadOrStore ensures they get the same instance
+	t, _ := c.templates.LoadOrStore(src, ParseTemplate(src))
+	return t.(*Template)
+}

--- a/excellent/cache_test.go
+++ b/excellent/cache_test.go
@@ -1,0 +1,36 @@
+package excellent_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/nyaruka/goflow/excellent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplateCache(t *testing.T) {
+	cache := excellent.NewTemplateCache()
+
+	t1 := cache.Get(`Hello @contact.name`)
+	t2 := cache.Get(`Hello @contact.name`)
+	assert.Same(t, t1, t2)
+	assert.Equal(t, `Hello @contact.name`, t1.String())
+
+	t3 := cache.Get(`Goodbye @contact.name`)
+	assert.NotSame(t, t1, t3)
+
+	// safe for concurrent use (run with -race)
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 100 {
+				parsed := cache.Get(fmt.Sprintf("template @(%d)", i%10))
+				assert.NotNil(t, parsed)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/excellent/template.go
+++ b/excellent/template.go
@@ -112,6 +112,25 @@ func (t *Template) Evaluate(env envs.Environment, ctx *types.XObject, escaping E
 	return buf.String(), warnings, nil
 }
 
+// EvaluateValue evaluates this template and returns a typed value, producing the same output, warnings and error
+// as passing the original source to Evaluator.TemplateValue - except that it doesn't trim the source, so callers
+// wanting that behavior should parse the trimmed source.
+func (t *Template) EvaluateValue(env envs.Environment, ctx *types.XObject) (types.XValue, []string, error) {
+	// if the template is a single expression, return the typed value it evaluates to
+	if len(t.segments) == 1 {
+		if s, ok := t.segments[0].(*expressionSegment); ok {
+			if s.topLevel == "" || slices.Contains(ctx.Properties(), s.topLevel) {
+				value, warnings := s.evaluate(env, ctx)
+				return value, warnings, nil
+			}
+		}
+	}
+
+	// otherwise fallback to full template evaluation
+	asStr, warnings, err := t.Evaluate(env, ctx, nil)
+	return types.NewXText(asStr), warnings, err
+}
+
 // a segment of a parsed template - either literal text or an expression
 type templateSegment interface {
 	source() string

--- a/excellent/template_test.go
+++ b/excellent/template_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/excellent/functions"
 	"github.com/nyaruka/goflow/excellent/types"
+	"github.com/nyaruka/goflow/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +70,10 @@ var templateTestCases = []string{
 	`@(err)`,
 	`1 + 2`,
 	"line1\nline2 @string1\n@@line3",
+	`  @(1 + 2)  `,
+	" @string1 ",
+	"\t@string1.xxx\n",
+	` @dec1 and @dec1 `,
 }
 
 func makeTemplateContext() *types.XObject {
@@ -116,6 +121,25 @@ func assertTemplateEquivalent(t *testing.T, env envs.Environment, ctx *types.XOb
 	}
 }
 
+// asserts that evaluating the parse of the trimmed source as a value produces the same result as the existing
+// evaluator's TemplateValue (which trims the source itself)
+func assertTemplateValueEquivalent(t *testing.T, env envs.Environment, ctx *types.XObject, src string) {
+	t.Helper()
+
+	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().TemplateValue(env, ctx, src)
+	actualVal, actualWarns, actualErr := excellent.ParseTemplate(strings.TrimSpace(src)).EvaluateValue(env, ctx)
+
+	test.AssertXEqual(t, expectedVal, actualVal, "value mismatch for template %q", src)
+	assert.Equal(t, expectedWarns, actualWarns, "warnings mismatch for template %q", src)
+
+	if expectedErr != nil {
+		require.Error(t, actualErr, "expected error for template %q", src)
+		assert.Equal(t, expectedErr.Error(), actualErr.Error(), "error mismatch for template %q", src)
+	} else {
+		assert.NoError(t, actualErr, "unexpected error for template %q", src)
+	}
+}
+
 func TestParseTemplate(t *testing.T) {
 	env := envs.NewBuilder().Build()
 	ctx := makeTemplateContext()
@@ -125,11 +149,13 @@ func TestParseTemplate(t *testing.T) {
 	for _, src := range templateTestCases {
 		assertTemplateEquivalent(t, env, ctx, src, nil)
 		assertTemplateEquivalent(t, env, ctx, src, escaping)
+		assertTemplateValueEquivalent(t, env, ctx, src)
 	}
 
 	// context with no matching properties means identifiers are treated as literal text
 	empty := types.NewXObject(map[string]types.XValue{})
 	assertTemplateEquivalent(t, env, empty, `Hello @string1 and @(string2)`, nil)
+	assertTemplateValueEquivalent(t, env, empty, `@string1`)
 }
 
 // tests that a template parsed once can be safely evaluated concurrently (run with -race).. note that contexts
@@ -204,6 +230,7 @@ func TestParseTemplateWithFixtures(t *testing.T) {
 
 	for _, src := range templates {
 		assertTemplateEquivalent(t, env, ctx, src, nil)
+		assertTemplateValueEquivalent(t, env, ctx, src)
 	}
 }
 
@@ -242,6 +269,19 @@ func FuzzParseTemplate(f *testing.F) {
 		}
 		if (actualErr != nil) != (expectedErr != nil) || (actualErr != nil && actualErr.Error() != expectedErr.Error()) {
 			t.Fatalf("error mismatch for %q: %v != %v", src, actualErr, expectedErr)
+		}
+
+		expectedTV, expectedTVWarns, expectedTVErr := excellent.NewEvaluator().TemplateValue(env, ctx, src)
+		actualTV, actualTVWarns, actualTVErr := excellent.ParseTemplate(strings.TrimSpace(src)).EvaluateValue(env, ctx)
+
+		if !types.Equals(expectedTV, actualTV) {
+			t.Fatalf("value mismatch for %q: %v != %v", src, actualTV, expectedTV)
+		}
+		if !slices.Equal(actualTVWarns, expectedTVWarns) {
+			t.Fatalf("value warnings mismatch for %q: %v != %v", src, actualTVWarns, expectedTVWarns)
+		}
+		if (actualTVErr != nil) != (expectedTVErr != nil) || (actualTVErr != nil && actualTVErr.Error() != expectedTVErr.Error()) {
+			t.Fatalf("value error mismatch for %q: %v != %v", src, actualTVErr, expectedTVErr)
 		}
 	})
 }

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -834,7 +834,7 @@ func TestStartSessionLoopProtection(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	flow := assets.NewFlowReference("5472a1c3-63e1-484f-8485-cc8ecb16a058", "Inception")
@@ -964,7 +964,7 @@ func TestStartSessionLoopProtectionWithInput(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	flow := assets.NewFlowReference("5472a1c3-63e1-484f-8485-cc8ecb16a058", "Inception")

--- a/flows/cache.go
+++ b/flows/cache.go
@@ -1,0 +1,19 @@
+package flows
+
+import (
+	"github.com/nyaruka/goflow/excellent"
+)
+
+// Cache is a container for caches of parsed things whose lifetime should be tied to the assets they are parsed
+// from rather than to a single session - e.g. templates which are shared by all sessions using the same assets.
+type Cache struct {
+	templates *excellent.TemplateCache
+}
+
+// NewCache creates a new empty cache
+func NewCache() *Cache {
+	return &Cache{templates: excellent.NewTemplateCache()}
+}
+
+// Templates returns the cache of parsed templates
+func (c *Cache) Templates() *excellent.TemplateCache { return c.templates }

--- a/flows/definition/assets_test.go
+++ b/flows/definition/assets_test.go
@@ -41,7 +41,7 @@ func TestFlowAssets(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, source, sa.Source())

--- a/flows/engine/assets.go
+++ b/flows/engine/assets.go
@@ -14,6 +14,7 @@ import (
 // our implementation of SessionAssets - the high-level API for asset access from the engine
 type sessionAssets struct {
 	source assets.Source
+	cache  *flows.Cache
 
 	campaigns *core.CampaignAssets
 	channels  *core.ChannelAssets
@@ -33,8 +34,13 @@ type sessionAssets struct {
 
 var _ flows.SessionAssets = (*sessionAssets)(nil)
 
-// NewSessionAssets creates a new session assets instance with the provided base URLs
-func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfig *migrations.Config) (flows.SessionAssets, error) {
+// NewSessionAssets creates a new session assets instance from the given source. The cache is optional - passing nil
+// creates a private one - but callers reusing sources across assets instances should pass a shared cache.
+func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfig *migrations.Config, cache *flows.Cache) (flows.SessionAssets, error) {
+	if cache == nil {
+		cache = flows.NewCache()
+	}
+
 	campaigns, err := source.Campaigns()
 	if err != nil {
 		return nil, err
@@ -106,6 +112,7 @@ func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfi
 
 	return &sessionAssets{
 		source:    source,
+		cache:     cache,
 		campaigns: core.NewCampaignAssets(campaigns),
 		channels:  core.NewChannelAssets(channels),
 		fields:    fieldAssets,
@@ -124,6 +131,7 @@ func NewSessionAssets(env envs.Environment, source assets.Source, migrationConfi
 }
 
 func (s *sessionAssets) Source() assets.Source           { return s.source }
+func (s *sessionAssets) Cache() *flows.Cache             { return s.cache }
 func (s *sessionAssets) Campaigns() *core.CampaignAssets { return s.campaigns }
 func (s *sessionAssets) Channels() *core.ChannelAssets   { return s.channels }
 func (s *sessionAssets) Fields() *core.FieldAssets       { return s.fields }

--- a/flows/engine/assets_test.go
+++ b/flows/engine/assets_test.go
@@ -89,7 +89,7 @@ func TestSessionAssets(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, source, sa.Source())
@@ -146,7 +146,7 @@ func TestSessionAssetsWithSourceErrors(t *testing.T) {
 
 	source := &testSource{}
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	source.currentErrType = "flow"
@@ -159,7 +159,7 @@ func TestSessionAssetsWithSourceErrors(t *testing.T) {
 
 	for _, errType := range []string{"channels", "fields", "globals", "groups", "labels", "llms", "locations", "optins", "resthooks", "templates", "users"} {
 		source.currentErrType = errType
-		_, err = engine.NewSessionAssets(env, source, nil)
+		_, err = engine.NewSessionAssets(env, source, nil, nil)
 		assert.EqualError(t, err, fmt.Sprintf("unable to load %s assets", errType), "error mismatch for type %s", errType)
 	}
 }

--- a/flows/engine/run.go
+++ b/flows/engine/run.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nyaruka/gocommon/dates"
@@ -308,7 +309,8 @@ func (r *run) nodeContext(env envs.Environment) map[string]types.XValue {
 func (r *run) EvaluateTemplateValue(template string, log events.EventLogger) (types.XValue, bool) {
 	ctx := types.NewXObject(r.RootContext(r.session.MergedEnvironment()))
 
-	value, warnings, err := r.session.Engine().Evaluator().TemplateValue(r.session.MergedEnvironment(), ctx, template)
+	parsed := r.session.Assets().Cache().Templates().Get(strings.TrimSpace(template))
+	value, warnings, err := parsed.EvaluateValue(r.session.MergedEnvironment(), ctx)
 	if err != nil {
 		r.errorToEvents(err, log)
 	}
@@ -322,7 +324,8 @@ func (r *run) EvaluateTemplateValue(template string, log events.EventLogger) (ty
 func (r *run) EvaluateTemplateText(template string, escaping excellent.Escaping, truncate bool, log events.EventLogger) (string, bool) {
 	ctx := types.NewXObject(r.RootContext(r.session.MergedEnvironment()))
 
-	value, warnings, err := r.session.Engine().Evaluator().Template(r.session.MergedEnvironment(), ctx, template, escaping)
+	parsed := r.session.Assets().Cache().Templates().Get(template)
+	value, warnings, err := parsed.Evaluate(r.session.MergedEnvironment(), ctx, escaping)
 	if err != nil {
 		r.errorToEvents(err, log)
 	}

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -130,7 +130,7 @@ func TestReadWithMissingAssets(t *testing.T) {
 	require.NoError(t, err)
 
 	// try to read it back but with no assets
-	sessionAssets, err := engine.NewSessionAssets(session.Environment(), static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(session.Environment(), static.NewEmptySource(), nil, nil)
 	require.NoError(t, err)
 
 	missingAssets := make([]assets.Reference, 0)
@@ -339,7 +339,7 @@ func TestSessionHistory(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	flow := assets.NewFlowReference("5472a1c3-63e1-484f-8485-cc8ecb16a058", "Inception")

--- a/flows/engine/sprint_test.go
+++ b/flows/engine/sprint_test.go
@@ -61,7 +61,7 @@ func TestSprint(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := NewSessionAssets(env, source, nil)
+	sa, err := NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, source, sa.Source())

--- a/flows/engine/summary_test.go
+++ b/flows/engine/summary_test.go
@@ -57,7 +57,7 @@ func TestRunSummary(t *testing.T) {
 	assert.Equal(t, "Ryan Lewis@Registration", engine.FormatRunSummary(session.Environment(), summary))
 
 	// try reading with missing assets
-	emptyAssets, err := engine.NewSessionAssets(session.Environment(), static.NewEmptySource(), nil)
+	emptyAssets, err := engine.NewSessionAssets(session.Environment(), static.NewEmptySource(), nil, nil)
 	assert.NoError(t, err)
 
 	summary, err = engine.ReadRunSummary(emptyAssets, marshaled, assets.IgnoreMissing)

--- a/flows/environment_test.go
+++ b/flows/environment_test.go
@@ -73,7 +73,7 @@ func TestLocationResolver(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	contact := core.NewEmptyContact(sa, "", i18n.NilLanguage, nil)
@@ -121,7 +121,7 @@ func TestSessionEnvironment(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	contact, err := core.ReadContact(sa, []byte(contactJSON), assets.IgnoreMissing)

--- a/flows/inputs/base_test.go
+++ b/flows/inputs/base_test.go
@@ -19,7 +19,7 @@ func TestReadInput(t *testing.T) {
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil, nil)
 	require.NoError(t, err)
 
 	// error if no type field

--- a/flows/inspect/dependencies_test.go
+++ b/flows/inspect/dependencies_test.go
@@ -63,7 +63,7 @@ func TestDependencies(t *testing.T) {
 		}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	deps := inspect.NewDependencies(refs, sa)

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -53,6 +53,7 @@ type SessionAssets interface {
 
 	Source() assets.Source
 	Flows() FlowAssets
+	Cache() *Cache
 }
 
 // Localizable is anything in the flow definition which can be localized and therefore needs a UUID

--- a/flows/modifiers/base_test.go
+++ b/flows/modifiers/base_test.go
@@ -278,7 +278,7 @@ func TestReadModifier(t *testing.T) {
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil, nil)
 	require.NoError(t, err)
 
 	// error if no type field
@@ -313,7 +313,7 @@ func TestReadModifier(t *testing.T) {
 			{"uuid": "4349cdd6-5385-46f3-8e55-5750dd4f35fb", "name": "Winners"}
 		]
 	}`))
-	sessionAssets, err = engine.NewSessionAssets(env, source, nil)
+	sessionAssets, err = engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	mod, err = modifiers.Read(sessionAssets, []byte(`{"type": "groups", "modification": "add", "groups": [{"uuid": "cd1a2aa6-0d9d-4a8c-b32d-ca5de9c43bdb", "name": "Losers"}, {"uuid": "4349cdd6-5385-46f3-8e55-5750dd4f35fb", "name": "Winners"}]}`), missing)
@@ -334,7 +334,7 @@ func TestReadModifier(t *testing.T) {
 			{"uuid": "3a05eaf5-cb1b-4246-bef1-f277419c83a7", "name": "Nexmo", "address": "+", "schemes": ["tel"], "roles": ["send", "receive"]}
 		]
 	}`))
-	sessionAssets, err = engine.NewSessionAssets(env, source, nil)
+	sessionAssets, err = engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	mod, err = modifiers.Read(sessionAssets, []byte(`{"type": "routes", "modification": "append", "routes": [{"urn": "tel:+1234567890", "channel": {"uuid": "cd1a2aa6-0d9d-4a8c-b32d-ca5de9c43bdb", "name": "Missing"}}, {"urn": "tel:+1234567891", "channel": {"uuid": "3a05eaf5-cb1b-4246-bef1-f277419c83a7", "name": "Nexmo"}}]}`), missing)
@@ -353,7 +353,7 @@ func TestFieldValueTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	env := envs.NewBuilder().Build()
-	sessionAssets, err := engine.NewSessionAssets(env, source, nil)
+	sessionAssets, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	// value can be omitted

--- a/flows/resumes/base_test.go
+++ b/flows/resumes/base_test.go
@@ -151,7 +151,7 @@ func TestReadResume(t *testing.T) {
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil, nil)
 	require.NoError(t, err)
 
 	// error if no type field

--- a/flows/routers/cases/tests_test.go
+++ b/flows/routers/cases/tests_test.go
@@ -425,7 +425,7 @@ func TestTests(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(dmy, source, nil)
+	sa, err := engine.NewSessionAssets(dmy, source, nil, nil)
 	require.NoError(t, err)
 
 	contact := core.NewEmptyContact(sa, "", i18n.NilLanguage, nil)

--- a/flows/session_test.go
+++ b/flows/session_test.go
@@ -33,7 +33,7 @@ func TestHistory(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	flow := assets.NewFlowReference("5472a1c3-63e1-484f-8485-cc8ecb16a058", "Inception")

--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -196,7 +196,7 @@ func TestTriggerMarshaling(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	flow := assets.NewFlowReference("7c37d7e5-6468-4b31-8109-ced2ef8b5ddc", "Registration")
@@ -328,7 +328,7 @@ func TestReadTrigger(t *testing.T) {
 	missingAssets := make([]assets.Reference, 0)
 	missing := func(a assets.Reference, err error) { missingAssets = append(missingAssets, a) }
 
-	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil)
+	sessionAssets, err := engine.NewSessionAssets(env, static.NewEmptySource(), nil, nil)
 	require.NoError(t, err)
 
 	// error if no type field
@@ -365,7 +365,7 @@ func TestTriggerSessionInitialization(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	flow := assets.NewFlowReference(assets.FlowUUID("7c37d7e5-6468-4b31-8109-ced2ef8b5ddc"), "Registration")
@@ -407,7 +407,7 @@ func TestTriggerContext(t *testing.T) {
 	source, err := static.NewSource([]byte(assetsJSON))
 	require.NoError(t, err)
 
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	require.NoError(t, err)
 
 	flow := assets.NewFlowReference(assets.FlowUUID("7c37d7e5-6468-4b31-8109-ced2ef8b5ddc"), "Registration")

--- a/test/assets.go
+++ b/test/assets.go
@@ -28,7 +28,7 @@ func LoadSessionAssets(env envs.Environment, path string) (flows.SessionAssets, 
 
 	mconfig := &migrations.Config{BaseMediaURL: "http://temba.io/"}
 
-	return engine.NewSessionAssets(env, source, mconfig)
+	return engine.NewSessionAssets(env, source, mconfig, nil)
 }
 
 func LoadFlowFromAssets(env envs.Environment, path string, uuid assets.FlowUUID) (flows.Flow, error) {

--- a/test/session.go
+++ b/test/session.go
@@ -576,7 +576,7 @@ func CreateSessionAssets(assetsJSON []byte, testServerURL string) (flows.Session
 	}
 
 	// create our engine session
-	sa, err := engine.NewSessionAssets(env, source, nil)
+	sa, err := engine.NewSessionAssets(env, source, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating test session assets: %w", err)
 	}


### PR DESCRIPTION
Templates are now parsed once and cached, keyed by their source, with the cache living alongside session assets so all sessions using the same assets share parsed templates. Parse-once evaluation is ~8.5x faster than parsing per evaluation (#1533).

- `excellent.TemplateCache` - a thread-safe content-addressed cache: `Get(src)` parses on miss. Because a parsed template is a pure function of its source and immutable, entries never go stale and no invalidation/TTL/eviction is needed - the cache's lifetime is bound to that of the content it came from.
- `flows.Cache` - a container for such caches, exposed as `SessionAssets.Cache()`. For now it only holds `Templates()` but is a natural home for other parsed-thing caches later (e.g. contactql queries, which are currently re-parsed on every session assets construction).
- `engine.NewSessionAssets` takes an optional `*flows.Cache` - nil creates a private one; callers that rebuild session assets against unchanged content can pass a shared cache to extend its lifetime.
- Runs now evaluate templates through the cache. `excellent.Template` gains `EvaluateValue` (the typed counterpart of `Evaluate`, mirroring `Evaluator.TemplateValue`) to cover the `EvaluateTemplateValue` path - note that path keys the cache on the trimmed source since `TemplateValue` trims before evaluating.

Callers evaluating templates outside of flow runs (e.g. broadcast message rendering) can use `sa.Cache().Templates().Get(text).Evaluate(...)` instead of the engine's evaluator to get the same benefit.

Testing: the existing differential tests and fuzz target now also verify `EvaluateValue` against `Evaluator.TemplateValue` across the adversarial corpus and all runner fixture strings (fuzzed 186k execs clean); `TemplateCache` has a race-tested concurrency test; the full suite passes with all golden runner fixtures unchanged, confirming the rewired run evaluation is behaviorally identical.