### PR TITLE
Don't hold flow assets lock while loading and reading flows

### DIFF
--- a/flows/definition/assets.go
+++ b/flows/definition/assets.go
@@ -11,18 +11,15 @@ import (
 
 // implemention of FlowAssets which provides lazy loading and validation of flows
 type flowAssets struct {
-	cache map[assets.FlowUUID]flows.Flow
+	cache sync.Map // assets.FlowUUID -> flows.Flow
 
-	mutex  sync.Mutex
-	source assets.Source
-
+	source          assets.Source
 	migrationConfig *migrations.Config
 }
 
 // NewFlowAssets creates a new flow assets
 func NewFlowAssets(source assets.Source, migrationConfig *migrations.Config) flows.FlowAssets {
 	return &flowAssets{
-		cache:           make(map[assets.FlowUUID]flows.Flow),
 		source:          source,
 		migrationConfig: migrationConfig,
 	}
@@ -30,12 +27,8 @@ func NewFlowAssets(source assets.Source, migrationConfig *migrations.Config) flo
 
 // Get returns the flow with the given UUID
 func (a *flowAssets) Get(uuid assets.FlowUUID) (flows.Flow, error) {
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-
-	flow := a.cache[uuid]
-	if flow != nil {
-		return flow, nil
+	if flow, ok := a.cache.Load(uuid); ok {
+		return flow.(flows.Flow), nil
 	}
 
 	asset, err := a.source.FlowByUUID(uuid)
@@ -43,24 +36,26 @@ func (a *flowAssets) Get(uuid assets.FlowUUID) (flows.Flow, error) {
 		return nil, err
 	}
 
-	flow, err = ReadAsset(asset, a.migrationConfig)
+	flow, err := ReadAsset(asset, a.migrationConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	a.cache[flow.UUID()] = flow
-	return flow, nil
+	return a.cached(flow), nil
 }
 
 // FindByName tries to find a flow with the given name
 func (a *flowAssets) FindByName(name string) (flows.Flow, error) {
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-
-	for _, flow := range a.cache {
-		if strings.EqualFold(flow.Name(), name) {
-			return flow, nil
+	var found flows.Flow
+	a.cache.Range(func(_, v any) bool {
+		if flow := v.(flows.Flow); strings.EqualFold(flow.Name(), name) {
+			found = flow
+			return false
 		}
+		return true
+	})
+	if found != nil {
+		return found, nil
 	}
 
 	asset, err := a.source.FlowByName(name)
@@ -73,6 +68,11 @@ func (a *flowAssets) FindByName(name string) (flows.Flow, error) {
 		return nil, err
 	}
 
-	a.cache[flow.UUID()] = flow
-	return flow, nil
+	return a.cached(flow), nil
+}
+
+// concurrent misses may both read a flow but this ensures all callers get the same instance
+func (a *flowAssets) cached(flow flows.Flow) flows.Flow {
+	actual, _ := a.cache.LoadOrStore(flow.UUID(), flow)
+	return actual.(flows.Flow)
 }

--- a/flows/definition/assets_test.go
+++ b/flows/definition/assets_test.go
@@ -1,11 +1,14 @@
 package definition_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
 	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/flows/definition"
 	"github.com/nyaruka/goflow/flows/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,4 +76,35 @@ func TestFlowAssets(t *testing.T) {
 	flow, err = sa.Flows().FindByName("zog")
 	assert.EqualError(t, err, "no such flow with name 'zog'")
 	assert.Nil(t, flow)
+}
+
+// tests that concurrent access is safe and that all callers get the same instance of a flow (run with -race)
+func TestFlowAssetsConcurrent(t *testing.T) {
+	source, err := static.NewSource([]byte(assetsJSON))
+	require.NoError(t, err)
+
+	flowAssets := definition.NewFlowAssets(source, nil)
+
+	got := make([]flows.Flow, 20)
+	var wg sync.WaitGroup
+	for i := range got {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var f flows.Flow
+			var err error
+			if i%2 == 0 {
+				f, err = flowAssets.Get("76f0a02f-3b75-4b86-9064-e9195e1b3a02")
+			} else {
+				f, err = flowAssets.FindByName("Zig")
+			}
+			assert.NoError(t, err)
+			got[i] = f
+		}()
+	}
+	wg.Wait()
+
+	for _, f := range got {
+		assert.Same(t, got[0], f)
+	}
 }


### PR DESCRIPTION
The flow assets cache used a single mutex held across the entire miss path - including the asset source fetch (which can be a database query for some sources) and `ReadAsset` (JSON parse + migration + validation). That meant a miss on one flow blocked even cache hits on other flows, serializing all flow access behind a lock wrapping I/O.

This replaces it with a `sync.Map`, the same pattern as the template cache:

- Cache hits are lock-free.
- Misses fetch and read outside any lock; concurrent misses of the same flow may duplicate that work (rare, and at most once per flow per assets lifetime) but `LoadOrStore` ensures every caller still gets the same canonical `flows.Flow` instance.
- `FindByName` keeps its existing semantics (scan cached flows first, then fall through to the source) via `Range`.

Adds a race-tested concurrency test asserting instance canonicalization across concurrent `Get` and `FindByName` calls. Existing tests covering same-instance guarantees and error paths are unchanged and pass.