### PR TITLE
Guard against panics when handling malformed flow definitions

### DIFF
--- a/core/template.go
+++ b/core/template.go
@@ -99,6 +99,10 @@ func (t *TemplateTranslation) Preview(vars []*TemplatingVariable) *MsgContent {
 	for _, comp := range t.Components() {
 		content := comp.Content()
 		for key, index := range comp.Variables() {
+			// component variable indexes come from an asset and may be out of range for a malformed template
+			if index < 0 || index >= len(vars) {
+				continue
+			}
 			variable := vars[index]
 
 			if variable.Type == "text" {

--- a/core/template_test.go
+++ b/core/template_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindTranslation(t *testing.T) {
@@ -380,4 +381,37 @@ func TestTemplating(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestPreviewMalformed checks that generating a preview from a malformed template asset - one whose
+// component references a variable index beyond the declared variable list - doesn't panic.
+func TestPreviewMalformed(t *testing.T) {
+	channel := core.NewChannel(static.NewChannel("79401ef2-8eb6-48f4-9f9d-0604530b1ac0", "WhatsApp", "1234", []string{"whatsapp"}, nil, nil))
+
+	// component maps its placeholder to index 5 but only one variable is declared
+	tplAsset := &static.Template{}
+	jsonx.MustUnmarshal([]byte(`{
+		"uuid": "4c01c732-e644-421c-af15-f5606c3e05f0",
+		"name": "greeting",
+		"translations": [
+			{
+				"channel": {"uuid": "79401ef2-8eb6-48f4-9f9d-0604530b1ac0", "name": "WhatsApp"},
+				"locale": "eng",
+				"components": [
+					{"name": "body", "type": "body/text", "content": "Hi {{1}}", "variables": {"1": 5}}
+				],
+				"variables": [{"type": "text"}]
+			}
+		]
+	}`), tplAsset)
+
+	tpl := core.NewTemplate(tplAsset)
+	trans := tpl.FindTranslation(channel, []i18n.Locale{"eng"})
+	require.NotNil(t, trans)
+
+	templating := tpl.Templating(trans, []string{"Chef"})
+
+	assert.NotPanics(t, func() {
+		core.NewTemplateTranslation(trans).Preview(templating.Variables)
+	})
 }

--- a/flows/definition/legacy/definition.go
+++ b/flows/definition/legacy/definition.go
@@ -588,7 +588,9 @@ func migrateRuleSet(lang i18n.Language, r RuleSet, validDests map[uuids.UUID]boo
 
 	case "form_field":
 		operand, _ := expressions.MigrateTemplate(r.Operand, nil)
-		operand = fmt.Sprintf("@(field(%s, %d, \"%s\"))", operand[1:], config.FieldIndex, config.FieldDelimiter)
+		// migrated operand is expected to be an @-prefixed expression; strip the @ to nest it inside field(...)
+		operand = strings.TrimPrefix(operand, "@")
+		operand = fmt.Sprintf("@(field(%s, %d, \"%s\"))", operand, config.FieldIndex, config.FieldDelimiter)
 		router = newSwitchRouter(nil, resultName, categories, operand, cases, defaultCategory)
 
 		lastDot := strings.LastIndex(r.Operand, ".")

--- a/flows/definition/legacy/definition_test.go
+++ b/flows/definition/legacy/definition_test.go
@@ -328,3 +328,31 @@ func TestMigrateDefinition(t *testing.T) {
 		}
 	}`), migrated, "migrated flow mismatch")
 }
+
+// TestMigrateDefinitionMalformed checks that migrating deliberately malformed legacy definitions doesn't
+// panic. A form_field ruleset with an empty operand previously caused a slice-bounds panic when the
+// migrated operand was stripped of its leading @.
+func TestMigrateDefinitionMalformed(t *testing.T) {
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(123456, time.Now))
+
+	def := `{
+		"base_language": "eng",
+		"flow_type": "M",
+		"version": "11.12",
+		"metadata": {"uuid": "50a9c0c0-0000-0000-0000-000000000001", "name": "L"},
+		"action_sets": [],
+		"rule_sets": [{
+			"uuid": "413868c6-f35b-4a1c-b80e-df0091568b59",
+			"label": "Delimited Split",
+			"ruleset_type": "form_field",
+			"operand": "",
+			"config": {"field_index": 1, "field_delimiter": " "},
+			"rules": [{"uuid": "22b5ef86-afad-41aa-8863-c167996083a6", "category": {"eng": "Other"}, "destination": null, "destination_type": null, "test": {"type": "true"}, "label": null}]
+		}]
+	}`
+
+	assert.NotPanics(t, func() {
+		legacy.MigrateDefinition([]byte(def), "")
+	})
+}

--- a/flows/definition/migrations/14.x.go
+++ b/flows/definition/migrations/14.x.go
@@ -205,6 +205,9 @@ func Migrate14_3_0(f Flow, cfg *Config) (Flow, error) {
 		}
 
 		case0, _ := cases[0].(map[string]any)
+		if case0 == nil {
+			continue
+		}
 		case0["type"] = "has_text"
 		case0["arguments"] = []any{}
 
@@ -272,6 +275,9 @@ func Migrate14_1_0(f Flow, cfg *Config) (Flow, error) {
 		}
 
 		case0, _ := cases[0].(map[string]any)
+		if case0 == nil {
+			continue
+		}
 		case0["type"] = "has_number_between"
 		case0["arguments"] = []any{"200", "299"}
 

--- a/flows/definition/migrations/base_test.go
+++ b/flows/definition/migrations/base_test.go
@@ -358,3 +358,45 @@ func TestMultiVersionMigration(t *testing.T) {
     }`, definition.CurrentSpecVersion)
 	test.AssertEqualJSON(t, []byte(expected), migrated, "flow migration mismatch")
 }
+
+// TestMigrateMalformed checks that migrating deliberately malformed definitions doesn't panic. These
+// craft the specific conditions (a switch router on a webhook/local result with a non-object first case)
+// that previously caused a nil-map write in the 14.1.0 and 14.3.0 migrations.
+func TestMigrateMalformed(t *testing.T) {
+	tcs := []struct {
+		name string
+		flow string
+	}{
+		{
+			"14.1.0 non-object case", `{
+				"uuid": "8ca44c09-791d-453a-9799-a70dd3303306", "name": "T", "spec_version": "14.0.0",
+				"language": "eng", "type": "messaging",
+				"nodes": [{
+					"uuid": "a58be63b-907d-4a1a-856b-0bf9edf634db",
+					"actions": [{"type": "call_webhook", "uuid": "5405def7-e2e3-4c85-b74f-8695eeb85f56", "method": "GET", "url": "http://x"}],
+					"router": {"type": "switch", "operand": "@results.x", "cases": ["notanobject"], "categories": [{"uuid": "c854e63b-907d-4a1a-856b-0bf9edf634db", "name": "All", "exit_uuid": "e5f27d75-7f9a-4a35-a9a2-2f2f2a2e6f2b"}], "default_category_uuid": "c854e63b-907d-4a1a-856b-0bf9edf634db"},
+					"exits": [{"uuid": "e5f27d75-7f9a-4a35-a9a2-2f2f2a2e6f2b"}]
+				}]
+			}`,
+		},
+		{
+			"14.3.0 non-object case", `{
+				"uuid": "8ca44c09-791d-453a-9799-a70dd3303306", "name": "T", "spec_version": "14.2.0",
+				"language": "eng", "type": "messaging",
+				"nodes": [{
+					"uuid": "a58be63b-907d-4a1a-856b-0bf9edf634db",
+					"actions": [{"type": "open_ticket", "uuid": "5405def7-e2e3-4c85-b74f-8695eeb85f56", "result_name": "Ticket"}],
+					"router": {"type": "switch", "operand": "@results.x", "cases": [123], "categories": [{"uuid": "c854e63b-907d-4a1a-856b-0bf9edf634db", "name": "All", "exit_uuid": "e5f27d75-7f9a-4a35-a9a2-2f2f2a2e6f2b"}], "default_category_uuid": "c854e63b-907d-4a1a-856b-0bf9edf634db"},
+					"exits": [{"uuid": "e5f27d75-7f9a-4a35-a9a2-2f2f2a2e6f2b"}]
+				}]
+			}`,
+		},
+	}
+
+	for _, tc := range tcs {
+		// must not panic - a malformed case is left untouched rather than crashing
+		assert.NotPanics(t, func() {
+			migrations.MigrateToVersion([]byte(tc.flow), definition.CurrentSpecVersion, &migrations.Config{})
+		}, tc.name)
+	}
+}


### PR DESCRIPTION
Crafted flow definitions could trigger panics in the migration and templating code paths. This adds guards (and regression tests) for three cases found while auditing untrusted-input handling:

- **`Migrate14_1_0` / `Migrate14_3_0`** wrote to a nil map when a switch router's first `cases` entry was a non-object JSON value (e.g. `"cases": ["x"]`). Now skips such a case, matching the existing guard in `Migrate14_4_1`.
- **Legacy `form_field` ruleset migration** sliced the migrated operand with `[1:]`, panicking with `slice bounds out of range` when the operand was empty/missing. Now strips the leading `@` with `strings.TrimPrefix`.
- **`TemplateTranslation.Preview`** indexed the variable list with a component-supplied index with no bounds check, panicking on a template asset whose component references a variable index beyond the declared list. Now bounds-checked (mirroring the guard already in `Templating`).

All three are pure defensive fixes with no behavioural change on valid input. Each regression test was confirmed to fail (panic) without its fix. Full suite passes with `go test -p=1 ./...`.

Part of a small series hardening untrusted-input handling; a follow-up will cover resource-exhaustion cases (parser recursion depth, `repeat()` output size).