### PR TITLE
Cap query complexity and flatten condition chains in linear time

### DIFF
--- a/contactql/parse/parse_test.go
+++ b/contactql/parse/parse_test.go
@@ -1,9 +1,9 @@
 package parse_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
@@ -537,29 +537,19 @@ func TestParseQueryTooComplex(t *testing.T) {
 	assert.Equal(t, contactql.ErrTooComplex, err.(*contactql.QueryError).Code())
 }
 
-// TestSimplifyLongChain checks that a long chain of same-op conditions is flattened correctly and, more
-// importantly, in linear time. Parsing `a or b or c ...` produces a left leaning tree and flattening it
-// used to copy the promoted children at every level, which is quadratic - a ~1.7MB query of this shape
-// took ~35s of CPU. The time bound here is very generous compared to the ~0.2s this now takes; it exists
-// only to catch a return of the quadratic behaviour.
-func TestSimplifyLongChain(t *testing.T) {
+func TestParseQueryTooManyConditions(t *testing.T) {
 	env := envs.NewBuilder().Build()
 	resolver := contactql.NewMockResolver(nil, nil, nil)
 
-	const n = 100000
-	query := "name=x" + strings.Repeat(" OR name=x", n)
-
-	start := time.Now()
-	parsed, err := parse.Query(env, query, resolver)
-	elapsed := time.Since(start)
-
+	// a query right on the limit is fine
+	ok := "name=x" + strings.Repeat(" OR name=x", contactql.MaxConditions-1)
+	parsed, err := parse.Query(env, ok, resolver)
 	require.NoError(t, err)
+	assert.Len(t, parsed.Root().(*contactql.BoolCombination).Children(), contactql.MaxConditions)
 
-	// all the conditions should have been promoted into a single OR node
-	root, ok := parsed.Root().(*contactql.BoolCombination)
-	require.True(t, ok, "root should be a bool combination")
-	assert.Equal(t, contactql.BoolOperatorOr, root.Operator())
-	assert.Len(t, root.Children(), n+1)
-
-	assert.Less(t, elapsed, 10*time.Second, "flattening a chain of %d conditions took %s - has it become quadratic again?", n, elapsed)
+	// one more is rejected
+	tooMany := "name=x" + strings.Repeat(" OR name=x", contactql.MaxConditions)
+	_, err = parse.Query(env, tooMany, resolver)
+	assert.EqualError(t, err, fmt.Sprintf("query contains more than %d conditions", contactql.MaxConditions))
+	assert.Equal(t, contactql.ErrTooComplex, err.(*contactql.QueryError).Code())
 }

--- a/contactql/parse/parse_test.go
+++ b/contactql/parse/parse_test.go
@@ -3,6 +3,7 @@ package parse_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/assets/static"
@@ -10,6 +11,7 @@ import (
 	"github.com/nyaruka/goflow/contactql/parse"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseQuery(t *testing.T) {
@@ -533,4 +535,31 @@ func TestParseQueryTooComplex(t *testing.T) {
 	})
 	assert.EqualError(t, err, "query is too complex")
 	assert.Equal(t, contactql.ErrTooComplex, err.(*contactql.QueryError).Code())
+}
+
+// TestSimplifyLongChain checks that a long chain of same-op conditions is flattened correctly and, more
+// importantly, in linear time. Parsing `a or b or c ...` produces a left leaning tree and flattening it
+// used to copy the promoted children at every level, which is quadratic - a ~1.7MB query of this shape
+// took ~35s of CPU. The time bound here is very generous compared to the ~0.2s this now takes; it exists
+// only to catch a return of the quadratic behaviour.
+func TestSimplifyLongChain(t *testing.T) {
+	env := envs.NewBuilder().Build()
+	resolver := contactql.NewMockResolver(nil, nil, nil)
+
+	const n = 100000
+	query := "name=x" + strings.Repeat(" OR name=x", n)
+
+	start := time.Now()
+	parsed, err := parse.Query(env, query, resolver)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+
+	// all the conditions should have been promoted into a single OR node
+	root, ok := parsed.Root().(*contactql.BoolCombination)
+	require.True(t, ok, "root should be a bool combination")
+	assert.Equal(t, contactql.BoolOperatorOr, root.Operator())
+	assert.Len(t, root.Children(), n+1)
+
+	assert.Less(t, elapsed, 10*time.Second, "flattening a chain of %d conditions took %s - has it become quadratic again?", n, elapsed)
 }

--- a/contactql/query.go
+++ b/contactql/query.go
@@ -308,24 +308,28 @@ func (b *BoolCombination) validate(env envs.Environment, resolver Resolver) erro
 }
 
 func (b *BoolCombination) Simplify() QueryNode {
-	simplifiedChildren := make([]QueryNode, 0, len(b.children))
+	var newChildren []QueryNode
 
+	// simplify by promoting grand children to children if they're combined with same op
 	for _, child := range b.children {
 		// let children remove themselves by simplifying to nil
 		sc := child.Simplify()
-		if sc != nil {
-			simplifiedChildren = append(simplifiedChildren, sc)
+		if sc == nil {
+			continue
 		}
-	}
 
-	newChildren := make([]QueryNode, 0, 2*len(simplifiedChildren))
-
-	// simplify by promoting grand children to children if they're combined with same op
-	for _, child := range simplifiedChildren {
-		switch typed := child.(type) {
+		switch typed := sc.(type) {
 		case *BoolCombination:
 			if typed.op == b.op {
-				newChildren = append(newChildren, typed.children...)
+				// adopt the grand children slice the first time we promote rather than copying into a new
+				// one. Parsing a chain like a AND b AND c gives a left leaning tree, so copying at every
+				// level would make flattening it quadratic in the length of the chain. The slice we adopt
+				// was freshly built by the child's own Simplify and isn't referenced anywhere else.
+				if newChildren == nil {
+					newChildren = typed.children
+				} else {
+					newChildren = append(newChildren, typed.children...)
+				}
 			} else {
 				newChildren = append(newChildren, typed)
 			}

--- a/contactql/query.go
+++ b/contactql/query.go
@@ -16,6 +16,11 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// MaxConditions is the maximum number of conditions a query can contain. Every condition becomes a clause
+// when the query is translated for a search backend, so this bounds how much work an untrusted query can
+// create both here and downstream. It's far more than any hand written query needs.
+const MaxConditions = 1000
+
 // Operator is a comparison operation between two values in a condition
 type Operator string
 
@@ -376,6 +381,15 @@ func (q *ContactQuery) String() string {
 // NewContactQuery creates a new query from the given root node, validating it against the given resolver
 // (or as much as possible if none is provided) and simplifying it.
 func NewContactQuery(env envs.Environment, root QueryNode, resolver Resolver) (*ContactQuery, error) {
+	// bound overall complexity before doing any per-condition work. Each condition becomes a clause when
+	// the query is translated for a search backend, so an oversized query is expensive for every consumer
+	// and not just for us.
+	numConditions := 0
+	walk(root, func(*Condition) { numConditions++ })
+	if numConditions > MaxConditions {
+		return nil, NewQueryError(ErrTooComplex, fmt.Sprintf("query contains more than %d conditions", MaxConditions))
+	}
+
 	if err := root.validate(env, resolver); err != nil {
 		return nil, err
 	}

--- a/contactql/query_test.go
+++ b/contactql/query_test.go
@@ -2,10 +2,12 @@ package contactql_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/nyaruka/goflow/contactql"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEscapeValue(t *testing.T) {
@@ -13,4 +15,31 @@ func TestEscapeValue(t *testing.T) {
 	assert.Equal(t, `"bobby tables"`, contactql.EscapeValue(`bobby tables`))
 	assert.Equal(t, `"\"\" OR (id = 1)"`, contactql.EscapeValue(`"" OR (id = 1)`))
 	assert.Equal(t, `"\\\"foo"`, contactql.EscapeValue(`\"foo`))
+}
+
+// TestSimplifyLongChain checks that flattening a long chain of same-op conditions is linear. Parsing
+// `a or b or c ...` produces a left leaning tree, and promoting the grand children used to copy them at
+// every level, which is quadratic in the length of the chain. Queries are capped at MaxConditions so this
+// exercises Simplify directly, keeping the algorithm honest rather than relying on that cap. The time
+// bound is very loose compared to the ~0.2s this takes; it only exists to catch a quadratic regression.
+func TestSimplifyLongChain(t *testing.T) {
+	const n = 100000
+
+	var node contactql.QueryNode = contactql.NewCondition(contactql.PropertyTypeAttribute, "name", contactql.OpEqual, "x")
+	for range n {
+		cond := contactql.NewCondition(contactql.PropertyTypeAttribute, "name", contactql.OpEqual, "x")
+		node = contactql.NewBoolCombination(contactql.BoolOperatorOr, node, cond)
+	}
+
+	start := time.Now()
+	simplified := node.Simplify()
+	elapsed := time.Since(start)
+
+	// the whole chain should collapse into a single OR node
+	root, ok := simplified.(*contactql.BoolCombination)
+	require.True(t, ok, "simplified root should be a bool combination")
+	assert.Equal(t, contactql.BoolOperatorOr, root.Operator())
+	assert.Len(t, root.Children(), n+1)
+
+	assert.Less(t, elapsed, 10*time.Second, "flattening a chain of %d conditions took %s - has it become quadratic again?", n, elapsed)
 }


### PR DESCRIPTION
Follow-up to #1541, bounding contact query complexity. Two related changes.

### 1. Cap the number of conditions in a query

Every condition becomes a clause when a query is translated for a search backend, so an unbounded query is expensive for whatever consumes it (Elasticsearch in particular) and not just for goflow. `NewContactQuery` now rejects queries with more than `MaxConditions` (**1000**) conditions with an `ErrTooComplex` error.

Enforcing it in `NewContactQuery` rather than in the parser means it also covers programmatically-built queries, not just parsed ones.

This is not covered by the nesting-depth limit from #1541 — a chain like `a or b or c or ...` is flat, so its bracket depth never exceeds 0.

### 2. Flatten condition chains in linear time

Parsing `a or b or c ...` produces a left-leaning tree, and `BoolCombination.Simplify` flattened it by copying the promoted grand children into a fresh slice at **every level** — quadratic in the length of the chain:

| conditions | before | after |
|---|---|---|
| 40,000 | 2.2s | 0.06s |
| 160,000 | 35.3s | 0.26s |

Fixed by adopting the grand children slice on first promotion instead of copying it. The adopted slice was freshly built by the child's own `Simplify` and isn't referenced anywhere else, so reusing it is safe.

The cap in (1) already bounds this in practice, but the algorithm shouldn't rely on the cap to be well behaved — `Simplify` is exported and callable on a hand-built tree.

### Tests
- `TestParseQueryTooManyConditions` — a query of exactly `MaxConditions` is accepted and flattens to that many children; one more is rejected with `ErrTooComplex`.
- `TestSimplifyLongChain` — exercises `Simplify` directly (bypassing the cap) on a 100k chain, asserting correct flattening plus a deliberately loose 10s bound against ~0.02s actual, so it isn't flaky. Verified it catches a regression: with the old `Simplify` restored it fails at 14.1s.
- Existing `TestSimplify` cases cover the semantics this touches (same-op promotion, different-op nesting, alternating chains) and are unchanged.