### PR TITLE
Tighten repeat() output limit to 10000 characters

### DIFF
--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -25,9 +25,10 @@ import (
 var nanosPerSecond = decimal.RequireFromString("1000000000")
 var nonPrintableRegex = regexp.MustCompile(`[\p{Cc}\p{C}]`)
 
-// maxRepeatOutput caps the size in bytes of the string that repeat() will build, to avoid unbounded
-// allocation from an attacker-controlled count.
-const maxRepeatOutput = 1_000_000
+// maxRepeatOutput caps the number of characters that repeat() will build, to avoid unbounded allocation
+// from an attacker-controlled count. Matches the default limit on an evaluated template, beyond which the
+// output would be truncated anyway.
+const maxRepeatOutput = 10_000
 
 func init() {
 	builtin := map[string]types.XFunc{
@@ -822,8 +823,8 @@ func Repeat(env envs.Environment, text *types.XText, count int) types.XValue {
 	if count < 0 {
 		return types.NewXErrorf("must be called with a positive integer, got %d", count)
 	}
-	if n := len(text.Native()); n > 0 && count > maxRepeatOutput/n {
-		return types.NewXErrorf("cannot build a string longer than %d bytes", maxRepeatOutput)
+	if n := utf8.RuneCountInString(text.Native()); n > 0 && count > maxRepeatOutput/n {
+		return types.NewXErrorf("cannot build a string longer than %d characters", maxRepeatOutput)
 	}
 
 	var output bytes.Buffer

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -3,6 +3,7 @@ package functions_test
 import (
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -545,8 +546,12 @@ func TestFunctions(t *testing.T) {
 		{"repeat", dmy, []types.XValue{xs("hi"), xs("-1")}, ERROR},
 		{"repeat", dmy, []types.XValue{xs("hello"), nil}, ERROR},
 		{"repeat", dmy, []types.XValue{}, ERROR},
-		{"repeat", dmy, []types.XValue{xs("x"), xi(2000000000)}, ERROR}, // would exceed max output size
-		{"repeat", dmy, []types.XValue{xs("abcdefghij"), xi(200000)}, ERROR},
+		{"repeat", dmy, []types.XValue{xs("x"), xi(10000)}, xs(strings.Repeat("x", 10000))}, // exactly at the limit
+		{"repeat", dmy, []types.XValue{xs("x"), xi(10001)}, ERROR},                          // one over
+		{"repeat", dmy, []types.XValue{xs("é"), xi(10000)}, xs(strings.Repeat("é", 10000))}, // limit is characters, not bytes
+		{"repeat", dmy, []types.XValue{xs("é"), xi(10001)}, ERROR},
+		{"repeat", dmy, []types.XValue{xs("abcdefghij"), xi(1001)}, ERROR}, // 10010 chars
+		{"repeat", dmy, []types.XValue{xs("x"), xi(2000000000)}, ERROR},
 
 		{"replace", dmy, []types.XValue{xs("hi ho"), xs("hi"), xs("bye")}, xs("bye ho")},
 		{"replace", dmy, []types.XValue{xs("hi ho hi"), xs("hi"), xs("bye"), xi(1)}, xs("bye ho hi")},


### PR DESCRIPTION
Follow-up to #1541, which capped `repeat()` output at 1MB purely to stop an OOM. That's far more than anything destined for a message could need.

### Changes

**Limit lowered to 10,000 characters.** This isn't an arbitrary number — it matches the default `MaxTemplateChars`, the limit an evaluated template is truncated to. Building more than that was never useful, since the result would be truncated on the way out regardless. Worst-case allocation drops from ~1MB to ~40KB.

**Counted in characters rather than bytes.** `len()` is bytes, so the old check halved the effective limit for multi-byte text — `repeat("é", n)` would have tripped at 5,000 characters rather than 10,000. Now uses `utf8.RuneCountInString`, which also makes the error message accurate and matches how `stringsx.Truncate` measures `MaxTemplateChars` (it's rune-based).

I considered capping the repetition *count* at 100 instead, but the output size is the dimension that actually matters, and a count limit would reject harmless things like `repeat("-", 200)` for a separator while still allowing `repeat(<long string>, 100)`.

The overflow-safe form of the check (division rather than multiplication) is retained.

### Tests
Boundary cases added: exactly at the limit is accepted, one over is rejected, and `repeat("é", 10000)` succeeds — which the previous byte-based check would have wrongly rejected. Full suite passes.