### PR TITLE
Use the same generic message for all too-complex queries

### DIFF
--- a/contactql/parse/parse_test.go
+++ b/contactql/parse/parse_test.go
@@ -1,7 +1,6 @@
 package parse_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -550,6 +549,8 @@ func TestParseQueryTooManyConditions(t *testing.T) {
 	// one more is rejected
 	tooMany := "name=x" + strings.Repeat(" OR name=x", contactql.MaxConditions)
 	_, err = parse.Query(env, tooMany, resolver)
-	assert.EqualError(t, err, fmt.Sprintf("query contains more than %d conditions", contactql.MaxConditions))
+	// deliberately the same generic message as any other too-complex query, so we don't tell a bad actor
+	// which limit they hit or where it is
+	assert.EqualError(t, err, "query is too complex")
 	assert.Equal(t, contactql.ErrTooComplex, err.(*contactql.QueryError).Code())
 }

--- a/contactql/query.go
+++ b/contactql/query.go
@@ -387,7 +387,7 @@ func NewContactQuery(env envs.Environment, root QueryNode, resolver Resolver) (*
 	numConditions := 0
 	walk(root, func(*Condition) { numConditions++ })
 	if numConditions > MaxConditions {
-		return nil, NewQueryError(ErrTooComplex, fmt.Sprintf("query contains more than %d conditions", MaxConditions))
+		return nil, NewQueryError(ErrTooComplex, "query is too complex")
 	}
 
 	if err := root.validate(env, resolver); err != nil {


### PR DESCRIPTION
Follow-up to #1541 / #1542, which added two query limits sharing the `too_complex` error code:

- nesting depth → `"query is too complex"`
- condition count → `"query contains more than 1000 conditions"`

The second reported the exact threshold, which tells anyone probing the limits precisely what we detect and where the boundary sits. Both now report the same generic message, so the two limits are indistinguishable from outside.

Keeping a single `too_complex` code (rather than splitting it per limit) is deliberate for the same reason. A user who hits a limit on a legitimate query can report it and we can work out whether we're blocking a valid use case.

Trade-off worth noting: we lose the ability to tell the two limits apart from the message alone when debugging a report — the distinction is still recoverable from the query itself.

Note this error currently reaches users as raw untranslated English, because `too_complex` isn't in the mapping that turns query error codes into friendly localized messages. That's tracked separately.