### PR TITLE
Document invariants around contactql type assertions and nesting depth

### DIFF
--- a/contactql/evaluator.go
+++ b/contactql/evaluator.go
@@ -13,6 +13,10 @@ import (
 )
 
 // Queryable is the interface objects must implement queried
+//
+// Returned values must match the type the queried property is declared as - decimal.Decimal for number
+// properties, time.Time for datetime ones and string for everything else - as evaluation asserts them to
+// that type. Return no values rather than a value of a different type.
 type Queryable interface {
 	QueryProperty(envs.Environment, string, PropertyType) []any
 }

--- a/utils/text.go
+++ b/utils/text.go
@@ -101,6 +101,9 @@ func Indent(s string, prefix string) string {
 // as opening brackets and ), ] and } as closing. String literals are not interpreted, so brackets inside
 // quoted text are counted too - a conservative over-estimate that's safe against input crafted to trigger
 // deep recursion in the expression and query parsers. Scanning stops as soon as the limit is exceeded.
+//
+// It's shared by grammars that use different subsets of these brackets, so for any given grammar it may
+// count brackets that aren't nesting tokens there at all - again an over-estimate and never an under one.
 func NestingDepthExceeds(s string, max int) bool {
 	depth := 0
 	for _, r := range s {


### PR DESCRIPTION
Comment-only. This started as defensive guards against two panic classes in `contactql`, but checking the real implementations showed both are unreachable by construction and that guarding them would have made failures worse, so the runtime changes were dropped in favour of writing the invariants down.

**Type assertions when evaluating a condition.** The evaluator asserts a queried value to the type the property is *declared* as. This is safe because the value is produced from that same declared type — `FieldValue.QueryValue()` switches on `field.Type()`, the same source the evaluator reads — so the two cannot disagree. A field whose stored value doesn't match its declared type yields no value at all rather than a mistyped one. That invariant lives entirely in the `Queryable` contract, so it's now stated there.

**Re-resolving field and group references.** Converting a query to Elastic or inspecting it calls `ResolveField`/`ResolveGroup` again, which would nil-deref if the resolver no longer resolves them. Field conditions are validated against their resolver at parse time, so this needs a resolver that changed since — developer misuse, which both files already handle by panicking deliberately. Substituting a match-nothing query would be worse than the panic: it turns a loud crash into a query that silently matches no contacts, which for dynamic group re-evaluation would depopulate a group instead of failing. Left as-is.

**`NestingDepthExceeds`.** Notes that it's shared by grammars using different subsets of the brackets it counts, so it may count brackets that aren't nesting tokens in a given grammar — an over-estimate, never an under one.

No behaviour change, so no new tests. Full suite passes.