### PR TITLE
Tighten limits on contact queries

### DIFF
--- a/contactql/parse/parse.go
+++ b/contactql/parse/parse.go
@@ -6,6 +6,7 @@ package parse
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/antlr4-go/antlr/v4"
 	gen "github.com/nyaruka/goflow/antlr/gen/contactql"
@@ -19,11 +20,23 @@ import (
 // process. Real queries are written by humans and nest a handful of levels deep at most.
 const maxQueryDepth = 100
 
+// maxQueryLength is the maximum length of query text we'll attempt to parse. The cost of parsing is
+// proportional to the length of the input, and the bracket depth limit doesn't bound a query that's simply
+// long rather than nested, so without this a huge query is fully parsed before being rejected for having
+// too many conditions. Matches the limit applied by callers.
+const maxQueryLength = 10_000
+
 // Query parses a ContactQL query from the given input. If resolver is provided then we validate against it
 // to ensure that fields and groups exist. If not provided then still validate what we can.
 func Query(env envs.Environment, text string, resolver contactql.Resolver) (*contactql.ContactQuery, error) {
 	// preprocess text before parsing
 	text = strings.TrimSpace(text)
+
+	// reject overly long queries before parsing. Length is counted in characters to match how callers count
+	// it, and the byte length is checked first to short circuit as it's never less than the character count.
+	if len(text) > maxQueryLength && utf8.RuneCountInString(text) > maxQueryLength {
+		return nil, contactql.NewQueryError(contactql.ErrTooComplex, "query is too complex")
+	}
 
 	// reject overly nested queries before parsing to avoid a stack overflow
 	if utils.NestingDepthExceeds(text, maxQueryDepth) {

--- a/contactql/parse/parse_test.go
+++ b/contactql/parse/parse_test.go
@@ -1,6 +1,7 @@
 package parse_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -534,6 +535,29 @@ func TestParseQueryTooComplex(t *testing.T) {
 	})
 	assert.EqualError(t, err, "query is too complex")
 	assert.Equal(t, contactql.ErrTooComplex, err.(*contactql.QueryError).Code())
+}
+
+func TestParseQueryTooLong(t *testing.T) {
+	env := envs.NewBuilder().Build()
+	resolver := contactql.NewMockResolver(nil, nil, nil)
+
+	// a query can be too long without being nested or having many conditions, so neither of the other
+	// limits sees this one
+	long := fmt.Sprintf(`name = "%s"`, strings.Repeat("x", 10000))
+	_, err := parse.Query(env, long, resolver)
+	assert.EqualError(t, err, "query is too complex")
+	assert.Equal(t, contactql.ErrTooComplex, err.(*contactql.QueryError).Code())
+
+	// a query right on the limit is fine
+	ok := fmt.Sprintf(`name = "%s"`, strings.Repeat("x", 10000-len(`name = ""`)))
+	_, err = parse.Query(env, ok, resolver)
+	assert.NoError(t, err)
+
+	// length is counted in characters and not bytes, so a query of multi-byte characters isn't rejected
+	// for being long when a caller counting characters would have let it through
+	multiByte := fmt.Sprintf(`name = "%s"`, strings.Repeat("é", 5000))
+	_, err = parse.Query(env, multiByte, resolver)
+	assert.NoError(t, err)
 }
 
 func TestParseQueryTooManyConditions(t *testing.T) {

--- a/contactql/query.go
+++ b/contactql/query.go
@@ -18,8 +18,9 @@ import (
 
 // MaxConditions is the maximum number of conditions a query can contain. Every condition becomes a clause
 // when the query is translated for a search backend, so this bounds how much work an untrusted query can
-// create both here and downstream. It's far more than any hand written query needs.
-const MaxConditions = 1000
+// create both here and downstream. Hand written queries use a handful of conditions, but generated ones
+// that OR together a list of values are legitimate and much larger, so this leaves room for those.
+const MaxConditions = 250
 
 // Operator is a comparison operation between two values in a condition
 type Operator string


### PR DESCRIPTION
Two changes to how contact queries are bounded, one calibration and one missing backstop.

## Reduce `MaxConditions` from 1000 to 250

1000 was a conservative first guess made without data. Sampling stored queries on smart groups, broadcasts and flow starts:

- median query is a **single** condition
- 99th percentile is around **five**
- only a handful anywhere exceed 100

The largest legitimate queries are generated rather than hand written — they OR together a list of values (a set of postcodes, say) with an exclusion or two, and reach the low hundreds. Those are real, so the limit has to stay above them. 250 leaves headroom over the largest observed while cutting the ceiling 4x. Nothing currently stored is affected.

Note this is checked in `NewContactQuery`, so it applies on **re-evaluation** of existing smart groups and not just when one is saved — which is why the limit has to clear existing queries rather than merely future ones.

## Add a query length limit

The existing limits leave a gap. Bracket nesting depth only bounds queries that are actually nested, and the condition count is only checked *after* the query has been parsed. A query that is simply long — a flat `a OR b OR c ...` chain with no brackets, or a single condition with an enormous value — is matched by neither until the parsing work is already done.

Measured on the previous code, a flat chain with no brackets:

| Conditions | Size | Depth limit | Result | Time | Heap |
|---|---|---|---|---|---|
| 1,000 | 10 KB | not triggered | rejected | 2 ms | 1 MB |
| 200,000 | 2 MB | not triggered | rejected | 614 ms | 379 MB |
| 1,000,000 | 10 MB | not triggered | rejected | 10.8 s | 1.9 GB |

The query is correctly rejected every time — it just costs 10.8 seconds and 1.9 GB to say no, and the time grows superlinearly with input as GC pressure builds. With the length check that same input is rejected in 2.4 ms with no measurable allocation.

The limit matches what callers already apply, so it rejects nothing that reaches us through a caller that validates. Its value is as a backstop for callers that don't — the library shouldn't depend on every caller remembering. Length is counted in characters rather than bytes so a query of non-latin text isn't rejected here when a caller counting characters would have allowed it.

Both limits report the existing generic `too_complex` error, so nothing distinguishes which one was hit.