### PR TITLE
Guard against panics in remaining sites handling malformed input

### DIFF
--- a/core/field.go
+++ b/core/field.go
@@ -221,11 +221,20 @@ func (f FieldValues) Parse(env envs.Environment, fields *FieldAssets, field *Fie
 		case LocationLevelState:
 			asState = envs.LocationPath(asLocation.Path())
 		case LocationLevelDistrict:
-			asState = envs.LocationPath(asLocation.Parent().Path())
+			// hierarchies read from assets always have complete parent chains, but hierarchies can also be
+			// constructed programmatically so we can't assume that here
+			if state := asLocation.Parent(); state != nil {
+				asState = envs.LocationPath(state.Path())
+			}
 			asDistrict = envs.LocationPath(asLocation.Path())
 		case LocationLevelWard:
-			asState = envs.LocationPath(asLocation.Parent().Parent().Path())
-			asDistrict = envs.LocationPath(asLocation.Parent().Path())
+			if district := asLocation.Parent(); district != nil {
+				asDistrict = envs.LocationPath(district.Path())
+
+				if state := district.Parent(); state != nil {
+					asState = envs.LocationPath(state.Path())
+				}
+			}
 			asWard = envs.LocationPath(asLocation.Path())
 		}
 	}

--- a/core/field_test.go
+++ b/core/field_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/assets/static"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
@@ -125,4 +126,42 @@ func TestFieldAssets(t *testing.T) {
 	// but groups don't support query conditions on groups or flows so those aren't included
 	assert.Nil(t, fields.ResolveGroup(`b7cf0d83-f1c9-411c-96fd-c511a4cfa86d`))
 	assert.Nil(t, fields.ResolveFlow(`50c3706e-fedb-42c0-8eab-dda3335714b7`))
+}
+
+// a location hierarchy can be constructed programmatically with an incomplete parent chain, which parsing a field
+// value against must tolerate rather than panic on
+type orphanHierarchy struct{ *envs.LocationHierarchy }
+
+func TestFieldValueParseWithIncompleteLocationHierarchy(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
+	tcs := []struct {
+		level    envs.LocationLevel
+		state    envs.LocationPath
+		district envs.LocationPath
+		ward     envs.LocationPath
+	}{
+		{core.LocationLevelState, "Rwanda > Kigali", "", ""},
+		{core.LocationLevelDistrict, "", "Rwanda > Kigali", ""},
+		{core.LocationLevelWard, "", "", "Rwanda > Kigali"},
+	}
+
+	for _, tc := range tcs {
+		// a hierarchy rooted at this level, so its locations have no parents at all
+		root := envs.NewLocation(tc.level, "Rwanda > Kigali")
+		locations := core.NewLocationAssets([]assets.LocationHierarchy{
+			&orphanHierarchy{envs.NewLocationHierarchy(env, root, 4)},
+		})
+
+		env := envs.NewBuilder().WithLocationResolver(locations).Build()
+		fields := core.NewFieldAssets([]assets.Field{
+			static.NewField("f4a0d0c1-4d0e-4e9c-9b2b-1a3e6f1b2c3d", "place", "Place", assets.FieldTypeWard),
+		})
+		field := fields.All()[0]
+
+		actual := core.FieldValues{}.Parse(env, fields, field, "Rwanda > Kigali")
+
+		assert.Equal(t, core.NewValue(types.NewXText("Rwanda > Kigali"), nil, nil, tc.state, tc.district, tc.ward), actual,
+			"parse mismatch at location level %d", tc.level)
+	}
 }

--- a/envs/environment.go
+++ b/envs/environment.go
@@ -138,7 +138,10 @@ func ReadEnvironment(data []byte) (Environment, error) {
 	env.timeFormat = envelope.TimeFormat
 	env.allowedLanguages = envelope.AllowedLanguages
 	env.defaultCountry = envelope.DefaultCountry
-	env.numberFormat = envelope.NumberFormat
+	// an explicit null in the JSON would otherwise clear the default we started with
+	if envelope.NumberFormat != nil {
+		env.numberFormat = envelope.NumberFormat
+	}
 	env.inputCollation = envelope.InputCollation
 	env.redactionPolicy = envelope.RedactionPolicy
 	env.obfuscationKey = envelope.ObfuscationKey

--- a/envs/environment_test.go
+++ b/envs/environment_test.go
@@ -49,6 +49,11 @@ func TestEnvironmentMarshaling(t *testing.T) {
 	assert.Equal(t, envs.RedactionPolicyNone, env.RedactionPolicy())
 	assert.Equal(t, [4]uint32{0xA3B1C, 0xD2E3F, 0x1A2B3, 0xC0FFEE}, env.ObfuscationKey())
 
+	// an explicit null number format doesn't clear the default
+	env, err = envs.ReadEnvironment([]byte(`{"number_format": null}`))
+	assert.NoError(t, err)
+	assert.Equal(t, envs.DefaultNumberFormat, env.NumberFormat())
+
 	// can create with valid values
 	env, err = envs.ReadEnvironment([]byte(`{
 		"date_format": "DD-MM-YYYY", 

--- a/flows/inspect/gettext.go
+++ b/flows/inspect/gettext.go
@@ -40,7 +40,11 @@ func extractLocalizableText(v reflect.Value) (func() []string, func([]string)) {
 			return []string{typed}
 		}
 		w := func(n []string) {
-			v.SetString(n[0])
+			// callers of the write function are expected to pass a non-empty slice but be defensive as this
+			// is driven by localization assets
+			if len(n) > 0 {
+				v.SetString(n[0])
+			}
 		}
 		return r, w
 	}

--- a/flows/inspect/gettext_test.go
+++ b/flows/inspect/gettext_test.go
@@ -49,4 +49,11 @@ func TestLocalizableText(t *testing.T) {
 			"bar"
 		]
 	}`), data, "JSON mismatch")
+
+	// writing an empty slice leaves the text as is rather than panicking
+	inspect.LocalizableText(sendMsg, func(uuid uuids.UUID, property string, vals []string, write func([]string)) {
+		write(nil)
+	})
+
+	assert.Equal(t, "foo", sendMsg.Text)
 }

--- a/flows/routers/base.go
+++ b/flows/routers/base.go
@@ -78,8 +78,18 @@ func (r *baseRouter) EnumerateTemplates(localization flows.Localization, include
 // EnumerateLocalizables enumerates all the localizable text on this object
 func (r *baseRouter) EnumerateLocalizables(include func(uuids.UUID, string, []string, func([]string))) {
 	for _, cat := range r.categories {
+		// categories read from a flow definition are always *Category, but the interface is exported so an
+		// externally constructed router could contain something else, which we simply can't rewrite
+		typed, ok := cat.(*Category)
+		if !ok {
+			continue
+		}
 		w := func(v []string) {
-			cat.(*Category).name = v[0]
+			// callers of the write function are expected to pass a non-empty slice but be defensive as this
+			// is driven by localization assets
+			if len(v) > 0 {
+				typed.name = v[0]
+			}
 		}
 		include(cat.LocalizationUUID(), "name", []string{cat.Name()}, w)
 	}

--- a/flows/routers/base_test.go
+++ b/flows/routers/base_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/routers"
 	"github.com/nyaruka/goflow/flows/triggers"
 	"github.com/nyaruka/goflow/test"
@@ -155,4 +157,27 @@ func TestReadRouter(t *testing.T) {
 	// error if we don't recognize action type
 	_, err = routers.Read([]byte(`{"type": "do_the_foo", "foo": "bar"}`))
 	assert.EqualError(t, err, "unknown type: 'do_the_foo'")
+}
+
+// a category implementation other than routers.Category, which an external caller could construct
+type customCategory struct {
+	flows.Category
+}
+
+func TestEnumerateLocalizables(t *testing.T) {
+	cat := routers.NewCategory("dbd6c2ce-1c2a-4b1d-8a3f-b9df1a1f1cbb", "Red", "0f5bd0d3-a1c5-4b5d-b0b9-a1b4c5d6e7f8")
+	router := routers.NewRandom(nil, "Color", []flows.Category{cat, &customCategory{cat}})
+
+	// writing an empty slice leaves the name as is rather than panicking, and non-*Category categories are skipped
+	router.EnumerateLocalizables(func(uuid uuids.UUID, property string, vals []string, write func([]string)) {
+		write(nil)
+	})
+
+	assert.Equal(t, "Red", cat.Name())
+
+	router.EnumerateLocalizables(func(uuid uuids.UUID, property string, vals []string, write func([]string)) {
+		write([]string{"Rouge"})
+	})
+
+	assert.Equal(t, "Rouge", cat.Name())
 }

--- a/flows/routers/cases/tests.go
+++ b/flows/routers/cases/tests.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/i18n"
@@ -804,9 +805,32 @@ func hasOnlyPhraseTest(env envs.Environment, hays []string, pins []string) types
 
 type decimalTest func(value decimal.Decimal, test1 decimal.Decimal, test2 decimal.Decimal) bool
 
+// compiled number finding regexes, cached by number format so that we don't recompile on every evaluation
+var numberPatterns sync.Map
+
+// creates a regex which finds number like things in text, based on the given number format
+func numberPattern(nf *envs.NumberFormat) (*regexp.Regexp, error) {
+	if cached, ok := numberPatterns.Load(*nf); ok {
+		return cached.(*regexp.Regexp), nil
+	}
+
+	// the symbols come from environment configuration so they have to be quoted to be safely interpolated
+	pattern, err := regexp.Compile(fmt.Sprintf(`[-+]?([\pN%[1]s]+(%[2]s[\pN]+)?|(\W|^)%[2]s[\pN]+)`,
+		regexp.QuoteMeta(nf.DigitGroupingSymbol), regexp.QuoteMeta(nf.DecimalSymbol)))
+	if err != nil {
+		return nil, err
+	}
+
+	numberPatterns.Store(*nf, pattern)
+	return pattern, nil
+}
+
 func testNumber(env envs.Environment, str *types.XText, testNum1 *types.XNumber, testNum2 *types.XNumber, testFunc decimalTest) types.XValue {
-	// create a number finding regex based on current environment
-	pattern := regexp.MustCompile(fmt.Sprintf(`[-+]?([\pN\%[1]s]+(\%[2]s[\pN]+)?|(\W|^)\%[2]s[\pN]+)`, env.NumberFormat().DigitGroupingSymbol, env.NumberFormat().DecimalSymbol))
+	// get a number finding regex based on current environment
+	pattern, err := numberPattern(env.NumberFormat())
+	if err != nil {
+		return types.NewXErrorf("environment has a number format which can't be used to find numbers")
+	}
 
 	// look for number like things in the input and use the first one that we can actually parse
 	for _, value := range pattern.FindAllString(str.Native(), -1) {

--- a/flows/routers/cases/tests_test.go
+++ b/flows/routers/cases/tests_test.go
@@ -541,3 +541,38 @@ func TestHasPhone(t *testing.T) {
 		test.AssertXEqual(t, expected, actual, "has_phone mismatch for input=%s country=%s", tc.input, tc.country)
 	}
 }
+
+func TestHasNumberWithNumberFormats(t *testing.T) {
+	tests := []struct {
+		decimalSymbol       string
+		digitGroupingSymbol string
+		input               string
+		expected            string
+	}{
+		{".", ",", "i have 1,234.5 apples", "1234.5"},
+		{",", ".", "i have 1.234,5 apples", "1234.5"},
+
+		// symbols which are regex meta characters are matched literally rather than breaking the pattern
+		{".", "]", "i have 1]234.5 apples", "1234.5"},
+		{"^", "$", "i have 1$234^5 apples", "1234.5"},
+
+		// empty symbols are tolerated - they can make numbers unparseable but must never panic
+		{".", "", "i have 234.5 apples", "234.5"},
+		{"", ",", "i have 1,234 apples", ""},
+	}
+
+	for _, tc := range tests {
+		env := envs.NewBuilder().WithNumberFormat(&envs.NumberFormat{
+			DecimalSymbol: tc.decimalSymbol, DigitGroupingSymbol: tc.digitGroupingSymbol,
+		}).Build()
+
+		actual := cases.HasNumber(env, xs(tc.input))
+
+		var expected types.XValue = falseResult
+		if tc.expected != "" {
+			expected = cases.NewTrueResult(types.RequireXNumberFromString(tc.expected))
+		}
+
+		test.AssertXEqual(t, expected, actual, "has_number mismatch for input=%s decimal=%s grouping=%s", tc.input, tc.decimalSymbol, tc.digitGroupingSymbol)
+	}
+}

--- a/utils/jsonpath/path.go
+++ b/utils/jsonpath/path.go
@@ -60,6 +60,10 @@ func parsePath(path string) ([]string, error) {
 		}
 	}
 
+	if len(steps) == 0 {
+		return nil, errors.New("path must contain at least one step")
+	}
+
 	return steps, nil
 }
 

--- a/utils/jsonpath/path_test.go
+++ b/utils/jsonpath/path_test.go
@@ -13,6 +13,7 @@ func TestParsePath(t *testing.T) {
 		err      string
 	}{
 		{"", []string{}, "path must begin with $"},
+		{"$", []string{}, "path must contain at least one step"},
 		{"$.foo", []string{"foo"}, ""},
 		{"$[*]", []string{"*"}, ""},
 		{"$[2]", []string{"2"}, ""},
@@ -63,6 +64,9 @@ func TestVisit(t *testing.T) {
 
 		assert.Equal(t, tc.expected, matches)
 	}
+
+	// a path with no steps is an error rather than a panic
+	assert.EqualError(t, Visit(data, "$", func(m any) {}), "path must contain at least one step")
 }
 
 func TestTransform(t *testing.T) {
@@ -82,4 +86,8 @@ func TestTransform(t *testing.T) {
 
 		assert.Equal(t, tc.expected, tc.data)
 	}
+
+	// a path with no steps is an error rather than a panic
+	err := Transform(map[string]any{"foo": "bar"}, "$", func(c, k, m any) any { return "baz" })
+	assert.EqualError(t, err, "path must contain at least one step")
 }


### PR DESCRIPTION
Hardens the remaining panic-risk sites found when auditing handling of malformed input. Each site was verified empirically before being changed, and each fix has a regression test that panics without it.

One of these is reachable from configuration; the rest require programmatically constructed objects or inputs no caller produces, and so are defensive guards with a comment recording the invariant.

### Reachable

**`has_number*` regex built from the number format** (`flows/routers/cases/tests.go`) — the digit grouping and decimal symbols were interpolated raw into a character class and compiled with `regexp.MustCompile`. An empty grouping symbol produces `[\pN\]+...`, where the backslash escapes the class closer and leaves it unterminated, so any `has_number*` test panicked. The symbols are now quoted with `regexp.QuoteMeta` and compiled with `regexp.Compile`, with the error surfaced as a test error. The pattern was also being recompiled on every evaluation, so it's now cached per number format.

### Defensive guards

**Environment with an explicit null number format** (`envs/environment.go`) — `ReadEnvironment` starts from an envelope pre-filled with defaults, so an absent `number_format` already resolves to the default. An explicit `"number_format": null` would instead overwrite it with nil, which then nil-dereferences anywhere the format is read. No caller emits null, but the field is a pointer on an exported entry point, so the default is now kept unless a format is actually supplied.

**Location parent chain** (`core/field.go`) — resolving a district or ward field value walked `Parent()` (and `Parent().Parent()`) without a nil check. Hierarchies read from asset JSON always have complete parent chains because levels are assigned top-down from the root, but a hierarchy can also be constructed programmatically, so the chain is now walked defensively.

**Localization writers** (`flows/routers/base.go`, `flows/inspect/gettext.go`) — both indexed `[0]` of the slice passed to the write callback. The only in-tree caller guards on length first, but these are exported extension points, so both now length check. The router one also asserted `cat.(*Category)` unchecked; the readers only ever construct that type, but the category interface is exported, so it now uses a comma-ok assertion and skips anything else.

**Empty jsonpath** (`utils/jsonpath/path.go`) — `parsePath("$")` returned no steps, so `Visit`/`Transform` panicked indexing `path[0]`. The only caller builds paths from a template catalog whose entries all start with `.`, so this wasn't reachable in practice, but `parsePath` now returns an error for a path with no steps.

### Testing

`go build ./...` and `go test -p=1 ./...` pass. Each new test was confirmed to panic with its fix reverted.
