### PR TITLE
Limit size of arrays built by functions and lower repeat() output limit

### DIFF
--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -26,9 +26,14 @@ var nanosPerSecond = decimal.RequireFromString("1000000000")
 var nonPrintableRegex = regexp.MustCompile(`[\p{Cc}\p{C}]`)
 
 // maxRepeatOutput caps the number of characters that repeat() will build, to avoid unbounded allocation
-// from an attacker-controlled count. Matches the default limit on an evaluated template, beyond which the
-// output would be truncated anyway.
-const maxRepeatOutput = 10_000
+// from an attacker-controlled count. Real usage repeats short strings a handful of times, so this is
+// generous headroom whilst still bounding a single call.
+const maxRepeatOutput = 1_000
+
+// maxArrayLength caps the number of items in an array built by a function such as split(), to avoid
+// unbounded allocation from attacker-controlled input. Matches the default limit on an evaluated template,
+// since splitting a maximum size text can produce at most that many items.
+const maxArrayLength = 10_000
 
 func init() {
 	builtin := map[string]types.XFunc{
@@ -277,6 +282,10 @@ func Time(env envs.Environment, value types.XValue) types.XValue {
 //
 // @function array(values...)
 func Array(env envs.Environment, values ...types.XValue) types.XValue {
+	if len(values) > maxArrayLength {
+		return types.NewXErrorf("cannot build an array with more than %d items", maxArrayLength)
+	}
+
 	// check none of our args are errors
 	for _, arg := range values {
 		if types.IsXError(arg) {
@@ -424,6 +433,9 @@ func Code(env envs.Environment, text *types.XText) types.XValue {
 // @function split(text, [,delimiters])
 func Split(env envs.Environment, text *types.XText, delimiters *types.XText) types.XValue {
 	splits := extractWords(text.Native(), delimiters.Native())
+	if len(splits) > maxArrayLength {
+		return types.NewXErrorf("cannot build an array with more than %d items", maxArrayLength)
+	}
 
 	nonEmpty := make([]types.XValue, 0)
 	for _, split := range splits {
@@ -1692,6 +1704,10 @@ func Unique(env envs.Environment, array *types.XArray) types.XValue {
 //
 // @function concat(array1, array2)
 func Concat(env envs.Environment, array1 *types.XArray, array2 *types.XArray) types.XValue {
+	if array1.Count()+array2.Count() > maxArrayLength {
+		return types.NewXErrorf("cannot build an array with more than %d items", maxArrayLength)
+	}
+
 	both := make([]types.XValue, 0, array1.Count()+array2.Count())
 
 	for i := 0; i < array1.Count(); i++ {

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -46,6 +46,15 @@ func TestFunctions(t *testing.T) {
 		WithTimezone(la).
 		Build()
 
+	// inputs for testing array size limits
+	xitems := func(n int) []types.XValue {
+		items := make([]types.XValue, n)
+		for i := range items {
+			items[i] = xs("x")
+		}
+		return items
+	}
+
 	var funcTests = []struct {
 		name     string
 		env      envs.Environment
@@ -69,6 +78,8 @@ func TestFunctions(t *testing.T) {
 		{"array", dmy, []types.XValue{}, xa()},
 		{"array", dmy, []types.XValue{xi(123), xs("abc")}, xa(xi(123), xs("abc"))},
 		{"array", dmy, []types.XValue{xi(123), ERROR, xs("abc")}, ERROR},
+		{"array", dmy, xitems(10_000), xa(xitems(10_000)...)}, // exactly at the limit
+		{"array", dmy, xitems(10_001), ERROR},                 // one over
 
 		{"attachment_parts", dmy, []types.XValue{xs("image/jpeg:http://s3.com/test.jpg")}, types.NewXObject(map[string]types.XValue{
 			"content_type": xs("image/jpeg"),
@@ -109,6 +120,8 @@ func TestFunctions(t *testing.T) {
 
 		{"concat", dmy, []types.XValue{xa(xi(1), xi(2)), xa(xi(3), xi(4))}, xa(xi(1), xi(2), xi(3), xi(4))},
 		{"concat", dmy, []types.XValue{xa(), xa()}, xa()},
+		{"concat", dmy, []types.XValue{xa(xitems(5_000)...), xa(xitems(5_000)...)}, xa(xitems(10_000)...)}, // exactly at the limit
+		{"concat", dmy, []types.XValue{xa(xitems(5_000)...), xa(xitems(5_001)...)}, ERROR},                 // one over
 		{"concat", dmy, []types.XValue{xa()}, ERROR},
 		{"concat", dmy, []types.XValue{xa(), ERROR}, ERROR},
 		{"concat", dmy, []types.XValue{ERROR, xa()}, ERROR},
@@ -546,11 +559,11 @@ func TestFunctions(t *testing.T) {
 		{"repeat", dmy, []types.XValue{xs("hi"), xs("-1")}, ERROR},
 		{"repeat", dmy, []types.XValue{xs("hello"), nil}, ERROR},
 		{"repeat", dmy, []types.XValue{}, ERROR},
-		{"repeat", dmy, []types.XValue{xs("x"), xi(10000)}, xs(strings.Repeat("x", 10000))}, // exactly at the limit
-		{"repeat", dmy, []types.XValue{xs("x"), xi(10001)}, ERROR},                          // one over
-		{"repeat", dmy, []types.XValue{xs("é"), xi(10000)}, xs(strings.Repeat("é", 10000))}, // limit is characters, not bytes
-		{"repeat", dmy, []types.XValue{xs("é"), xi(10001)}, ERROR},
-		{"repeat", dmy, []types.XValue{xs("abcdefghij"), xi(1001)}, ERROR}, // 10010 chars
+		{"repeat", dmy, []types.XValue{xs("x"), xi(1000)}, xs(strings.Repeat("x", 1000))}, // exactly at the limit
+		{"repeat", dmy, []types.XValue{xs("x"), xi(1001)}, ERROR},                         // one over
+		{"repeat", dmy, []types.XValue{xs("é"), xi(1000)}, xs(strings.Repeat("é", 1000))}, // limit is characters, not bytes
+		{"repeat", dmy, []types.XValue{xs("é"), xi(1001)}, ERROR},
+		{"repeat", dmy, []types.XValue{xs("abcdefghij"), xi(101)}, ERROR}, // 1010 chars
 		{"repeat", dmy, []types.XValue{xs("x"), xi(2000000000)}, ERROR},
 
 		{"replace", dmy, []types.XValue{xs("hi ho"), xs("hi"), xs("bye")}, xs("bye ho")},
@@ -623,6 +636,8 @@ func TestFunctions(t *testing.T) {
 		{"split", dmy, []types.XValue{xs("1 2,3"), nil}, xa(xs("1"), xs("2"), xs("3"))},
 		{"split", dmy, []types.XValue{xs("1,2,3"), xs(",")}, xa(xs("1"), xs("2"), xs("3"))},
 		{"split", dmy, []types.XValue{xs("1,2,3"), xs(".")}, xa(xs("1,2,3"))},
+		{"split", dmy, []types.XValue{xs(strings.Repeat("x ", 10_000)), nil}, xa(xitems(10_000)...)}, // exactly at the limit
+		{"split", dmy, []types.XValue{xs(strings.Repeat("x ", 10_001)), nil}, ERROR},                // one over
 		{"split", dmy, []types.XValue{xs("1,2,3"), ERROR}, ERROR},
 		{"split", dmy, []types.XValue{ERROR, xs(",")}, ERROR},
 		{"split", dmy, []types.XValue{}, ERROR},


### PR DESCRIPTION
Adds per-call size limits to the builtin functions that can produce large values from small inputs:

* New `maxArrayLength` (10,000) enforced in `split()`, `concat()` and `array()` — matches the default limit on an evaluated template, since splitting a maximum size text can produce at most that many items.
* `maxRepeatOutput` lowered from 10,000 to 1,000 characters — real usage repeats short strings a handful of times, so this is still generous headroom.

These bound what a single call can allocate and give function-specific errors for the naive cases. They don't bound cost compounding across calls (e.g. via `foreach`) — that needs a cumulative per-evaluation budget which will come separately.