### PR TITLE
Thread the caller's context through template evaluation and routing

### DIFF
--- a/cmd/docgen/docs/html_renderers.go
+++ b/cmd/docgen/docs/html_renderers.go
@@ -400,7 +400,7 @@ func checkExample(session flows.Session, line string) error {
 
 	// evaluate our expression
 	log := test.NewEventLog()
-	val, ok := session.Runs()[0].EvaluateTemplate(example, log.Log)
+	val, ok := session.Runs()[0].EvaluateTemplate(context.Background(), example, log.Log)
 
 	if expected == "ERROR" {
 		if ok {

--- a/excellent/base.go
+++ b/excellent/base.go
@@ -37,16 +37,16 @@ func NewEvaluator() *Evaluator {
 type Escaping func(string) string
 
 // Template evaluates the passed in template
-func (e *Evaluator) Template(env envs.Environment, ctx *types.XObject, template string, escaping Escaping) (string, []string, error) {
+func (e *Evaluator) Template(ctx context.Context, env envs.Environment, root *types.XObject, template string, escaping Escaping) (string, []string, error) {
 	var buf strings.Builder
 	var allWarnings []string
 
-	err := VisitTemplate(template, ctx.Properties(), true, func(tokenType XTokenType, token string) error {
+	err := VisitTemplate(template, root.Properties(), true, func(tokenType XTokenType, token string) error {
 		switch tokenType {
 		case BODY:
 			buf.WriteString(token)
 		case IDENTIFIER, EXPRESSION:
-			value, warnings := e.Expression(env, ctx, token)
+			value, warnings := e.Expression(ctx, env, root, token)
 
 			allWarnings = append(allWarnings, warnings...)
 
@@ -74,9 +74,9 @@ func (e *Evaluator) Template(env envs.Environment, ctx *types.XObject, template 
 // TemplateValue is equivalent to Template except in the case where the template contains
 // a single identifier or expression, ie: "@contact" or "@(first(contact.urns))". In these cases we return
 // the typed value from EvaluateExpression instead of stringifying the result.
-func (e *Evaluator) TemplateValue(env envs.Environment, ctx *types.XObject, template string) (types.XValue, []string, error) {
+func (e *Evaluator) TemplateValue(ctx context.Context, env envs.Environment, root *types.XObject, template string) (types.XValue, []string, error) {
 	template = strings.TrimSpace(template)
-	scanner := NewXScanner(strings.NewReader(template), ctx.Properties())
+	scanner := NewXScanner(strings.NewReader(template), root.Properties())
 
 	// parse our first token
 	tokenType, token := scanner.Scan()
@@ -88,19 +88,19 @@ func (e *Evaluator) TemplateValue(env envs.Environment, ctx *types.XObject, temp
 	if nextTT == EOF {
 		switch tokenType {
 		case IDENTIFIER, EXPRESSION:
-			val, warnings := e.Expression(env, ctx, token)
+			val, warnings := e.Expression(ctx, env, root, token)
 			return val, warnings, nil
 		}
 	}
 
 	// otherwise fallback to full template evaluation
-	asStr, warnings, err := e.Template(env, ctx, template, nil)
+	asStr, warnings, err := e.Template(ctx, env, root, template, nil)
 	return types.NewXText(asStr), warnings, err
 }
 
 // Expression evalutes the passed in Excellent expression, returning the typed value it evaluates to,
 // which might be an error, e.g. "2 / 3" or "contact.fields.age"
-func (e *Evaluator) Expression(env envs.Environment, root *types.XObject, expression string) (types.XValue, []string) {
+func (e *Evaluator) Expression(ctx context.Context, env envs.Environment, root *types.XObject, expression string) (types.XValue, []string) {
 	parsed, err := Parse(expression, nil)
 	if err != nil {
 		return types.NewXError(err), nil
@@ -110,9 +110,9 @@ func (e *Evaluator) Expression(env envs.Environment, root *types.XObject, expres
 
 	warnings := &Warnings{}
 
-	// evaluation is context-aware so that per-evaluation limits can be enforced; the context originates here
-	// rather than being threaded in from the caller until there's a caller-side deadline worth honouring
-	ctx := budget.With(context.Background(), budget.New(maxEvaluationCost))
+	// a per-evaluation cost budget is added to the caller's context so that its deadline (if any) is honoured
+	// alongside the budget
+	ctx = budget.With(ctx, budget.New(maxEvaluationCost))
 
 	return parsed.Evaluate(ctx, env, scope, warnings), warnings.all
 }

--- a/excellent/base_test.go
+++ b/excellent/base_test.go
@@ -1,7 +1,6 @@
 package excellent_test
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -207,7 +206,7 @@ func TestEvaluateTemplateValue(t *testing.T) {
 
 	for _, tc := range evaluateTests {
 		eval := excellent.NewEvaluator()
-		result, _, err := eval.TemplateValue(context.Background(), env, ctx, tc.template)
+		result, _, err := eval.TemplateValue(t.Context(), env, ctx, tc.template)
 		assert.NoError(t, err)
 
 		// don't check error equality - just check that we got an error if we expected one
@@ -347,7 +346,7 @@ func TestEvaluateTemplate(t *testing.T) {
 		}()
 
 		eval := excellent.NewEvaluator()
-		val, _, err := eval.Template(context.Background(), env, ctx, tc.template, nil)
+		val, _, err := eval.Template(t.Context(), env, ctx, tc.template, nil)
 
 		if tc.hasError {
 			assert.Error(t, err, "expected error evaluating template '%s'", tc.template)
@@ -369,7 +368,7 @@ func TestEvaluateTemplateWithEscaping(t *testing.T) {
 
 	eval := excellent.NewEvaluator()
 	env := envs.NewBuilder().Build()
-	val, _, err := eval.Template(context.Background(), env, ctx, `Hi @string1`, escaping)
+	val, _, err := eval.Template(t.Context(), env, ctx, `Hi @string1`, escaping)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi \"\"; DROP`, val)
 }
@@ -392,17 +391,17 @@ func TestEvaluateTemplateWithDeprecatedValues(t *testing.T) {
 	eval := excellent.NewEvaluator()
 	env := envs.NewBuilder().Build()
 
-	val, warnings, err := eval.Template(context.Background(), env, ctx, `Hi @foo.bar`, nil)
+	val, warnings, err := eval.Template(t.Context(), env, ctx, `Hi @foo.bar`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi 123`, val)
 	assert.Len(t, warnings, 0)
 
-	val, warnings, err = eval.Template(context.Background(), env, ctx, `Hi @foo.zzz`, nil)
+	val, warnings, err = eval.Template(t.Context(), env, ctx, `Hi @foo.zzz`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi abc`, val)
 	assert.Equal(t, []string{"deprecated context value accessed: foooo"}, warnings)
 
-	val, warnings, err = eval.Template(context.Background(), env, ctx, `Hi @yyy @foo.zzz`, nil)
+	val, warnings, err = eval.Template(t.Context(), env, ctx, `Hi @yyy @foo.zzz`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi xyz abc`, val)
 	assert.Equal(t, []string{"deprecated context value accessed: noooo", "deprecated context value accessed: foooo"}, warnings)
@@ -460,7 +459,7 @@ func TestEvaluationErrors(t *testing.T) {
 
 	for _, tc := range tcs {
 		eval := excellent.NewEvaluator()
-		result, _, err := eval.Template(context.Background(), env, ctx, tc.template, nil)
+		result, _, err := eval.Template(t.Context(), env, ctx, tc.template, nil)
 		assert.Equal(t, "", result)
 		assert.NotNil(t, err)
 
@@ -482,7 +481,7 @@ func TestEvaluationBudget(t *testing.T) {
 		`@(repeat("=", 80))`,
 	}
 	for _, tpl := range allowed {
-		_, _, err := eval.Template(context.Background(), env, ctx, tpl, nil)
+		_, _, err := eval.Template(t.Context(), env, ctx, tpl, nil)
 		assert.NoError(t, err, "expected %s to be within budget", tpl)
 	}
 
@@ -497,7 +496,7 @@ func TestEvaluationBudget(t *testing.T) {
 		{`@(foreach(split(repeat("x ",500)," "), (a) => foreach(split(repeat("x ",500)," "), (b) => foreach(split(repeat("x ",500)," "), (c) => 1))))`, "pure iteration over tiny values"},
 	}
 	for _, tc := range blocked {
-		_, _, err := eval.Template(context.Background(), env, ctx, tc.template, nil)
+		_, _, err := eval.Template(t.Context(), env, ctx, tc.template, nil)
 		if assert.Error(t, err, "expected %s to exceed budget", tc.desc) {
 			assert.Contains(t, err.Error(), "expression is too complex to evaluate", "for %s", tc.desc)
 		}
@@ -505,7 +504,7 @@ func TestEvaluationBudget(t *testing.T) {
 
 	// the budget is also wired for the Expression() entry point, and empty text can't be produced for free
 	// (which would otherwise bypass the per-value floor and allow unbounded iteration)
-	val, _ := eval.Expression(context.Background(), env, ctx, `foreach(split(repeat("x ",500)," "), (a) => foreach(split(repeat("x ",500)," "), (b) => foreach(split(repeat("x ",500)," "), (c) => "")))`)
+	val, _ := eval.Expression(t.Context(), env, ctx, `foreach(split(repeat("x ",500)," "), (a) => foreach(split(repeat("x ",500)," "), (b) => foreach(split(repeat("x ",500)," "), (c) => "")))`)
 	assert.True(t, types.IsXError(val))
 	assert.Contains(t, val.(*types.XError).Error(), "expression is too complex to evaluate")
 }

--- a/excellent/base_test.go
+++ b/excellent/base_test.go
@@ -1,6 +1,7 @@
 package excellent_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -206,7 +207,7 @@ func TestEvaluateTemplateValue(t *testing.T) {
 
 	for _, tc := range evaluateTests {
 		eval := excellent.NewEvaluator()
-		result, _, err := eval.TemplateValue(env, ctx, tc.template)
+		result, _, err := eval.TemplateValue(context.Background(), env, ctx, tc.template)
 		assert.NoError(t, err)
 
 		// don't check error equality - just check that we got an error if we expected one
@@ -346,7 +347,7 @@ func TestEvaluateTemplate(t *testing.T) {
 		}()
 
 		eval := excellent.NewEvaluator()
-		val, _, err := eval.Template(env, ctx, tc.template, nil)
+		val, _, err := eval.Template(context.Background(), env, ctx, tc.template, nil)
 
 		if tc.hasError {
 			assert.Error(t, err, "expected error evaluating template '%s'", tc.template)
@@ -368,7 +369,7 @@ func TestEvaluateTemplateWithEscaping(t *testing.T) {
 
 	eval := excellent.NewEvaluator()
 	env := envs.NewBuilder().Build()
-	val, _, err := eval.Template(env, ctx, `Hi @string1`, escaping)
+	val, _, err := eval.Template(context.Background(), env, ctx, `Hi @string1`, escaping)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi \"\"; DROP`, val)
 }
@@ -391,17 +392,17 @@ func TestEvaluateTemplateWithDeprecatedValues(t *testing.T) {
 	eval := excellent.NewEvaluator()
 	env := envs.NewBuilder().Build()
 
-	val, warnings, err := eval.Template(env, ctx, `Hi @foo.bar`, nil)
+	val, warnings, err := eval.Template(context.Background(), env, ctx, `Hi @foo.bar`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi 123`, val)
 	assert.Len(t, warnings, 0)
 
-	val, warnings, err = eval.Template(env, ctx, `Hi @foo.zzz`, nil)
+	val, warnings, err = eval.Template(context.Background(), env, ctx, `Hi @foo.zzz`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi abc`, val)
 	assert.Equal(t, []string{"deprecated context value accessed: foooo"}, warnings)
 
-	val, warnings, err = eval.Template(env, ctx, `Hi @yyy @foo.zzz`, nil)
+	val, warnings, err = eval.Template(context.Background(), env, ctx, `Hi @yyy @foo.zzz`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi xyz abc`, val)
 	assert.Equal(t, []string{"deprecated context value accessed: noooo", "deprecated context value accessed: foooo"}, warnings)
@@ -459,7 +460,7 @@ func TestEvaluationErrors(t *testing.T) {
 
 	for _, tc := range tcs {
 		eval := excellent.NewEvaluator()
-		result, _, err := eval.Template(env, ctx, tc.template, nil)
+		result, _, err := eval.Template(context.Background(), env, ctx, tc.template, nil)
 		assert.Equal(t, "", result)
 		assert.NotNil(t, err)
 
@@ -481,7 +482,7 @@ func TestEvaluationBudget(t *testing.T) {
 		`@(repeat("=", 80))`,
 	}
 	for _, tpl := range allowed {
-		_, _, err := eval.Template(env, ctx, tpl, nil)
+		_, _, err := eval.Template(context.Background(), env, ctx, tpl, nil)
 		assert.NoError(t, err, "expected %s to be within budget", tpl)
 	}
 
@@ -496,7 +497,7 @@ func TestEvaluationBudget(t *testing.T) {
 		{`@(foreach(split(repeat("x ",500)," "), (a) => foreach(split(repeat("x ",500)," "), (b) => foreach(split(repeat("x ",500)," "), (c) => 1))))`, "pure iteration over tiny values"},
 	}
 	for _, tc := range blocked {
-		_, _, err := eval.Template(env, ctx, tc.template, nil)
+		_, _, err := eval.Template(context.Background(), env, ctx, tc.template, nil)
 		if assert.Error(t, err, "expected %s to exceed budget", tc.desc) {
 			assert.Contains(t, err.Error(), "expression is too complex to evaluate", "for %s", tc.desc)
 		}
@@ -504,7 +505,7 @@ func TestEvaluationBudget(t *testing.T) {
 
 	// the budget is also wired for the Expression() entry point, and empty text can't be produced for free
 	// (which would otherwise bypass the per-value floor and allow unbounded iteration)
-	val, _ := eval.Expression(env, ctx, `foreach(split(repeat("x ",500)," "), (a) => foreach(split(repeat("x ",500)," "), (b) => foreach(split(repeat("x ",500)," "), (c) => "")))`)
+	val, _ := eval.Expression(context.Background(), env, ctx, `foreach(split(repeat("x ",500)," "), (a) => foreach(split(repeat("x ",500)," "), (b) => foreach(split(repeat("x ",500)," "), (c) => "")))`)
 	assert.True(t, types.IsXError(val))
 	assert.Contains(t, val.(*types.XError).Error(), "expression is too complex to evaluate")
 }

--- a/excellent/refactor/base_test.go
+++ b/excellent/refactor/base_test.go
@@ -1,6 +1,7 @@
 package refactor_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/nyaruka/goflow/envs"
@@ -56,8 +57,8 @@ func TestRefactorTemplate(t *testing.T) {
 			assert.NoError(t, err, "unexpected error for template: %s, err: %s", tc.template, err)
 
 			// test that the original and the refactored template evaluate equally
-			originalValue, _, _ := eval.Template(env, ctx, tc.template, nil)
-			refactoredValue, _, _ := eval.Template(env, ctx, actual, nil)
+			originalValue, _, _ := eval.Template(context.Background(), env, ctx, tc.template, nil)
+			refactoredValue, _, _ := eval.Template(context.Background(), env, ctx, actual, nil)
 
 			assert.Equal(t, originalValue, refactoredValue, "refactoring of template %s gives different value: %s", tc.template, refactoredValue)
 		}

--- a/excellent/refactor/base_test.go
+++ b/excellent/refactor/base_test.go
@@ -1,7 +1,6 @@
 package refactor_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/nyaruka/goflow/envs"
@@ -57,8 +56,8 @@ func TestRefactorTemplate(t *testing.T) {
 			assert.NoError(t, err, "unexpected error for template: %s, err: %s", tc.template, err)
 
 			// test that the original and the refactored template evaluate equally
-			originalValue, _, _ := eval.Template(context.Background(), env, ctx, tc.template, nil)
-			refactoredValue, _, _ := eval.Template(context.Background(), env, ctx, actual, nil)
+			originalValue, _, _ := eval.Template(t.Context(), env, ctx, tc.template, nil)
+			refactoredValue, _, _ := eval.Template(t.Context(), env, ctx, actual, nil)
 
 			assert.Equal(t, originalValue, refactoredValue, "refactoring of template %s gives different value: %s", tc.template, refactoredValue)
 		}

--- a/excellent/template_test.go
+++ b/excellent/template_test.go
@@ -1,7 +1,6 @@
 package excellent_test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -103,7 +102,7 @@ func assertTemplateEquivalent(t *testing.T, env envs.Environment, ctx *types.XOb
 	template := excellent.ParseTemplate(src)
 	require.Equal(t, src, template.String(), "round trip mismatch for template %q", src)
 
-	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(context.Background(), env, ctx, src, escaping)
+	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(t.Context(), env, ctx, src, escaping)
 	actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, escaping)
 
 	assert.Equal(t, expectedVal, actualVal, "output mismatch for template %q", src)
@@ -232,7 +231,7 @@ func FuzzParseTemplate(f *testing.F) {
 			return
 		}
 
-		expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(context.Background(), env, ctx, src, nil)
+		expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(t.Context(), env, ctx, src, nil)
 		actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, nil)
 
 		if actualVal != expectedVal {
@@ -256,7 +255,7 @@ func BenchmarkEvaluatorTemplate(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		eval.Template(context.Background(), env, ctx, benchmarkTemplate, nil)
+		eval.Template(b.Context(), env, ctx, benchmarkTemplate, nil)
 	}
 }
 

--- a/excellent/template_test.go
+++ b/excellent/template_test.go
@@ -1,6 +1,7 @@
 package excellent_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -102,7 +103,7 @@ func assertTemplateEquivalent(t *testing.T, env envs.Environment, ctx *types.XOb
 	template := excellent.ParseTemplate(src)
 	require.Equal(t, src, template.String(), "round trip mismatch for template %q", src)
 
-	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(env, ctx, src, escaping)
+	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(context.Background(), env, ctx, src, escaping)
 	actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, escaping)
 
 	assert.Equal(t, expectedVal, actualVal, "output mismatch for template %q", src)
@@ -231,7 +232,7 @@ func FuzzParseTemplate(f *testing.F) {
 			return
 		}
 
-		expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(env, ctx, src, nil)
+		expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(context.Background(), env, ctx, src, nil)
 		actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, nil)
 
 		if actualVal != expectedVal {
@@ -255,7 +256,7 @@ func BenchmarkEvaluatorTemplate(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		eval.Template(env, ctx, benchmarkTemplate, nil)
+		eval.Template(context.Background(), env, ctx, benchmarkTemplate, nil)
 	}
 }
 

--- a/excellent/types/json_test.go
+++ b/excellent/types/json_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/nyaruka/goflow/envs"
@@ -80,7 +79,7 @@ func TestXJSONResolve(t *testing.T) {
 		ctx := types.NewXObject(map[string]types.XValue{"j": fragment})
 
 		eval := excellent.NewEvaluator()
-		value, _ := eval.Expression(context.Background(), env, ctx, tc.expression)
+		value, _ := eval.Expression(t.Context(), env, ctx, tc.expression)
 		err, _ := value.(error)
 
 		if tc.hasError {

--- a/excellent/types/json_test.go
+++ b/excellent/types/json_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/nyaruka/goflow/envs"
@@ -79,7 +80,7 @@ func TestXJSONResolve(t *testing.T) {
 		ctx := types.NewXObject(map[string]types.XValue{"j": fragment})
 
 		eval := excellent.NewEvaluator()
-		value, _ := eval.Expression(env, ctx, tc.expression)
+		value, _ := eval.Expression(context.Background(), env, ctx, tc.expression)
 		err, _ := value.(error)
 
 		if tc.hasError {

--- a/flows/actions/add_contact_groups.go
+++ b/flows/actions/add_contact_groups.go
@@ -46,7 +46,7 @@ func NewAddContactGroups(uuid flows.ActionUUID, groups []*assets.GroupReference)
 
 // Execute adds our contact to the specified groups
 func (a *AddContactGroups) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	groups := resolveGroups(run, a.Groups, log)
+	groups := resolveGroups(ctx, run, a.Groups, log)
 
 	_, err := a.applyModifier(ctx, run, modifiers.NewGroups(groups, modifiers.GroupsAdd), log)
 	return err

--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -55,7 +55,7 @@ func NewAddContactURN(uuid flows.ActionUUID, scheme string, path string) *AddCon
 
 // Execute runs the labeling action
 func (a *AddContactURN) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	evaluatedPath, _ := run.EvaluateTemplate(a.Path, log)
+	evaluatedPath, _ := run.EvaluateTemplate(ctx, a.Path, log)
 	evaluatedPath = strings.TrimSpace(evaluatedPath)
 	if evaluatedPath == "" {
 		log(events.NewError("Can't add URN with empty path", ""))

--- a/flows/actions/add_input_labels.go
+++ b/flows/actions/add_input_labels.go
@@ -54,7 +54,7 @@ func (a *AddInputLabels) Execute(ctx context.Context, run flows.Run, step flows.
 		return nil
 	}
 
-	labels := resolveLabels(run, a.Labels, log)
+	labels := resolveLabels(ctx, run, a.Labels, log)
 
 	if len(labels) > 0 {
 		log(events.NewInputLabelsAdded(input.UUID(), core.LabelReferences(labels)))

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -81,16 +81,16 @@ func (a *baseAction) Inspect(dependency func(assets.Reference), local func(strin
 func (a *baseAction) LocalizationUUID() uuids.UUID { return uuids.UUID(a.UUID_) }
 
 // helper function for actions that send a message (text + attachments) that must be localized and evalulated
-func (a *baseAction) evaluateMessage(run flows.Run, languages []i18n.Language, actionText string, actionAttachments []string, actionQuickReplies []string, log events.EventLogger) (*core.MsgContent, i18n.Language) {
+func (a *baseAction) evaluateMessage(ctx context.Context, run flows.Run, languages []i18n.Language, actionText string, actionAttachments []string, actionQuickReplies []string, log events.EventLogger) (*core.MsgContent, i18n.Language) {
 	// localize and evaluate the message text
 	localizedText, txtLang := run.GetTextArray(uuids.UUID(a.UUID()), "text", []string{actionText}, languages)
-	evaluatedText, _ := run.EvaluateTemplate(localizedText[0], log)
+	evaluatedText, _ := run.EvaluateTemplate(ctx, localizedText[0], log)
 
 	// localize and evaluate the message attachments
 	translatedAttachments, attLang := run.GetTextArray(uuids.UUID(a.UUID()), "attachments", actionAttachments, languages)
 	evaluatedAttachments := make([]utils.Attachment, 0, len(translatedAttachments))
 	for _, a := range translatedAttachments {
-		evaluatedAttachment, _ := run.EvaluateTemplate(a, log)
+		evaluatedAttachment, _ := run.EvaluateTemplate(ctx, a, log)
 		evaluatedAttachment = strings.TrimSpace(evaluatedAttachment)
 		if !utils.IsValidAttachment(evaluatedAttachment) {
 			log(events.NewError("Attachment evaluated to invalid value and will be ignored", ""))
@@ -107,7 +107,7 @@ func (a *baseAction) evaluateMessage(run flows.Run, languages []i18n.Language, a
 	translatedQuickReplies, qrsLang := run.GetTextArray(uuids.UUID(a.UUID()), "quick_replies", actionQuickReplies, languages)
 	evaluatedQuickReplies := make([]core.QuickReply, 0, len(translatedQuickReplies))
 	for _, qr := range translatedQuickReplies {
-		evaluatedQuickReply, _ := run.EvaluateTemplate(qr, log)
+		evaluatedQuickReply, _ := run.EvaluateTemplate(ctx, qr, log)
 		if evaluatedQuickReply == "" {
 			log(events.NewError("Quick reply evaluated to empty string and will be ignored", ""))
 			continue
@@ -221,7 +221,7 @@ func (a *otherContactsAction) Inspect(dependency func(assets.Reference), local f
 	}
 }
 
-func (a *otherContactsAction) resolveRecipients(run flows.Run, log events.EventLogger) ([]*assets.GroupReference, []*core.ContactReference, string, []urns.URN, error) {
+func (a *otherContactsAction) resolveRecipients(ctx context.Context, run flows.Run, log events.EventLogger) ([]*assets.GroupReference, []*core.ContactReference, string, []urns.URN, error) {
 	groupSet := run.Session().Assets().Groups()
 
 	// copy URNs
@@ -233,7 +233,7 @@ func (a *otherContactsAction) resolveRecipients(run flows.Run, log events.EventL
 	contactRefs = append(contactRefs, a.Contacts...)
 
 	// resolve group references
-	groups := resolveGroups(run, a.Groups, log)
+	groups := resolveGroups(ctx, run, a.Groups, log)
 	groupRefs := make([]*assets.GroupReference, 0, len(groups))
 	for _, group := range groups {
 		groupRefs = append(groupRefs, group.Reference())
@@ -241,7 +241,7 @@ func (a *otherContactsAction) resolveRecipients(run flows.Run, log events.EventL
 
 	// evaluate the legacy variables
 	for _, legacyVar := range a.LegacyVars {
-		evaluatedLegacyVar, _ := run.EvaluateTemplate(legacyVar, log)
+		evaluatedLegacyVar, _ := run.EvaluateTemplate(ctx, legacyVar, log)
 
 		evaluatedLegacyVar = strings.TrimSpace(evaluatedLegacyVar)
 
@@ -271,7 +271,7 @@ func (a *otherContactsAction) resolveRecipients(run flows.Run, log events.EventL
 	}
 
 	// evaluate contact query
-	contactQuery, _ := run.EvaluateTemplateText(a.ContactQuery, contactql.EscapeValue, true, log)
+	contactQuery, _ := run.EvaluateTemplateText(ctx, a.ContactQuery, contactql.EscapeValue, true, log)
 	contactQuery = strings.TrimSpace(contactQuery)
 
 	return groupRefs, contactRefs, contactQuery, urnList, nil
@@ -293,7 +293,7 @@ func (a *createMsgAction) Inspect(dependency func(assets.Reference), local func(
 }
 
 // helper function for actions that have a set of group references that must be resolved to actual groups
-func resolveGroups(run flows.Run, references []*assets.GroupReference, log events.EventLogger) []*core.Group {
+func resolveGroups(ctx context.Context, run flows.Run, references []*assets.GroupReference, log events.EventLogger) []*core.Group {
 	groupAssets := run.Session().Assets().Groups()
 	groups := make([]*core.Group, 0, len(references))
 
@@ -302,7 +302,7 @@ func resolveGroups(run flows.Run, references []*assets.GroupReference, log event
 
 		if ref.Variable() {
 			// is an expression that evaluates to an existing group's name
-			evaluatedName, ok := run.EvaluateTemplate(ref.NameMatch, log)
+			evaluatedName, ok := run.EvaluateTemplate(ctx, ref.NameMatch, log)
 			if ok {
 
 				// look up the set of all groups to see if such a group exists
@@ -328,7 +328,7 @@ func resolveGroups(run flows.Run, references []*assets.GroupReference, log event
 }
 
 // helper function for actions that have a set of label references that must be resolved to actual labels
-func resolveLabels(run flows.Run, references []*assets.LabelReference, log events.EventLogger) []*core.Label {
+func resolveLabels(ctx context.Context, run flows.Run, references []*assets.LabelReference, log events.EventLogger) []*core.Label {
 	labelAssets := run.Session().Assets().Labels()
 	labels := make([]*core.Label, 0, len(references))
 
@@ -337,7 +337,7 @@ func resolveLabels(run flows.Run, references []*assets.LabelReference, log event
 
 		if ref.Variable() {
 			// is an expression that evaluates to an existing label's name
-			evaluatedName, ok := run.EvaluateTemplate(ref.NameMatch, log)
+			evaluatedName, ok := run.EvaluateTemplate(ctx, ref.NameMatch, log)
 			if ok {
 				// look up the set of all labels to see if such a label exists
 				label = labelAssets.FindByName(evaluatedName)
@@ -362,13 +362,13 @@ func resolveLabels(run flows.Run, references []*assets.LabelReference, log event
 }
 
 // helper function to resolve a user reference to a user
-func resolveUser(run flows.Run, ref *assets.UserReference, log events.EventLogger) *core.User {
+func resolveUser(ctx context.Context, run flows.Run, ref *assets.UserReference, log events.EventLogger) *core.User {
 	userAssets := run.Session().Assets().Users()
 	var user *core.User
 
 	if ref.Variable() {
 		// is an expression that evaluates to an existing user's email
-		evaluatedEmail, ok := run.EvaluateTemplate(ref.EmailMatch, log)
+		evaluatedEmail, ok := run.EvaluateTemplate(ctx, ref.EmailMatch, log)
 		if ok {
 			// look up to see if such a user exists
 			user = userAssets.FindByEmail(evaluatedEmail)

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -783,7 +783,7 @@ func TestResthookPayload(t *testing.T) {
 	run := session.Runs()[0]
 
 	log := test.NewEventLog()
-	payload, _ := run.EvaluateTemplate(context.Background(), actions.ResthookPayload, log.Log)
+	payload, _ := run.EvaluateTemplate(t.Context(), actions.ResthookPayload, log.Log)
 	require.NoError(t, log.Error())
 
 	pretty, err := jsonx.MarshalPretty(json.RawMessage(payload))

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -783,7 +783,7 @@ func TestResthookPayload(t *testing.T) {
 	run := session.Runs()[0]
 
 	log := test.NewEventLog()
-	payload, _ := run.EvaluateTemplate(actions.ResthookPayload, log.Log)
+	payload, _ := run.EvaluateTemplate(context.Background(), actions.ResthookPayload, log.Log)
 	require.NoError(t, log.Error())
 
 	pretty, err := jsonx.MarshalPretty(json.RawMessage(payload))

--- a/flows/actions/call_llm.go
+++ b/flows/actions/call_llm.go
@@ -84,8 +84,8 @@ func (a *CallLLM) call(ctx context.Context, run flows.Run, log events.EventLogge
 	}
 
 	// substitute any variables in our instructions and input
-	instructions, _ := run.EvaluateTemplate(a.Instructions, log)
-	input, _ := run.EvaluateTemplate(a.Input, log)
+	instructions, _ := run.EvaluateTemplate(ctx, a.Instructions, log)
+	input, _ := run.EvaluateTemplate(ctx, a.Input, log)
 
 	svc, err := run.Session().Engine().Services().LLM(llm)
 	if err != nil {

--- a/flows/actions/call_resthook.go
+++ b/flows/actions/call_resthook.go
@@ -92,7 +92,7 @@ func (a *CallResthook) Execute(ctx context.Context, run flows.Run, step flows.St
 	}
 
 	// build our payload (not truncated)
-	payload, _ := run.EvaluateTemplateText(ResthookPayload, nil, false, log)
+	payload, _ := run.EvaluateTemplateText(ctx, ResthookPayload, nil, false, log)
 
 	// check the payload is valid JSON - it ends up in the session so needs to be valid
 	if !json.Valid([]byte(payload)) {

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -88,7 +88,7 @@ func (a *CallWebhook) Validate() error {
 
 // Execute runs this action
 func (a *CallWebhook) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	url, _ := run.EvaluateTemplate(a.URL, log)
+	url, _ := run.EvaluateTemplate(ctx, a.URL, log)
 	url = strings.TrimSpace(url)
 
 	if url == "" {
@@ -106,7 +106,7 @@ func (a *CallWebhook) Execute(ctx context.Context, run flows.Run, step flows.Ste
 	// substitute any body variables
 	if body != "" {
 		// webhook bodies aren't truncated like other templates
-		body, _ = run.EvaluateTemplateText(body, nil, false, log)
+		body, _ = run.EvaluateTemplateText(ctx, body, nil, false, log)
 	}
 
 	call := a.call(ctx, run, step, url, method, body, log)
@@ -127,7 +127,7 @@ func (a *CallWebhook) call(ctx context.Context, run flows.Run, step flows.Step, 
 
 	// add the custom headers, substituting any template vars
 	for key, value := range a.Headers {
-		headerValue, _ := run.EvaluateTemplate(value, log)
+		headerValue, _ := run.EvaluateTemplate(ctx, value, log)
 
 		req.Header.Add(key, headerValue)
 	}

--- a/flows/actions/deprecated.go
+++ b/flows/actions/deprecated.go
@@ -41,7 +41,7 @@ func NewCallClassifier(uuid flows.ActionUUID, input string, resultName string) *
 
 // Execute runs this action
 func (a *CallClassifier) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	input, _ := run.EvaluateTemplate(a.Input, log)
+	input, _ := run.EvaluateTemplate(ctx, a.Input, log)
 
 	log(events.NewWarning("NLU classifiers are no longer supported"))
 	a.saveResult(run, step, a.ResultName, "0", CategoryFailure, "", input, nil, log)

--- a/flows/actions/open_ticket.go
+++ b/flows/actions/open_ticket.go
@@ -69,10 +69,10 @@ func (a *OpenTicket) Execute(ctx context.Context, run flows.Run, step flows.Step
 
 	var assignee *core.User
 	if a.Assignee != nil {
-		assignee = resolveUser(run, a.Assignee, log)
+		assignee = resolveUser(ctx, run, a.Assignee, log)
 	}
 
-	evaluatedNote, _ := run.EvaluateTemplate(a.Note, log)
+	evaluatedNote, _ := run.EvaluateTemplate(ctx, a.Note, log)
 	evaluatedNote = strings.TrimSpace(evaluatedNote)
 
 	ticket, err := a.open(ctx, run, topic, assignee, evaluatedNote, log)

--- a/flows/actions/play_audio.go
+++ b/flows/actions/play_audio.go
@@ -47,7 +47,7 @@ func NewPlayAudio(uuid flows.ActionUUID, audioURL string) *PlayAudio {
 func (a *PlayAudio) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
 	// localize and evaluate audio URL
 	localizedAudioURL, urlLang := run.GetText(uuids.UUID(a.UUID()), "audio_url", a.AudioURL)
-	evaluatedAudioURL, ok := run.EvaluateTemplate(localizedAudioURL, log)
+	evaluatedAudioURL, ok := run.EvaluateTemplate(ctx, localizedAudioURL, log)
 	if !ok {
 		return nil
 	}

--- a/flows/actions/remove_contact_groups.go
+++ b/flows/actions/remove_contact_groups.go
@@ -68,7 +68,7 @@ func (a *RemoveContactGroups) Execute(ctx context.Context, run flows.Run, step f
 			}
 		}
 	} else {
-		groups = resolveGroups(run, a.Groups, log)
+		groups = resolveGroups(ctx, run, a.Groups, log)
 	}
 
 	_, err := a.applyModifier(ctx, run, modifiers.NewGroups(groups, modifiers.GroupsRemove), log)

--- a/flows/actions/say_msg.go
+++ b/flows/actions/say_msg.go
@@ -52,7 +52,7 @@ func NewSayMsg(uuid flows.ActionUUID, text string, audioURL string) *SayMsg {
 func (a *SayMsg) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
 	// localize and evaluate the message text
 	localizedText, textLang := run.GetText(uuids.UUID(a.UUID()), "text", a.Text)
-	evaluatedText, _ := run.EvaluateTemplate(localizedText, log)
+	evaluatedText, _ := run.EvaluateTemplate(ctx, localizedText, log)
 	evaluatedText = strings.TrimSpace(evaluatedText)
 
 	// localize the audio URL

--- a/flows/actions/send_broadcast.go
+++ b/flows/actions/send_broadcast.go
@@ -67,7 +67,7 @@ func NewSendBroadcast(uuid flows.ActionUUID, text string, attachments []string, 
 
 // Execute runs this action
 func (a *SendBroadcast) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	groupRefs, contactRefs, contactQuery, urnList, err := a.resolveRecipients(run, log)
+	groupRefs, contactRefs, contactQuery, urnList, err := a.resolveRecipients(ctx, run, log)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (a *SendBroadcast) Execute(ctx context.Context, run flows.Run, step flows.S
 	for _, language := range languages {
 		languages := []i18n.Language{language, run.Flow().Language()}
 
-		content, _ := a.evaluateMessage(run, languages, a.Text, a.Attachments, a.QuickReplies, log)
+		content, _ := a.evaluateMessage(ctx, run, languages, a.Text, a.Attachments, a.QuickReplies, log)
 		translations[language] = content
 	}
 
@@ -105,7 +105,7 @@ func (a *SendBroadcast) Execute(ctx context.Context, run flows.Run, step flows.S
 			templateRef = a.Template
 			templateVariables = make([]string, len(a.TemplateVariables))
 			for i, varExp := range a.TemplateVariables {
-				v, _ := run.EvaluateTemplate(varExp, log)
+				v, _ := run.EvaluateTemplate(ctx, varExp, log)
 				templateVariables[i] = v
 			}
 		}

--- a/flows/actions/send_email.go
+++ b/flows/actions/send_email.go
@@ -54,7 +54,7 @@ func NewSendEmail(uuid flows.ActionUUID, addresses []string, subject string, bod
 // Execute creates the email events
 func (a *SendEmail) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
 	localizedSubject, _ := run.GetText(uuids.UUID(a.UUID()), "subject", a.Subject)
-	evaluatedSubject, _ := run.EvaluateTemplate(localizedSubject, log)
+	evaluatedSubject, _ := run.EvaluateTemplate(ctx, localizedSubject, log)
 
 	// make sure the subject is single line - replace '\t\n\r\f\v' to ' '
 	evaluatedSubject = regexp.MustCompile(`\s+`).ReplaceAllString(evaluatedSubject, " ")
@@ -66,7 +66,7 @@ func (a *SendEmail) Execute(ctx context.Context, run flows.Run, step flows.Step,
 	}
 
 	localizedBody, _ := run.GetText(uuids.UUID(a.UUID()), "body", a.Body)
-	evaluatedBody, _ := run.EvaluateTemplate(localizedBody, log)
+	evaluatedBody, _ := run.EvaluateTemplate(ctx, localizedBody, log)
 	if evaluatedBody == "" {
 		log(events.NewError("Email body evaluated to empty string, skipping", ""))
 		return nil
@@ -75,7 +75,7 @@ func (a *SendEmail) Execute(ctx context.Context, run flows.Run, step flows.Step,
 	evaluatedAddresses := make([]string, 0)
 
 	for _, address := range a.Addresses {
-		evaluatedAddress, _ := run.EvaluateTemplate(address, log)
+		evaluatedAddress, _ := run.EvaluateTemplate(ctx, address, log)
 		if evaluatedAddress == "" {
 			log(events.NewError("Email address evaluated to empty string, skipping", ""))
 			continue

--- a/flows/actions/send_msg.go
+++ b/flows/actions/send_msg.go
@@ -58,7 +58,7 @@ func NewSendMsg(uuid flows.ActionUUID, text string, attachments []string, quickR
 
 // Execute runs this action
 func (a *SendMsg) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	content, lang := a.evaluateMessage(run, nil, a.Text, a.Attachments, a.QuickReplies, log)
+	content, lang := a.evaluateMessage(ctx, run, nil, a.Text, a.Attachments, a.QuickReplies, log)
 
 	// determine if this message can be sent - unsendable messages are still created for history's sake
 	var unsendableReason core.UnsendableReason
@@ -87,7 +87,7 @@ func (a *SendMsg) Execute(ctx context.Context, run flows.Run, step flows.Step, l
 		if template != nil {
 			templateVariables = make([]string, len(a.TemplateVariables))
 			for i, varExp := range a.TemplateVariables {
-				v, _ := run.EvaluateTemplate(varExp, log)
+				v, _ := run.EvaluateTemplate(ctx, varExp, log)
 				templateVariables[i] = v
 			}
 		}

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -48,7 +48,7 @@ func NewSetContactField(uuid flows.ActionUUID, field *assets.FieldReference, val
 
 // Execute runs this action
 func (a *SetContactField) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	value, ok := run.EvaluateTemplate(a.Value, log)
+	value, ok := run.EvaluateTemplate(ctx, a.Value, log)
 	value = strings.TrimSpace(value)
 
 	if !ok {

--- a/flows/actions/set_contact_language.go
+++ b/flows/actions/set_contact_language.go
@@ -45,7 +45,7 @@ func NewSetContactLanguage(uuid flows.ActionUUID, language string) *SetContactLa
 
 // Execute runs this action
 func (a *SetContactLanguage) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	language, ok := run.EvaluateTemplate(a.Language, log)
+	language, ok := run.EvaluateTemplate(ctx, a.Language, log)
 	language = strings.TrimSpace(language)
 
 	if !ok {

--- a/flows/actions/set_contact_name.go
+++ b/flows/actions/set_contact_name.go
@@ -44,7 +44,7 @@ func NewSetContactName(uuid flows.ActionUUID, name string) *SetContactName {
 
 // Execute runs this action
 func (a *SetContactName) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	name, ok := run.EvaluateTemplate(a.Name, log)
+	name, ok := run.EvaluateTemplate(ctx, a.Name, log)
 	name = strings.TrimSpace(name)
 
 	if !ok {

--- a/flows/actions/set_contact_timezone.go
+++ b/flows/actions/set_contact_timezone.go
@@ -46,7 +46,7 @@ func NewSetContactTimezone(uuid flows.ActionUUID, timezone string) *SetContactTi
 
 // Execute runs this action
 func (a *SetContactTimezone) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	timezone, ok := run.EvaluateTemplate(a.Timezone, log)
+	timezone, ok := run.EvaluateTemplate(ctx, a.Timezone, log)
 	timezone = strings.TrimSpace(timezone)
 
 	if !ok {

--- a/flows/actions/set_run_local.go
+++ b/flows/actions/set_run_local.go
@@ -57,7 +57,7 @@ func NewSetRunLocal(uuid flows.ActionUUID, local, value string) *SetRunLocal {
 
 // Execute runs this action
 func (a *SetRunLocal) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	value, ok := run.EvaluateTemplate(a.Value, log)
+	value, ok := run.EvaluateTemplate(ctx, a.Value, log)
 	if !ok {
 		return nil
 	}

--- a/flows/actions/set_run_result.go
+++ b/flows/actions/set_run_result.go
@@ -53,7 +53,7 @@ func NewSetRunResult(uuid flows.ActionUUID, name string, value string, category 
 
 // Execute runs this action
 func (a *SetRunResult) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	value, ok := run.EvaluateTemplate(a.Value, log)
+	value, ok := run.EvaluateTemplate(ctx, a.Value, log)
 	if !ok {
 		return nil
 	}

--- a/flows/actions/start_session.go
+++ b/flows/actions/start_session.go
@@ -63,7 +63,7 @@ func NewStartSession(uuid flows.ActionUUID, flow *assets.FlowReference, groups [
 
 // Execute runs our action
 func (a *StartSession) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	groupRefs, contactRefs, contactQuery, urnList, err := a.resolveRecipients(run, log)
+	groupRefs, contactRefs, contactQuery, urnList, err := a.resolveRecipients(ctx, run, log)
 	if err != nil {
 		return err
 	}

--- a/flows/definition/legacy/expressions/functions_test.go
+++ b/flows/definition/legacy/expressions/functions_test.go
@@ -1,7 +1,6 @@
 package expressions_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -165,7 +164,7 @@ func TestMigrateFunctionCall(t *testing.T) {
 		if migratedTemplate == tc.new {
 			// check that the migrated template can be evaluated
 			log := test.NewEventLog()
-			val, _ := session.Runs()[0].EvaluateTemplate(context.Background(), migratedTemplate, log.Log)
+			val, _ := session.Runs()[0].EvaluateTemplate(t.Context(), migratedTemplate, log.Log)
 			require.NoError(t, log.Error(), "unable to evaluate migrated function call '%s'", migratedTemplate)
 
 			if tc.val != "" {

--- a/flows/definition/legacy/expressions/functions_test.go
+++ b/flows/definition/legacy/expressions/functions_test.go
@@ -1,6 +1,7 @@
 package expressions_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -164,7 +165,7 @@ func TestMigrateFunctionCall(t *testing.T) {
 		if migratedTemplate == tc.new {
 			// check that the migrated template can be evaluated
 			log := test.NewEventLog()
-			val, _ := session.Runs()[0].EvaluateTemplate(migratedTemplate, log.Log)
+			val, _ := session.Runs()[0].EvaluateTemplate(context.Background(), migratedTemplate, log.Log)
 			require.NoError(t, log.Error(), "unable to evaluate migrated function call '%s'", migratedTemplate)
 
 			if tc.val != "" {

--- a/flows/definition/legacy/expressions/migrate_test.go
+++ b/flows/definition/legacy/expressions/migrate_test.go
@@ -2,7 +2,6 @@ package expressions_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -250,7 +249,7 @@ func TestMigrateTemplate(t *testing.T) {
 		if migratedTemplate == tc.new && !tc.dontEval {
 			// check that the migrated template can be evaluated
 			log := test.NewEventLog()
-			session.Runs()[0].EvaluateTemplate(context.Background(), migratedTemplate, log.Log)
+			session.Runs()[0].EvaluateTemplate(t.Context(), migratedTemplate, log.Log)
 			require.NoError(t, log.Error(), "unable to evaluate migrated template '%s'", migratedTemplate)
 		}
 	}
@@ -383,7 +382,7 @@ func TestLegacyTests(t *testing.T) {
 			migratedVarsJSON := jsonx.MustMarshal(migratedVars)
 
 			eval := excellent.NewEvaluator()
-			_, _, err = eval.Template(context.Background(), env, migratedVars, migratedTemplate, nil)
+			_, _, err = eval.Template(t.Context(), env, migratedVars, migratedTemplate, nil)
 
 			if len(tc.Errors) > 0 {
 				assert.Error(t, err, "expecting error evaluating template '%s' (migrated from '%s') with context %s", migratedTemplate, tc.Template, migratedVarsJSON)

--- a/flows/definition/legacy/expressions/migrate_test.go
+++ b/flows/definition/legacy/expressions/migrate_test.go
@@ -2,6 +2,7 @@ package expressions_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -249,7 +250,7 @@ func TestMigrateTemplate(t *testing.T) {
 		if migratedTemplate == tc.new && !tc.dontEval {
 			// check that the migrated template can be evaluated
 			log := test.NewEventLog()
-			session.Runs()[0].EvaluateTemplate(migratedTemplate, log.Log)
+			session.Runs()[0].EvaluateTemplate(context.Background(), migratedTemplate, log.Log)
 			require.NoError(t, log.Error(), "unable to evaluate migrated template '%s'", migratedTemplate)
 		}
 	}
@@ -382,7 +383,7 @@ func TestLegacyTests(t *testing.T) {
 			migratedVarsJSON := jsonx.MustMarshal(migratedVars)
 
 			eval := excellent.NewEvaluator()
-			_, _, err = eval.Template(env, migratedVars, migratedTemplate, nil)
+			_, _, err = eval.Template(context.Background(), env, migratedVars, migratedTemplate, nil)
 
 			if len(tc.Errors) > 0 {
 				assert.Error(t, err, "expecting error evaluating template '%s' (migrated from '%s') with context %s", migratedTemplate, tc.Template, migratedVarsJSON)

--- a/flows/engine/legacy_test.go
+++ b/flows/engine/legacy_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,7 +47,7 @@ func TestLegacyExtra(t *testing.T) {
 	}
 	for _, tc := range tests {
 		log := test.NewEventLog()
-		output, _ := run.EvaluateTemplate(tc.template, log.Log)
+		output, _ := run.EvaluateTemplate(context.Background(), tc.template, log.Log)
 		assert.NoError(t, log.Error())
 		assert.Equal(t, tc.output, output, "evaluate failed for %s", tc.template)
 	}
@@ -56,7 +57,7 @@ func TestLegacyExtra(t *testing.T) {
 	run.SetResult(result)
 
 	log := test.NewEventLog()
-	output, _ := run.EvaluateTemplate(`@(legacy_extra[0])`, log.Log)
+	output, _ := run.EvaluateTemplate(context.Background(), `@(legacy_extra[0])`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, `{foo: 123}`, output)
 }

--- a/flows/engine/legacy_test.go
+++ b/flows/engine/legacy_test.go
@@ -1,7 +1,6 @@
 package engine_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -47,7 +46,7 @@ func TestLegacyExtra(t *testing.T) {
 	}
 	for _, tc := range tests {
 		log := test.NewEventLog()
-		output, _ := run.EvaluateTemplate(context.Background(), tc.template, log.Log)
+		output, _ := run.EvaluateTemplate(t.Context(), tc.template, log.Log)
 		assert.NoError(t, log.Error())
 		assert.Equal(t, tc.output, output, "evaluate failed for %s", tc.template)
 	}
@@ -57,7 +56,7 @@ func TestLegacyExtra(t *testing.T) {
 	run.SetResult(result)
 
 	log := test.NewEventLog()
-	output, _ := run.EvaluateTemplate(context.Background(), `@(legacy_extra[0])`, log.Log)
+	output, _ := run.EvaluateTemplate(t.Context(), `@(legacy_extra[0])`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, `{foo: 123}`, output)
 }

--- a/flows/engine/run.go
+++ b/flows/engine/run.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -305,10 +306,10 @@ func (r *run) nodeContext(env envs.Environment) map[string]types.XValue {
 }
 
 // EvaluateTemplate evaluates the given template in the context of this run
-func (r *run) EvaluateTemplateValue(template string, log events.EventLogger) (types.XValue, bool) {
-	ctx := types.NewXObject(r.RootContext(r.session.MergedEnvironment()))
+func (r *run) EvaluateTemplateValue(ctx context.Context, template string, log events.EventLogger) (types.XValue, bool) {
+	root := types.NewXObject(r.RootContext(r.session.MergedEnvironment()))
 
-	value, warnings, err := r.session.Engine().Evaluator().TemplateValue(r.session.MergedEnvironment(), ctx, template)
+	value, warnings, err := r.session.Engine().Evaluator().TemplateValue(ctx, r.session.MergedEnvironment(), root, template)
 	if err != nil {
 		r.errorToEvents(err, log)
 	}
@@ -319,10 +320,10 @@ func (r *run) EvaluateTemplateValue(template string, log events.EventLogger) (ty
 }
 
 // EvaluateTemplateText evaluates the given template as text in the context of this run
-func (r *run) EvaluateTemplateText(template string, escaping excellent.Escaping, truncate bool, log events.EventLogger) (string, bool) {
-	ctx := types.NewXObject(r.RootContext(r.session.MergedEnvironment()))
+func (r *run) EvaluateTemplateText(ctx context.Context, template string, escaping excellent.Escaping, truncate bool, log events.EventLogger) (string, bool) {
+	root := types.NewXObject(r.RootContext(r.session.MergedEnvironment()))
 
-	value, warnings, err := r.session.Engine().Evaluator().Template(r.session.MergedEnvironment(), ctx, template, escaping)
+	value, warnings, err := r.session.Engine().Evaluator().Template(ctx, r.session.MergedEnvironment(), root, template, escaping)
 	if err != nil {
 		r.errorToEvents(err, log)
 	}
@@ -347,8 +348,8 @@ func (r *run) errorToEvents(err error, log events.EventLogger) {
 }
 
 // EvaluateTemplate is a convenience function for evaluating as text with truncating but no escaping
-func (r *run) EvaluateTemplate(template string, log events.EventLogger) (string, bool) {
-	return r.EvaluateTemplateText(template, nil, true, log)
+func (r *run) EvaluateTemplate(ctx context.Context, template string, log events.EventLogger) (string, bool) {
+	return r.EvaluateTemplateText(ctx, template, nil, true, log)
 }
 
 // get the ordered list of languages to be used for localization in this run

--- a/flows/engine/run_test.go
+++ b/flows/engine/run_test.go
@@ -218,14 +218,14 @@ func TestRunContext(t *testing.T) {
 
 	for _, tc := range testCases {
 		log := test.NewEventLog()
-		actual, _ := run.EvaluateTemplate(tc.template, log.Log)
+		actual, _ := run.EvaluateTemplate(context.Background(), tc.template, log.Log)
 		assert.NoError(t, log.Error())
 		assert.Equal(t, tc.expected, actual, "template mismatch for %s", tc.template)
 	}
 
 	// test with escaping
 	log := test.NewEventLog()
-	evaluated, _ := run.EvaluateTemplateText(`gender = @("M\" OR")`, contactql.EscapeValue, true, log.Log)
+	evaluated, _ := run.EvaluateTemplateText(context.Background(), `gender = @("M\" OR")`, contactql.EscapeValue, true, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, `gender = "M\" OR"`, evaluated)
 }
@@ -252,22 +252,22 @@ func TestMissingRelatedRunContext(t *testing.T) {
 	log := test.NewEventLog()
 
 	// since we have no parent, check that it resolves to nil
-	val, _ := run.EvaluateTemplateValue(`@parent`, log.Log)
+	val, _ := run.EvaluateTemplateValue(context.Background(), `@parent`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Nil(t, val)
 
 	// check that trying to resolve a property of parent is an error
-	val, _ = run.EvaluateTemplateValue(`@parent.contact`, log.Log)
+	val, _ = run.EvaluateTemplateValue(context.Background(), `@parent.contact`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, types.NewXErrorf("null doesn't support lookups"), val)
 
 	// we also have no child, check that it resolves to nil
-	val, _ = run.EvaluateTemplateValue(`@child`, log.Log)
+	val, _ = run.EvaluateTemplateValue(context.Background(), `@child`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Nil(t, val)
 
 	// check that trying to resolve a property of child is an error
-	val, _ = run.EvaluateTemplateValue(`@child.contact`, log.Log)
+	val, _ = run.EvaluateTemplateValue(context.Background(), `@child.contact`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, types.NewXErrorf("null doesn't support lookups"), val)
 }

--- a/flows/engine/run_test.go
+++ b/flows/engine/run_test.go
@@ -218,14 +218,14 @@ func TestRunContext(t *testing.T) {
 
 	for _, tc := range testCases {
 		log := test.NewEventLog()
-		actual, _ := run.EvaluateTemplate(context.Background(), tc.template, log.Log)
+		actual, _ := run.EvaluateTemplate(t.Context(), tc.template, log.Log)
 		assert.NoError(t, log.Error())
 		assert.Equal(t, tc.expected, actual, "template mismatch for %s", tc.template)
 	}
 
 	// test with escaping
 	log := test.NewEventLog()
-	evaluated, _ := run.EvaluateTemplateText(context.Background(), `gender = @("M\" OR")`, contactql.EscapeValue, true, log.Log)
+	evaluated, _ := run.EvaluateTemplateText(t.Context(), `gender = @("M\" OR")`, contactql.EscapeValue, true, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, `gender = "M\" OR"`, evaluated)
 }
@@ -252,22 +252,22 @@ func TestMissingRelatedRunContext(t *testing.T) {
 	log := test.NewEventLog()
 
 	// since we have no parent, check that it resolves to nil
-	val, _ := run.EvaluateTemplateValue(context.Background(), `@parent`, log.Log)
+	val, _ := run.EvaluateTemplateValue(t.Context(), `@parent`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Nil(t, val)
 
 	// check that trying to resolve a property of parent is an error
-	val, _ = run.EvaluateTemplateValue(context.Background(), `@parent.contact`, log.Log)
+	val, _ = run.EvaluateTemplateValue(t.Context(), `@parent.contact`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, types.NewXErrorf("null doesn't support lookups"), val)
 
 	// we also have no child, check that it resolves to nil
-	val, _ = run.EvaluateTemplateValue(context.Background(), `@child`, log.Log)
+	val, _ = run.EvaluateTemplateValue(t.Context(), `@child`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Nil(t, val)
 
 	// check that trying to resolve a property of child is an error
-	val, _ = run.EvaluateTemplateValue(context.Background(), `@child.contact`, log.Log)
+	val, _ = run.EvaluateTemplateValue(t.Context(), `@child.contact`, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, types.NewXErrorf("null doesn't support lookups"), val)
 }

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -304,7 +304,7 @@ func (s *session) tryToResume(ctx context.Context, sprint *sprint, waitingRun *r
 		waitingRun.setStatus(core.RunStatusActive)
 	}
 
-	exit, operand, err := s.findResumeExit(sprint, waitingRun, isTimeout)
+	exit, operand, err := s.findResumeExit(ctx, sprint, waitingRun, isTimeout)
 	if err != nil {
 		failSession(fmt.Sprintf("Unable to resolve router exit: %s", err.Error()))
 		return nil
@@ -318,7 +318,7 @@ func (s *session) tryToResume(ctx context.Context, sprint *sprint, waitingRun *r
 }
 
 // finds the exit from a the current node in a run that may have been waiting or a parent paused for a child subflow
-func (s *session) findResumeExit(sprint *sprint, run *run, isTimeout bool) (flows.Exit, string, error) {
+func (s *session) findResumeExit(ctx context.Context, sprint *sprint, run *run, isTimeout bool) (flows.Exit, string, error) {
 	// we might have no immediate destination in this run, but continueUntilWait can resume a parent run
 	if run.Status() != core.RunStatusActive {
 		return nil, "", nil
@@ -334,7 +334,7 @@ func (s *session) findResumeExit(sprint *sprint, run *run, isTimeout bool) (flow
 	}
 
 	// see if this node can now pick a destination
-	return s.pickNodeExit(sprint, run, node, step, isTimeout, logEvent)
+	return s.pickNodeExit(ctx, sprint, run, node, step, isTimeout, logEvent)
 }
 
 // the main flow execution loop
@@ -409,7 +409,7 @@ func (s *session) continueUntilWait(ctx context.Context, sprint *sprint, current
 					if currentRun.Flow() == nil {
 						failRun(sprint, currentRun, nil, "Can't resume run with missing flow asset")
 					} else {
-						if exit, operand, err = s.findResumeExit(sprint, currentRun, false); err != nil {
+						if exit, operand, err = s.findResumeExit(ctx, sprint, currentRun, false); err != nil {
 							failRun(sprint, currentRun, nil, "Can't resume run as node no longer exists")
 						}
 					}
@@ -503,7 +503,7 @@ func (s *session) visitNode(ctx context.Context, sprint *sprint, r *run, node fl
 
 	if wait != nil {
 		// waits have the option to skip themselves
-		if wait.Begin(r, logEvent) {
+		if wait.Begin(ctx, r, logEvent) {
 			// mark ouselves as waiting and hand back to
 			r.setStatus(core.RunStatusWaiting)
 			s.status = flows.SessionStatusWaiting
@@ -513,21 +513,21 @@ func (s *session) visitNode(ctx context.Context, sprint *sprint, r *run, node fl
 	}
 
 	// use our node's router to determine where to go next
-	exit, operand, err := s.pickNodeExit(sprint, r, node, step, false, logEvent)
+	exit, operand, err := s.pickNodeExit(ctx, sprint, r, node, step, false, logEvent)
 	return step, exit, operand, err
 }
 
 // picks the exit to use on the given node
-func (s *session) pickNodeExit(sprint *sprint, r *run, node flows.Node, step flows.Step, isTimeout bool, logEvent events.EventLogger) (flows.Exit, string, error) {
+func (s *session) pickNodeExit(ctx context.Context, sprint *sprint, r *run, node flows.Node, step flows.Step, isTimeout bool, logEvent events.EventLogger) (flows.Exit, string, error) {
 	var exitUUID flows.ExitUUID
 	var operand string
 	var err error
 
 	if node.Router() != nil {
 		if isTimeout {
-			exitUUID, err = node.Router().RouteTimeout(r, step, logEvent)
+			exitUUID, err = node.Router().RouteTimeout(ctx, r, step, logEvent)
 		} else {
-			exitUUID, operand, err = node.Router().Route(r, step, logEvent)
+			exitUUID, operand, err = node.Router().Route(ctx, r, step, logEvent)
 		}
 
 		if err != nil {

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -60,7 +60,7 @@ func TestEvaluateTemplate(t *testing.T) {
 		}
 
 		log := test.NewEventLog()
-		eval, _ := run.EvaluateTemplate(context.Background(), tc.Template, log.Log)
+		eval, _ := run.EvaluateTemplate(t.Context(), tc.Template, log.Log)
 
 		// clone test case and populate with actual values
 		actual := tc
@@ -116,7 +116,7 @@ func BenchmarkEvaluateTemplate(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		for _, tc := range tests {
-			run.EvaluateTemplate(context.Background(), tc.Template, logEvent)
+			run.EvaluateTemplate(b.Context(), tc.Template, logEvent)
 		}
 	}
 }

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -60,7 +60,7 @@ func TestEvaluateTemplate(t *testing.T) {
 		}
 
 		log := test.NewEventLog()
-		eval, _ := run.EvaluateTemplate(tc.Template, log.Log)
+		eval, _ := run.EvaluateTemplate(context.Background(), tc.Template, log.Log)
 
 		// clone test case and populate with actual values
 		actual := tc
@@ -116,7 +116,7 @@ func BenchmarkEvaluateTemplate(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		for _, tc := range tests {
-			run.EvaluateTemplate(tc.Template, logEvent)
+			run.EvaluateTemplate(context.Background(), tc.Template, logEvent)
 		}
 	}
 }

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -132,8 +132,8 @@ type Router interface {
 	ResultName() string
 
 	AllowTimeout() bool
-	Route(Run, Step, events.EventLogger) (ExitUUID, string, error)
-	RouteTimeout(Run, Step, events.EventLogger) (ExitUUID, error)
+	Route(context.Context, Run, Step, events.EventLogger) (ExitUUID, string, error)
+	RouteTimeout(context.Context, Run, Step, events.EventLogger) (ExitUUID, error)
 
 	Validate(Flow, []Exit) error
 	Inspect(func(*ResultInfo), func(assets.Reference))
@@ -160,7 +160,7 @@ type Wait interface {
 
 	Timeout() Timeout
 
-	Begin(Run, events.EventLogger) bool
+	Begin(context.Context, Run, events.EventLogger) bool
 	Accepts(Resume) bool
 }
 

--- a/flows/routers/base.go
+++ b/flows/routers/base.go
@@ -1,6 +1,7 @@
 package routers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -138,7 +139,7 @@ func (r *baseRouter) isValidExit(uuid flows.ExitUUID, exits []flows.Exit) bool {
 }
 
 // RouteTimeout routes in the case that this router's wait timed out
-func (r *baseRouter) RouteTimeout(run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, error) {
+func (r *baseRouter) RouteTimeout(ctx context.Context, run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, error) {
 	if !r.AllowTimeout() {
 		return "", errors.New("can't call route timeout on router with no timeout")
 	}

--- a/flows/routers/cases/tests_test.go
+++ b/flows/routers/cases/tests_test.go
@@ -484,7 +484,7 @@ func TestEvaluateTemplate(t *testing.T) {
 	env := envs.NewBuilder().Build()
 	for _, test := range evalTests {
 		eval := excellent.NewEvaluator()
-		val, _, err := eval.Template(env, ctx, test.template, nil)
+		val, _, err := eval.Template(context.Background(), env, ctx, test.template, nil)
 
 		if test.hasError {
 			assert.Error(t, err, "expected error evaluating template '%s'", test.template)

--- a/flows/routers/cases/tests_test.go
+++ b/flows/routers/cases/tests_test.go
@@ -484,7 +484,7 @@ func TestEvaluateTemplate(t *testing.T) {
 	env := envs.NewBuilder().Build()
 	for _, test := range evalTests {
 		eval := excellent.NewEvaluator()
-		val, _, err := eval.Template(context.Background(), env, ctx, test.template, nil)
+		val, _, err := eval.Template(t.Context(), env, ctx, test.template, nil)
 
 		if test.hasError {
 			assert.Error(t, err, "expected error evaluating template '%s'", test.template)

--- a/flows/routers/random.go
+++ b/flows/routers/random.go
@@ -1,6 +1,7 @@
 package routers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/nyaruka/gocommon/jsonx"
@@ -35,7 +36,7 @@ func (r *Random) Validate(flow flows.Flow, exits []flows.Exit) error {
 }
 
 // Route determines which exit to take from a node
-func (r *Random) Route(run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, string, error) {
+func (r *Random) Route(ctx context.Context, run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, string, error) {
 	// pick a random category
 	rand := random.Decimal()
 	categoryNum := rand.Mul(decimal.New(int64(len(r.categories)), 0)).IntPart()

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -105,11 +105,11 @@ func (r *Switch) Validate(flow flows.Flow, exits []flows.Exit) error {
 }
 
 // Route determines which exit to take from a node
-func (r *Switch) Route(run flows.Run, step flows.Step, log events.EventLogger) (flows.ExitUUID, string, error) {
+func (r *Switch) Route(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) (flows.ExitUUID, string, error) {
 	env := run.Session().MergedEnvironment()
 
 	// first evaluate our operand
-	operand, _ := run.EvaluateTemplateValue(r.operand, log)
+	operand, _ := run.EvaluateTemplateValue(ctx, r.operand, log)
 
 	var operandAsStr string
 
@@ -119,7 +119,7 @@ func (r *Switch) Route(run flows.Run, step flows.Step, log events.EventLogger) (
 	}
 
 	// find first matching case
-	match, categoryUUID, extra, err := r.matchCase(run, operand, log)
+	match, categoryUUID, extra, err := r.matchCase(ctx, run, operand, log)
 	if err != nil {
 		return "", "", err
 	}
@@ -140,7 +140,7 @@ func (r *Switch) Route(run flows.Run, step flows.Step, log events.EventLogger) (
 	return exit, operandAsStr, err
 }
 
-func (r *Switch) matchCase(run flows.Run, operand types.XValue, log events.EventLogger) (string, flows.CategoryUUID, *types.XObject, error) {
+func (r *Switch) matchCase(ctx context.Context, run flows.Run, operand types.XValue, log events.EventLogger) (string, flows.CategoryUUID, *types.XObject, error) {
 	for _, c := range r.cases {
 		test := strings.ToLower(c.Type)
 
@@ -161,12 +161,12 @@ func (r *Switch) matchCase(run flows.Run, operand types.XValue, log events.Event
 		}
 
 		for _, localizedArg := range localizedArgs {
-			arg, _ := run.EvaluateTemplateValue(localizedArg, log)
+			arg, _ := run.EvaluateTemplateValue(ctx, localizedArg, log)
 			args = append(args, arg)
 		}
 
-		// call our function - context.TODO until the session threads its context through routing
-		result := xtest.Call(context.TODO(), run.Session().MergedEnvironment(), args)
+		// call our function
+		result := xtest.Call(ctx, run.Session().MergedEnvironment(), args)
 
 		// tests have to return either errors or test results
 		switch typed := result.(type) {

--- a/flows/routers/waits/dial.go
+++ b/flows/routers/waits/dial.go
@@ -1,6 +1,7 @@
 package waits
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -60,8 +61,8 @@ func (w *Dial) AllowedFlowTypes() []flows.FlowType {
 }
 
 // Begin beings waiting at this wait
-func (w *Dial) Begin(run flows.Run, log events.EventLogger) bool {
-	phone, _ := run.EvaluateTemplate(w.phone, log)
+func (w *Dial) Begin(ctx context.Context, run flows.Run, log events.EventLogger) bool {
+	phone, _ := run.EvaluateTemplate(ctx, w.phone, log)
 	country := run.Session().MergedEnvironment().DefaultCountry()
 
 	urn, err := urns.ParsePhone(phone, country, false, false)

--- a/flows/routers/waits/dial_test.go
+++ b/flows/routers/waits/dial_test.go
@@ -1,7 +1,6 @@
 package waits_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -47,7 +46,7 @@ func TestDialWait(t *testing.T) {
 
 	// try activating the wait
 	log := test.NewEventLog()
-	begun := wait.Begin(context.Background(), run, log.Log)
+	begun := wait.Begin(t.Context(), run, log.Log)
 
 	assert.True(t, begun)
 	assert.Equal(t, 1, len(log.Events))
@@ -64,7 +63,7 @@ func TestDialWait(t *testing.T) {
 	assert.NoError(t, err)
 
 	log = test.NewEventLog()
-	begun = wait.Begin(context.Background(), run, log.Log)
+	begun = wait.Begin(t.Context(), run, log.Log)
 
 	assert.True(t, begun)
 	assert.Equal(t, 2, len(log.Events))
@@ -79,7 +78,7 @@ func TestDialWait(t *testing.T) {
 	assert.NoError(t, err)
 
 	log = test.NewEventLog()
-	begun = wait.Begin(context.Background(), run, log.Log)
+	begun = wait.Begin(t.Context(), run, log.Log)
 
 	assert.False(t, begun)
 	assert.Equal(t, 1, len(log.Events))

--- a/flows/routers/waits/dial_test.go
+++ b/flows/routers/waits/dial_test.go
@@ -1,6 +1,7 @@
 package waits_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ func TestDialWait(t *testing.T) {
 
 	// try activating the wait
 	log := test.NewEventLog()
-	begun := wait.Begin(run, log.Log)
+	begun := wait.Begin(context.Background(), run, log.Log)
 
 	assert.True(t, begun)
 	assert.Equal(t, 1, len(log.Events))
@@ -63,7 +64,7 @@ func TestDialWait(t *testing.T) {
 	assert.NoError(t, err)
 
 	log = test.NewEventLog()
-	begun = wait.Begin(run, log.Log)
+	begun = wait.Begin(context.Background(), run, log.Log)
 
 	assert.True(t, begun)
 	assert.Equal(t, 2, len(log.Events))
@@ -78,7 +79,7 @@ func TestDialWait(t *testing.T) {
 	assert.NoError(t, err)
 
 	log = test.NewEventLog()
-	begun = wait.Begin(run, log.Log)
+	begun = wait.Begin(context.Background(), run, log.Log)
 
 	assert.False(t, begun)
 	assert.Equal(t, 1, len(log.Events))

--- a/flows/routers/waits/msg.go
+++ b/flows/routers/waits/msg.go
@@ -1,6 +1,7 @@
 package waits
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -48,7 +49,7 @@ func (w *Msg) AllowedFlowTypes() []flows.FlowType {
 }
 
 // Begin beings waiting at this wait
-func (w *Msg) Begin(run flows.Run, log events.EventLogger) bool {
+func (w *Msg) Begin(ctx context.Context, run flows.Run, log events.EventLogger) bool {
 	// if we have a msg trigger and we're the first thing to happen... then we skip ourselves
 	triggerHasMsg := run.Session().Trigger().Type() == triggers.TypeMsg
 

--- a/flows/routers/waits/msg_test.go
+++ b/flows/routers/waits/msg_test.go
@@ -1,7 +1,6 @@
 package waits_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/nyaruka/gocommon/jsonx"
@@ -80,7 +79,7 @@ func TestMsgWait(t *testing.T) {
 
 	// try activating the wait
 	log := test.NewEventLog()
-	begun := wait.Begin(context.Background(), run, log.Log)
+	begun := wait.Begin(t.Context(), run, log.Log)
 
 	assert.True(t, begun)
 	assert.Equal(t, 1, len(log.Events))

--- a/flows/routers/waits/msg_test.go
+++ b/flows/routers/waits/msg_test.go
@@ -1,6 +1,7 @@
 package waits_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/nyaruka/gocommon/jsonx"
@@ -79,7 +80,7 @@ func TestMsgWait(t *testing.T) {
 
 	// try activating the wait
 	log := test.NewEventLog()
-	begun := wait.Begin(run, log.Log)
+	begun := wait.Begin(context.Background(), run, log.Log)
 
 	assert.True(t, begun)
 	assert.Equal(t, 1, len(log.Events))

--- a/flows/run.go
+++ b/flows/run.go
@@ -1,6 +1,7 @@
 package flows
 
 import (
+	"context"
 	"time"
 
 	"github.com/nyaruka/gocommon/i18n"
@@ -61,9 +62,9 @@ type Run interface {
 	PathLocation() (Step, Node, error)
 	HadInput() bool
 
-	EvaluateTemplateValue(string, events.EventLogger) (types.XValue, bool)
-	EvaluateTemplateText(string, excellent.Escaping, bool, events.EventLogger) (string, bool)
-	EvaluateTemplate(string, events.EventLogger) (string, bool)
+	EvaluateTemplateValue(context.Context, string, events.EventLogger) (types.XValue, bool)
+	EvaluateTemplateText(context.Context, string, excellent.Escaping, bool, events.EventLogger) (string, bool)
+	EvaluateTemplate(context.Context, string, events.EventLogger) (string, bool)
 	RootContext(envs.Environment) map[string]types.XValue
 
 	GetText(uuids.UUID, string, string) (string, i18n.Language)

--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -102,7 +102,7 @@ func testTriggerType(t *testing.T, assetsJSON []byte, typeName string) {
 		actual := tc
 
 		log := test.NewEventLog()
-		actualContextJSON, _ := session.Runs()[0].EvaluateTemplate(`@(json(trigger))`, log.Log)
+		actualContextJSON, _ := session.Runs()[0].EvaluateTemplate(context.Background(), `@(json(trigger))`, log.Log)
 		assert.NoError(t, err)
 		actual.Context = []byte(actualContextJSON)
 

--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -102,7 +102,7 @@ func testTriggerType(t *testing.T, assetsJSON []byte, typeName string) {
 		actual := tc
 
 		log := test.NewEventLog()
-		actualContextJSON, _ := session.Runs()[0].EvaluateTemplate(context.Background(), `@(json(trigger))`, log.Log)
+		actualContextJSON, _ := session.Runs()[0].EvaluateTemplate(t.Context(), `@(json(trigger))`, log.Log)
 		assert.NoError(t, err)
 		actual.Context = []byte(actualContextJSON)
 


### PR DESCRIPTION
Completes the ctx threading started when the budget landed. The evaluator entry points previously originated their own `context.Background()`, so the per-evaluation budget worked but a **caller-side deadline** couldn't be honoured, and one routing path was unmetered.

## What changed

Threads `context.Context` from the session's execution loop all the way into the evaluator:

- `Run.EvaluateTemplate` / `EvaluateTemplateText` / `EvaluateTemplateValue` take a `context.Context` first arg
- `Evaluator.Template` / `TemplateValue` / `Expression` take it too, and now add the budget to the **caller's** context instead of a fresh one
- `Router.Route` / `RouteTimeout` and `Wait.Begin` take it, so the session threads its context through routing and waiting
- `baseAction` eval helpers (`evaluateMessage`, `resolveRecipients`, `resolveGroups`/`Labels`/`User`) take it and pass it down; actions already receive `ctx` in `Execute`

## Why it matters

- **Removes the `context.TODO()`** the switch router used for test-function calls — router test evaluation (`has_pattern`, etc.) is now covered by the budget and any request deadline.
- Sets up a wall-clock deadline to compose with mailroom's per-request context with no further plumbing — the deadline would be honoured wherever `ctx.Err()` is checked (a natural follow-up if wanted).

Pure plumbing — no behaviour change (the budget is still added per evaluation, exactly as before). Full suite passes; docgen verified in the devcontainer (needs pandoc).

Note: the precompiled `Template.Evaluate` path (no production callers yet) still originates its own context internally.