### PR TITLE
Raise repeat() output cap back to 10,000 characters

### DIFF
--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -26,10 +26,10 @@ import (
 var nanosPerSecond = decimal.RequireFromString("1000000000")
 var nonPrintableRegex = regexp.MustCompile(`[\p{Cc}\p{C}]`)
 
-// maxRepeatOutput caps the number of characters that repeat() will build, to avoid unbounded allocation
-// from an attacker-controlled count. Real usage repeats short strings a handful of times, so this is
-// generous headroom whilst still bounding a single call.
-const maxRepeatOutput = 1_000
+// maxRepeatOutput caps the number of characters that repeat() will build in a single call, to avoid a large
+// transient allocation from an attacker-controlled count (the per-evaluation budget bounds cost across calls,
+// but only after each value is built). Matches the default limit on an evaluated template.
+const maxRepeatOutput = 10_000
 
 // maxArrayLength caps the number of items in an array built by a function such as split(), to avoid
 // unbounded allocation from attacker-controlled input. Matches the default limit on an evaluated template,

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -559,11 +559,11 @@ func TestFunctions(t *testing.T) {
 		{"repeat", dmy, []types.XValue{xs("hi"), xs("-1")}, ERROR},
 		{"repeat", dmy, []types.XValue{xs("hello"), nil}, ERROR},
 		{"repeat", dmy, []types.XValue{}, ERROR},
-		{"repeat", dmy, []types.XValue{xs("x"), xi(1000)}, xs(strings.Repeat("x", 1000))}, // exactly at the limit
-		{"repeat", dmy, []types.XValue{xs("x"), xi(1001)}, ERROR},                         // one over
-		{"repeat", dmy, []types.XValue{xs("é"), xi(1000)}, xs(strings.Repeat("é", 1000))}, // limit is characters, not bytes
-		{"repeat", dmy, []types.XValue{xs("é"), xi(1001)}, ERROR},
-		{"repeat", dmy, []types.XValue{xs("abcdefghij"), xi(101)}, ERROR}, // 1010 chars
+		{"repeat", dmy, []types.XValue{xs("x"), xi(10000)}, xs(strings.Repeat("x", 10000))}, // exactly at the limit
+		{"repeat", dmy, []types.XValue{xs("x"), xi(10001)}, ERROR},                          // one over
+		{"repeat", dmy, []types.XValue{xs("é"), xi(10000)}, xs(strings.Repeat("é", 10000))}, // limit is characters, not bytes
+		{"repeat", dmy, []types.XValue{xs("é"), xi(10001)}, ERROR},
+		{"repeat", dmy, []types.XValue{xs("abcdefghij"), xi(1001)}, ERROR}, // 10010 chars
 		{"repeat", dmy, []types.XValue{xs("x"), xi(2000000000)}, ERROR},
 
 		{"replace", dmy, []types.XValue{xs("hi ho"), xs("hi"), xs("bye")}, xs("bye ho")},


### PR DESCRIPTION
`maxRepeatOutput` was lowered from 10,000 to 1,000 as defense-in-depth before the per-evaluation cost budget existed. Now that the budget bounds evaluation cost across composed calls (regardless of how per-call limits combine), `repeat()`'s per-call cap only needs to guard a single call's transient allocation.

Restores it to 10,000, which:
- matches the default evaluated-template limit (`MaxTemplateChars`), the same anchor `maxArrayLength` already uses
- gives flow authors more headroom for legitimate uses (padding, separators, fixed-width formatting) without weakening the actual composition bound, which the budget owns

Comment updated to reflect that the budget now owns cross-call cost and this cap is just the single-call transient guard.