### PR TITLE
Don't wrap fatal evaluation errors with location context

### DIFF
--- a/excellent/base_test.go
+++ b/excellent/base_test.go
@@ -505,8 +505,9 @@ func TestEvaluationBudget(t *testing.T) {
 	// the budget is also wired for the Expression() entry point, and empty text can't be produced for free
 	// (which would otherwise bypass the per-value floor and allow unbounded iteration)
 	val, _ := eval.Expression(t.Context(), env, ctx, `foreach(split(repeat("x ",500)," "), (a) => foreach(split(repeat("x ",500)," "), (b) => foreach(split(repeat("x ",500)," "), (c) => "")))`)
-	assert.True(t, types.IsXError(val))
-	assert.Contains(t, val.(*types.XError).Error(), "expression is too complex to evaluate")
+	// the budget error is fatal, so it propagates verbatim rather than being wrapped with "error calling ..."
+	assert.Same(t, types.ErrTooComplex, val)
+	assert.Equal(t, "expression is too complex to evaluate", val.(*types.XError).Error())
 }
 
 func TestHasExpressions(t *testing.T) {

--- a/excellent/tree.go
+++ b/excellent/tree.go
@@ -195,7 +195,7 @@ func (x *BinaryOperation) Evaluate(ctx context.Context, env envs.Environment, sc
 
 	// charge the cost of the produced value against the evaluation budget
 	if b := budget.From(ctx); b != nil && !b.Charge(types.CostOf(result)) {
-		return types.NewXErrorf("expression is too complex to evaluate")
+		return types.ErrTooComplex
 	}
 
 	return result

--- a/excellent/types/error.go
+++ b/excellent/types/error.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/nyaruka/gocommon/jsonx"
@@ -12,7 +13,12 @@ type XError struct {
 	baseValue
 
 	native error
+	fatal  bool // fatal errors abort evaluation as a whole and so aren't wrapped with location context
 }
+
+// ErrTooComplex is returned when an evaluation exceeds its cost budget. It refers to the evaluation as a
+// whole rather than any specific part of it, so it's fatal.
+var ErrTooComplex = &XError{native: errors.New("expression is too complex to evaluate"), fatal: true}
 
 // NewXError creates a new XError
 func NewXError(err error) *XError {

--- a/excellent/types/function.go
+++ b/excellent/types/function.go
@@ -33,14 +33,19 @@ func NewXFunction(name string, fn XFunc) *XFunction {
 func (x *XFunction) Call(ctx context.Context, env envs.Environment, params []XValue) XValue {
 	val := x.fn(ctx, env, params...)
 
-	// if function returned an error, wrap the error with the function name
+	// if function returned an error, wrap the error with the function name, unless it's fatal in which
+	// case there's no useful location context to add
 	if IsXError(val) {
-		return NewXErrorf("error calling %s: %s", x.Describe(), val.(*XError).Error())
+		xerr := val.(*XError)
+		if xerr.fatal {
+			return xerr
+		}
+		return NewXErrorf("error calling %s: %s", x.Describe(), xerr.Error())
 	}
 
 	// charge the cost of the produced value against the evaluation budget
 	if b := budget.From(ctx); b != nil && !b.Charge(CostOf(val)) {
-		return NewXErrorf("expression is too complex to evaluate")
+		return ErrTooComplex
 	}
 
 	return val

--- a/excellent/types/function_test.go
+++ b/excellent/types/function_test.go
@@ -36,6 +36,12 @@ func TestXFunction(t *testing.T) {
 
 	assert.Equal(t, types.NewXErrorf("error calling bad(...): boom"), func2.Call(t.Context(), env, nil))
 
+	// fatal errors aren't wrapped with the function name - they propagate verbatim
+	fatal := types.NewXFunction("fatal", func(ctx context.Context, env envs.Environment, args ...types.XValue) types.XValue {
+		return types.ErrTooComplex
+	})
+	assert.Same(t, types.ErrTooComplex, fatal.Call(t.Context(), env, nil))
+
 	assert.True(t, anon1.Truthy())
 	assert.Equal(t, `<anon>`, anon1.Render())
 	assert.Equal(t, `<anon>`, anon1.Format(env))


### PR DESCRIPTION
`XFunction.Call` wraps any error a function returns with `error calling foo(...): ...`, which is useful for locating *which* call in a large expression failed. But the budget-exceeded error (`expression is too complex to evaluate`) refers to the evaluation as a whole — it has no "where" — and because it's generated at the choke points and unwinds up through nested calls, every enclosing `Call` re-wraps it:

```
error calling foreach(...): error calling foreach(...): error calling <anon>(...): expression is too complex to evaluate
```

## Change

Adds a `fatal` field to `XError`. A fatal error aborts evaluation as a whole and so isn't wrapped with location context — `Call` returns it verbatim. `ErrTooComplex` is now a shared sentinel (`fatal: true`) returned at both budget charge sites (`XFunction.Call`, `BinaryOperation.Evaluate`).

- The `fatal` zero value is `false`, so every existing error and constructor is unchanged — only the sentinel opts in.
- `XError` is immutable, so the shared sentinel is safe across concurrent evaluations (and gives pointer identity in tests).
- Extends cleanly: a future "deadline exceeded" error is also a whole-evaluation error with no location — it becomes a second fatal sentinel with no new mechanism.

Net effect: the budget error now surfaces as a clean `expression is too complex to evaluate` in error events, instead of buried under `error calling ...:` prefixes.