### PR TITLE
Namespace event error codes and add expression:too_complex

### DIFF
--- a/core/events/error.go
+++ b/core/events/error.go
@@ -14,9 +14,10 @@ func init() {
 const TypeError string = "error"
 
 const (
-	ErrorCodeDependencyMissing = "dependency_missing"
-	ErrorCodeURNTaken          = "urn_taken"
-	ErrorCodeExpression        = "expression"
+	ErrorCodeDependencyMissing    = "dependency:missing"
+	ErrorCodeURNTaken             = "urn:taken"
+	ErrorCodeExpression           = "expression"
+	ErrorCodeExpressionTooComplex = "expression:too_complex"
 )
 
 // Error events are created when an error occurs during flow execution.

--- a/core/events/testdata/TestEventMarshaling_error_dependency.snap
+++ b/core/events/testdata/TestEventMarshaling_error_dependency.snap
@@ -3,5 +3,5 @@
     "type": "error",
     "created_on": "2025-05-04T12:30:46.123456789Z",
     "text": "Missing dependency: field[key=age,name=Age]",
-    "code": "dependency_missing"
+    "code": "dependency:missing"
 }

--- a/excellent/base.go
+++ b/excellent/base.go
@@ -164,7 +164,7 @@ func VisitTemplate(template string, allowedTopLevels []string, unescapeBody bool
 				repr = "@(" + token + ")"
 			}
 
-			errors.Add(repr, err.Error())
+			errors.Add(repr, err)
 		}
 	}
 

--- a/excellent/errors.go
+++ b/excellent/errors.go
@@ -10,11 +10,16 @@ import (
 // TemplateError is an error which occurs during evaluation of an expression
 type TemplateError struct {
 	Expression string
-	Message    string
+	Err        error
 }
 
 func (e TemplateError) Error() string {
-	return fmt.Sprintf("error evaluating %s: %s", e.Expression, e.Message)
+	return fmt.Sprintf("error evaluating %s: %s", e.Expression, e.Err)
+}
+
+// Unwrap allows the underlying evaluation error to be inspected, e.g. with errors.Is
+func (e TemplateError) Unwrap() error {
+	return e.Err
 }
 
 // TemplateErrors represents the list of all errors encountered during evaluation of a template
@@ -28,8 +33,8 @@ func NewTemplateErrors() *TemplateErrors {
 }
 
 // Add adds an error for the given expression
-func (e *TemplateErrors) Add(expression, message string) {
-	e.Errors = append(e.Errors, &TemplateError{Expression: expression, Message: message})
+func (e *TemplateErrors) Add(expression string, err error) {
+	e.Errors = append(e.Errors, &TemplateError{Expression: expression, Err: err})
 }
 
 // HasErrors returns whether there are errors

--- a/excellent/template.go
+++ b/excellent/template.go
@@ -92,7 +92,7 @@ func (t *Template) Evaluate(env envs.Environment, ctx *types.XObject, escaping E
 
 			// if we got an error, add it to our list and move on
 			if types.IsXError(value) {
-				errors.Add(s.src, value.(error).Error())
+				errors.Add(s.src, value.(error))
 				continue
 			}
 

--- a/excellent/types/error.go
+++ b/excellent/types/error.go
@@ -16,9 +16,11 @@ type XError struct {
 	fatal  bool // fatal errors abort evaluation as a whole and so aren't wrapped with location context
 }
 
+var errTooComplex = errors.New("expression is too complex to evaluate")
+
 // ErrTooComplex is returned when an evaluation exceeds its cost budget. It refers to the evaluation as a
 // whole rather than any specific part of it, so it's fatal.
-var ErrTooComplex = &XError{native: errors.New("expression is too complex to evaluate"), fatal: true}
+var ErrTooComplex = &XError{native: errTooComplex, fatal: true}
 
 // NewXError creates a new XError
 func NewXError(err error) *XError {
@@ -57,6 +59,13 @@ func (x *XError) Native() error {
 }
 
 func (x *XError) Error() string { return x.Native().Error() }
+
+// Is reports whether this error matches the target for errors.Is, comparing by the underlying native error
+// so that a fatal sentinel like ErrTooComplex is still recognized if it's ever re-wrapped in a new XError
+func (x *XError) Is(target error) bool {
+	t, ok := target.(*XError)
+	return ok && x.native != nil && t.native != nil && errors.Is(x.native, t.native)
+}
 
 // Equals determines equality for this type
 func (x *XError) Equals(o XValue) bool {

--- a/excellent/types/error_test.go
+++ b/excellent/types/error_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -27,4 +28,17 @@ func TestXError(t *testing.T) {
 	marshaled, err := jsonx.Marshal(err1)
 	assert.NoError(t, err)
 	assert.Equal(t, `null`, string(marshaled))
+}
+
+func TestErrTooComplex(t *testing.T) {
+	// the sentinel matches itself
+	assert.True(t, errors.Is(types.ErrTooComplex, types.ErrTooComplex))
+
+	// and still matches when re-wrapped in a new XError (identity would miss this)
+	rewrapped := types.NewXError(types.ErrTooComplex.Native())
+	assert.NotSame(t, types.ErrTooComplex, rewrapped)
+	assert.True(t, errors.Is(rewrapped, types.ErrTooComplex))
+
+	// an unrelated error doesn't match
+	assert.False(t, errors.Is(types.NewXErrorf("boom"), types.ErrTooComplex))
 }

--- a/flows/actions/testdata/add_contact_groups.json
+++ b/flows/actions/testdata/add_contact_groups.json
@@ -31,7 +31,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: group[uuid=33382939-babf-4982-9395-8793feb4e7c6,name=Climbers]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},

--- a/flows/actions/testdata/add_input_labels.json
+++ b/flows/actions/testdata/add_input_labels.json
@@ -176,7 +176,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: label[uuid=33382939-babf-4982-9395-8793feb4e7c6,name=Climbing]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},

--- a/flows/actions/testdata/call_llm.json
+++ b/flows/actions/testdata/call_llm.json
@@ -18,7 +18,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: llm[uuid=63998ee7-a7a5-4cc5-be67-c773e1b6b9b1,name=Deleted]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {

--- a/flows/actions/testdata/open_ticket.json
+++ b/flows/actions/testdata/open_ticket.json
@@ -16,7 +16,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: topic[uuid=dc61e948-26a1-407e-9739-b73b46400b51,name=Deleted]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {

--- a/flows/actions/testdata/remove_contact_groups.json
+++ b/flows/actions/testdata/remove_contact_groups.json
@@ -204,7 +204,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: group[uuid=33382939-babf-4982-9395-8793feb4e7c6,name=Climbers]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},

--- a/flows/actions/testdata/send_broadcast.json
+++ b/flows/actions/testdata/send_broadcast.json
@@ -45,7 +45,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: group[uuid=33382939-babf-4982-9395-8793feb4e7c6,name=Climbers]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},

--- a/flows/actions/testdata/set_contact_channel.json
+++ b/flows/actions/testdata/set_contact_channel.json
@@ -156,7 +156,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: channel[uuid=33382939-babf-4982-9395-8793feb4e7c6,name=My Phone]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},

--- a/flows/actions/testdata/set_contact_field.json
+++ b/flows/actions/testdata/set_contact_field.json
@@ -344,7 +344,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: field[key=score,name=Score]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},

--- a/flows/actions/testdata/start_session.json
+++ b/flows/actions/testdata/start_session.json
@@ -53,7 +53,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: flow[uuid=dede1e50-db55-4b50-8929-2116bfc56148,name=Missing]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},
@@ -116,7 +116,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Missing dependency: group[uuid=33382939-babf-4982-9395-8793feb4e7c6,name=Climbers]",
-                "code": "dependency_missing"
+                "code": "dependency:missing"
             }
         ],
         "locals_after": {},

--- a/flows/definition/legacy/expressions/migrate.go
+++ b/flows/definition/legacy/expressions/migrate.go
@@ -87,7 +87,7 @@ func migrateLegacyTemplateAsString(template string, options *MigrateOptions) (st
 
 			value, err := migrateExpression(nil, token, options)
 			if err != nil {
-				errors.Add(fmt.Sprintf("@(%s)", token), err.Error())
+				errors.Add(fmt.Sprintf("@(%s)", token), err)
 				buf.WriteString("@(")
 				buf.WriteString(token)
 				buf.WriteString(")")

--- a/flows/engine/run.go
+++ b/flows/engine/run.go
@@ -340,7 +340,11 @@ func (r *run) errorToEvents(err error, log events.EventLogger) {
 	var tplErrs *excellent.TemplateErrors
 	if errors.As(err, &tplErrs) {
 		for _, terr := range tplErrs.Errors {
-			log(events.NewError(fmt.Sprintf("Error evaluating expression: %s", terr.Message), events.ErrorCodeExpression, "expression", terr.Expression))
+			code := events.ErrorCodeExpression
+			if errors.Is(terr.Err, types.ErrTooComplex) {
+				code = events.ErrorCodeExpressionTooComplex
+			}
+			log(events.NewError(fmt.Sprintf("Error evaluating expression: %s", terr.Err), code, "expression", terr.Expression))
 		}
 	} else {
 		log(events.NewRawError(err))

--- a/flows/engine/run_test.go
+++ b/flows/engine/run_test.go
@@ -227,6 +227,20 @@ func TestRunContext(t *testing.T) {
 	evaluated, _ := run.EvaluateTemplateText(t.Context(), `gender = @("M\" OR")`, contactql.EscapeValue, true, log.Log)
 	assert.NoError(t, log.Error())
 	assert.Equal(t, `gender = "M\" OR"`, evaluated)
+
+	// an ordinary expression error is logged with the general expression code
+	log = test.NewEventLog()
+	run.EvaluateTemplate(t.Context(), `@(1 / 0)`, log.Log)
+	require.Len(t, log.Events, 1)
+	assert.Equal(t, events.ErrorCodeExpression, log.Events[0].(*events.Error).Code)
+
+	// exceeding the cost budget is logged with a distinct code so it can be alerted on
+	log = test.NewEventLog()
+	run.EvaluateTemplate(t.Context(), `@(join(foreach(split(repeat("a ",500)," "), (v) => join(foreach(split(repeat("a ",500)," "), repeat, 1000), "")), ""))`, log.Log)
+	require.Len(t, log.Events, 1)
+	errEvent := log.Events[0].(*events.Error)
+	assert.Equal(t, events.ErrorCodeExpressionTooComplex, errEvent.Code)
+	assert.Equal(t, "Error evaluating expression: expression is too complex to evaluate", errEvent.Text)
 }
 
 func TestMissingRelatedRunContext(t *testing.T) {

--- a/flows/modifiers/testdata/routes.json
+++ b/flows/modifiers/testdata/routes.json
@@ -573,7 +573,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:46.123456789Z",
                 "text": "URN is taken by another contact",
-                "code": "urn_taken",
+                "code": "urn:taken",
                 "extra": {
                     "urn": "twitter:taken123"
                 }

--- a/flows/modifiers/testdata/urns.json
+++ b/flows/modifiers/testdata/urns.json
@@ -395,7 +395,7 @@
                 "type": "error",
                 "created_on": "2025-05-04T12:30:46.123456789Z",
                 "text": "URN is taken by another contact",
-                "code": "urn_taken",
+                "code": "urn:taken",
                 "extra": {
                     "urn": "twitter:taken123"
                 }


### PR DESCRIPTION
Adopts the `domain:subtype` convention already used everywhere except goflow's event codes, and adds a distinct code for budget-exceeded errors.

## Why

The mailroom web API builds error codes as `domain:code` — `urn:taken`, `query:unknown_property`, `flow:invalid`, `ai:unknown` — and temba parses them by splitting on `:`. mailroom's series/metric codes are colon-namespaced too (`text:in`, `voice:out`, `tokens:in`, …). goflow's flat `dependency_missing` / `urn_taken` / `expression` were the outliers, and `urn_taken` was actually **inconsistent** with the `urn:taken` the mailroom API already emits for the same concept.

## Changes

- `dependency_missing` → `dependency:missing`
- `urn_taken` → `urn:taken`
- adds `expression:too_complex`, emitted when an evaluation exceeds its cost budget, so it's distinguishable from ordinary expression errors (a consumer can route only these to Sentry — hitting the budget is supposed to be impossible)

To carry the distinct code through cleanly, `TemplateError` now holds the underlying `error` instead of a pre-flattened string, so `errorToEvents` recognises the fatal `ErrTooComplex` sentinel via `errors.Is` rather than string-matching the message.

## Consumer impact

- `dependency_missing` and `expression` are used nowhere in mailroom/courier/temba/floweditor.
- `urn_taken` is used by mailroom ([event.go](https://github.com/nyaruka/mailroom), [contacts.go]) **via the constant** `events.ErrorCodeURNTaken`, in real time (comparing freshly-produced events). Changing the constant's value is safe under the normal lockstep bump — the comparison moves on both sides together. **Requires a mailroom bump.**
- No consumer queries stored event JSON by these code strings.

Fixtures/snapshots updated; docgen verified in the devcontainer.