### PR TITLE
Apply engine number range limits to contact query values

### DIFF
--- a/contactql/parse/parse_test.go
+++ b/contactql/parse/parse_test.go
@@ -252,10 +252,10 @@ func TestParseQuery(t *testing.T) {
 		{text: `dob > 20-02-2020`, parsed: `fields.dob > "20-02-2020"`, resolver: resolver},
 		{text: `state > Pichincha`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
 
-		// number values have the same range limits as numbers elsewhere in the engine
-		{text: `age <= 1e100`, parsed: `fields.age <= "1e100"`, resolver: resolver},
-		{text: `age > 1e101`, err: "can't convert '1e101' to a number", resolver: resolver},
-		{text: `age < 1e-101`, err: "can't convert '1e-101' to a number", resolver: resolver},
+		// number values have the same format restrictions and range limits as numbers elsewhere in the engine
+		{text: `age <= 1e10`, err: "can't convert '1e10' to a number", resolver: resolver},
+		{text: `age = 1` + strings.Repeat("0", 100), parsed: `fields.age = 1` + strings.Repeat("0", 100), resolver: resolver},
+		{text: `age = 1` + strings.Repeat("0", 101), err: "can't convert '1" + strings.Repeat("0", 101) + "' to a number", resolver: resolver},
 		{text: `tickets = 9999999999999999999999999999999999999`, err: "can't convert '9999999999999999999999999999999999999' to a number", resolver: resolver},
 
 		// however if we don't provide a resolver, we don't know the field type, so allowed for all

--- a/contactql/parse/parse_test.go
+++ b/contactql/parse/parse_test.go
@@ -252,6 +252,12 @@ func TestParseQuery(t *testing.T) {
 		{text: `dob > 20-02-2020`, parsed: `fields.dob > "20-02-2020"`, resolver: resolver},
 		{text: `state > Pichincha`, err: "comparisons with > can only be used with date and number fields", resolver: resolver},
 
+		// number values have the same range limits as numbers elsewhere in the engine
+		{text: `age <= 1e100`, parsed: `fields.age <= "1e100"`, resolver: resolver},
+		{text: `age > 1e101`, err: "can't convert '1e101' to a number", resolver: resolver},
+		{text: `age < 1e-101`, err: "can't convert '1e-101' to a number", resolver: resolver},
+		{text: `tickets = 9999999999999999999999999999999999999`, err: "can't convert '9999999999999999999999999999999999999' to a number", resolver: resolver},
+
 		// however if we don't provide a resolver, we don't know the field type, so allowed for all
 		{text: `age > 18`, parsed: `fields.age > 18`},
 		{text: `gender > male`, parsed: `fields.gender > "male"`},
@@ -326,6 +332,12 @@ func TestParsingErrors(t *testing.T) {
 			errMsg:   "can't convert 'XZ' to a number",
 			errCode:  "invalid_number",
 			errExtra: map[string]any{"value": "XZ"},
+		},
+		{
+			query:    `age = 1e200`,
+			errMsg:   "can't convert '1e200' to a number",
+			errCode:  "invalid_number",
+			errExtra: map[string]any{"value": "1e200"},
 		},
 		{
 			query:    `dob = AB`,

--- a/contactql/query.go
+++ b/contactql/query.go
@@ -140,18 +140,15 @@ func (c *Condition) Operator() Operator { return c.operator }
 // Value returns the value being compared against
 func (c *Condition) Value() string { return c.value }
 
-// ValueAsNumber returns the value as a number if possible, or an error if not
+// ValueAsNumber returns the value as a number if possible, or an error if not. Numbers have the same
+// format restrictions (no scientific notation) and range limits as numbers elsewhere in the engine -
+// an unbounded decimal can require huge allocations when compared or rendered in full notation.
 func (c *Condition) ValueAsNumber() (decimal.Decimal, error) {
-	d, err := decimal.NewFromString(c.value)
+	n, err := types.NewXNumberFromString(c.value)
 	if err != nil {
 		return decimal.Zero, err
 	}
-	// apply the same range limits as numbers elsewhere in the engine - an unbounded decimal can
-	// require huge allocations when compared or rendered in full notation
-	if err := types.CheckDecimalRange(d); err != nil {
-		return decimal.Zero, err
-	}
-	return d, nil
+	return n.Native(), nil
 }
 
 // ValueAsDate returns the value as a date if possible, or an error if not

--- a/contactql/query.go
+++ b/contactql/query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/goflow/utils/obfuscate"
 	"github.com/shopspring/decimal"
@@ -141,7 +142,16 @@ func (c *Condition) Value() string { return c.value }
 
 // ValueAsNumber returns the value as a number if possible, or an error if not
 func (c *Condition) ValueAsNumber() (decimal.Decimal, error) {
-	return decimal.NewFromString(c.value)
+	d, err := decimal.NewFromString(c.value)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	// apply the same range limits as numbers elsewhere in the engine - an unbounded decimal can
+	// require huge allocations when compared or rendered in full notation
+	if err := types.CheckDecimalRange(d); err != nil {
+		return decimal.Zero, err
+	}
+	return d, nil
 }
 
 // ValueAsDate returns the value as a date if possible, or an error if not

--- a/flows/routers/cases/utils.go
+++ b/flows/routers/cases/utils.go
@@ -68,14 +68,11 @@ func ParseDecimal(val string, format *envs.NumberFormat) (decimal.Decimal, error
 	// replace non-Arabic (0-9) numerals with their equivalents
 	cleaned = strings.Map(numeralMapper, cleaned)
 
-	d, err := decimal.NewFromString(cleaned)
+	// parse with the same format restrictions (no scientific notation) and range limits as numbers
+	// elsewhere in the engine
+	n, err := types.NewXNumberFromString(cleaned)
 	if err != nil {
-		return d, err
-	}
-
-	if err := types.CheckDecimalRange(d); err != nil {
 		return decimal.Zero, err
 	}
-
-	return d, nil
+	return n.Native(), nil
 }

--- a/flows/routers/cases/utils_test.go
+++ b/flows/routers/cases/utils_test.go
@@ -50,4 +50,8 @@ func TestParseDecimal(t *testing.T) {
 	// test that oversized numbers are rejected
 	_, err := cases.ParseDecimal("1234567890123456789012345678901234567", envs.DefaultNumberFormat)
 	assert.EqualError(t, err, "number has too many digits")
+
+	// test that scientific notation is rejected
+	_, err = cases.ParseDecimal("1e10", envs.DefaultNumberFormat)
+	assert.EqualError(t, err, "not a valid number format")
 }


### PR DESCRIPTION
Number values in contact query conditions and router case tests were parsed with raw `decimal.NewFromString`, unlike numbers in expressions which are restricted to plain notation (#964) and constrained to 36 significant digits and ±1E100 magnitude (#1488). A validated query could thus carry a decimal like `1e2000000000` whose comparison (big.Int rescale) or full-notation rendering (e.g. when the converted Elasticsearch query is marshaled) requires allocations proportional to the exponent — up to multiple GB from a short query string.

`contactql.Condition.ValueAsNumber` and `cases.ParseDecimal` now parse via `types.NewXNumberFromString` so all numbers entering the engine share the same code path: no scientific notation, max 36 significant digits, magnitude within ±1E100. Out-of-range or E-notation query values are rejected at validation with the existing `invalid_number` error code, and number-matching case tests (e.g. `has_number`) no longer match E-notation tokens in input text.