### PR TITLE
Confine shopspring/decimal to the engine's type system

### DIFF
--- a/contactql/evaluator.go
+++ b/contactql/evaluator.go
@@ -9,12 +9,12 @@ import (
 	"github.com/nyaruka/gocommon/stringsx"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
-	"github.com/shopspring/decimal"
+	"github.com/nyaruka/goflow/excellent/types"
 )
 
 // Queryable is the interface objects must implement queried
 //
-// Returned values must match the type the queried property is declared as - decimal.Decimal for number
+// Returned values must match the type the queried property is declared as - *types.XNumber for number
 // properties, time.Time for datetime ones and string for everything else - as evaluation asserts them to
 // that type. Return no values rather than a value of a different type.
 type Queryable interface {
@@ -99,7 +99,7 @@ func evaluateConditionWithValue(env envs.Environment, resolver Resolver, c *Cond
 	switch valueType {
 	case assets.FieldTypeNumber:
 		asNumber, _ := c.ValueAsNumber()
-		return numberComparison(val.(decimal.Decimal), c.operator, asNumber)
+		return numberComparison(val.(*types.XNumber), c.operator, asNumber)
 	case assets.FieldTypeDatetime:
 		asDate, _ := c.ValueAsDate(env)
 		return dateComparison(val.(time.Time), c.operator, asDate)
@@ -129,20 +129,20 @@ func textComparison(objectVal string, op Operator, queryVal string, isName bool)
 	}
 }
 
-func numberComparison(objectVal decimal.Decimal, op Operator, queryVal decimal.Decimal) bool {
+func numberComparison(objectVal *types.XNumber, op Operator, queryVal *types.XNumber) bool {
 	switch op {
 	case OpEqual:
-		return objectVal.Equal(queryVal)
+		return objectVal.Compare(queryVal) == 0
 	case OpNotEqual:
-		return !objectVal.Equal(queryVal)
+		return objectVal.Compare(queryVal) != 0
 	case OpGreaterThan:
-		return objectVal.GreaterThan(queryVal)
+		return objectVal.Compare(queryVal) > 0
 	case OpGreaterThanOrEqual:
-		return objectVal.GreaterThanOrEqual(queryVal)
+		return objectVal.Compare(queryVal) >= 0
 	case OpLessThan:
-		return objectVal.LessThan(queryVal)
+		return objectVal.Compare(queryVal) < 0
 	case OpLessThanOrEqual:
-		return objectVal.LessThanOrEqual(queryVal)
+		return objectVal.Compare(queryVal) <= 0
 	default:
 		panic(fmt.Sprintf("can't query number fields with %s", op))
 	}

--- a/contactql/evaluator_test.go
+++ b/contactql/evaluator_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nyaruka/goflow/contactql"
 	"github.com/nyaruka/goflow/contactql/parse"
 	"github.com/nyaruka/goflow/envs"
-	"github.com/shopspring/decimal"
+	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,7 +31,7 @@ func TestEvaluateQuery(t *testing.T) {
 		"twitter":  []any{"bob_smith"},
 		"whatsapp": []any{},
 		"gender":   []any{"male"},
-		"age":      []any{decimal.NewFromFloat(36)},
+		"age":      []any{types.NewXNumberFromInt(36)},
 		"dob":      []any{time.Date(1981, 5, 28, 13, 30, 23, 0, time.UTC)},
 		"state":    []any{"Kigali"},
 		"district": []any{"Gasabo"},

--- a/contactql/query.go
+++ b/contactql/query.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/goflow/utils/obfuscate"
-	"github.com/shopspring/decimal"
 )
 
 // MaxConditions is the maximum number of conditions a query can contain. Every condition becomes a clause
@@ -143,12 +142,8 @@ func (c *Condition) Value() string { return c.value }
 // ValueAsNumber returns the value as a number if possible, or an error if not. Numbers have the same
 // format restrictions (no scientific notation) and range limits as numbers elsewhere in the engine -
 // an unbounded decimal can require huge allocations when compared or rendered in full notation.
-func (c *Condition) ValueAsNumber() (decimal.Decimal, error) {
-	n, err := types.NewXNumberFromString(c.value)
-	if err != nil {
-		return decimal.Zero, err
-	}
-	return n.Native(), nil
+func (c *Condition) ValueAsNumber() (*types.XNumber, error) {
+	return types.NewXNumberFromString(c.value)
 }
 
 // ValueAsDate returns the value as a date if possible, or an error if not

--- a/core/contact.go
+++ b/core/contact.go
@@ -17,7 +17,6 @@ import (
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/goflow/utils/obfuscate"
-	"github.com/shopspring/decimal"
 )
 
 func init() {
@@ -595,7 +594,7 @@ func (c *Contact) QueryProperty(env envs.Environment, key string, propType conta
 			}
 			return vals
 		case contactql.AttributeTickets:
-			return []any{decimal.NewFromInt(int64(c.tickets.Open().Count()))}
+			return []any{types.NewXNumberFromInt(c.tickets.Open().Count())}
 		case contactql.AttributeCreatedOn:
 			return []any{c.createdOn}
 		case contactql.AttributeLastSeenOn:

--- a/core/field.go
+++ b/core/field.go
@@ -95,7 +95,7 @@ func (v *FieldValue) QueryValue() any {
 		}
 	case assets.FieldTypeNumber:
 		if v.Number != nil {
-			return (*v.Number).Native()
+			return v.Number
 		}
 
 	// we only search against location names and not full paths

--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -15,15 +15,13 @@ import (
 	"unicode/utf8"
 
 	"github.com/nyaruka/gocommon/dates"
-	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
-	"github.com/shopspring/decimal"
 )
 
-var nanosPerSecond = decimal.RequireFromString("1000000000")
+var nanosPerSecond = types.NewXNumberFromInt64(1000000000)
 var nonPrintableRegex = regexp.MustCompile(`[\p{Cc}\p{C}]`)
 
 // maxRepeatOutput caps the number of characters that repeat() will build in a single call, to avoid a large
@@ -900,8 +898,14 @@ func Upper(env envs.Environment, text *types.XText) types.XValue {
 //
 // @function percent(number)
 func Percent(env envs.Environment, num *types.XNumber) types.XValue {
-	// multiply by 100 and floor
-	percent := num.Native().Mul(decimal.NewFromFloat(100)).Round(0)
+	// multiply by 100 and round to a whole number
+	percent, err := num.Mul(types.NewXNumberFromInt(100))
+	if err == nil {
+		percent, err = percent.Round(0)
+	}
+	if err != nil {
+		return types.NewXError(err)
+	}
 
 	// add on a %
 	return types.NewXText(fmt.Sprintf("%d%%", percent.IntPart()))
@@ -945,7 +949,7 @@ func HTMLDecode(env envs.Environment, text *types.XText) types.XValue {
 //
 // @function abs(number)
 func Abs(env envs.Environment, num *types.XNumber) types.XValue {
-	return types.NewXNumber(num.Native().Abs())
+	return num.Abs()
 }
 
 // Round rounds `number` to the nearest value.
@@ -963,7 +967,11 @@ func Abs(env envs.Environment, num *types.XNumber) types.XValue {
 //
 // @function round(number [,places])
 func Round(env envs.Environment, num *types.XNumber, places int) types.XValue {
-	return types.NewXNumber(num.Native().Round(int32(places)))
+	rounded, err := num.Round(places)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return rounded
 }
 
 // RoundUp rounds `number` up to the nearest integer value.
@@ -979,15 +987,11 @@ func Round(env envs.Environment, num *types.XNumber, places int) types.XValue {
 //
 // @function round_up(number [,places])
 func RoundUp(env envs.Environment, num *types.XNumber, places int) types.XValue {
-	dec := num.Native()
-	if dec.Round(int32(places)).Equal(dec) {
-		return num
+	rounded, err := num.RoundUp(places)
+	if err != nil {
+		return types.NewXError(err)
 	}
-
-	halfPrecision := decimal.New(5, -int32(places)-1)
-	roundedDec := dec.Add(halfPrecision).Round(int32(places))
-
-	return types.NewXNumber(roundedDec)
+	return rounded
 }
 
 // RoundDown rounds `number` down to the nearest integer value.
@@ -1003,15 +1007,11 @@ func RoundUp(env envs.Environment, num *types.XNumber, places int) types.XValue 
 //
 // @function round_down(number [,places])
 func RoundDown(env envs.Environment, num *types.XNumber, places int) types.XValue {
-	dec := num.Native()
-	if dec.Round(int32(places)).Equal(dec) {
-		return num
+	rounded, err := num.RoundDown(places)
+	if err != nil {
+		return types.NewXError(err)
 	}
-
-	halfPrecision := decimal.New(5, -int32(places)-1)
-	roundedDec := dec.Sub(halfPrecision).Round(int32(places))
-
-	return types.NewXNumber(roundedDec)
+	return rounded
 }
 
 // Max returns the maximum value in `numbers`.
@@ -1074,17 +1074,26 @@ func Min(ctx context.Context, env envs.Environment, values ...types.XValue) type
 //
 // @function mean(numbers...)
 func Mean(ctx context.Context, env envs.Environment, args ...types.XValue) types.XValue {
-	sum := decimal.Zero
+	sum := types.XNumberZero
 
 	for _, val := range args {
 		num, xerr := types.ToXNumber(env, val)
 		if xerr != nil {
 			return xerr
 		}
-		sum = sum.Add(num.Native())
+
+		var err error
+		sum, err = sum.Add(num)
+		if err != nil {
+			return types.NewXError(err)
+		}
 	}
 
-	return types.NewXNumber(sum.Div(decimal.New(int64(len(args)), 0)))
+	mean, err := sum.Div(types.NewXNumberFromInt(len(args)))
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return mean
 }
 
 // Mod returns the remainder of the division of `dividend` by `divisor`.
@@ -1095,7 +1104,11 @@ func Mean(ctx context.Context, env envs.Environment, args ...types.XValue) types
 //
 // @function mod(dividend, divisor)
 func Mod(env envs.Environment, num1 *types.XNumber, num2 *types.XNumber) types.XValue {
-	return types.NewXNumber(num1.Native().Mod(num2.Native()))
+	remainder, err := num1.Mod(num2)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return remainder
 }
 
 // Rand returns a single random number between [0.0-1.0).
@@ -1105,7 +1118,7 @@ func Mod(env envs.Environment, num1 *types.XNumber, num2 *types.XNumber) types.X
 //
 // @function rand()
 func Rand(env envs.Environment) types.XValue {
-	return types.NewXNumber(random.Decimal())
+	return types.RandomXNumber()
 }
 
 // RandBetween a single random integer in the given inclusive range.
@@ -1115,11 +1128,23 @@ func Rand(env envs.Environment) types.XValue {
 //
 // @function rand_between()
 func RandBetween(env envs.Environment, min *types.XNumber, max *types.XNumber) types.XValue {
-	span := (max.Native().Sub(min.Native())).Add(decimal.New(1, 0))
+	span, err := max.Sub(min)
+	if err == nil {
+		span, err = span.Add(types.NewXNumberFromInt(1))
+	}
 
-	val := random.Decimal().Mul(span).Add(min.Native()).Floor()
+	var val *types.XNumber
+	if err == nil {
+		val, err = types.RandomXNumber().Mul(span)
+	}
+	if err == nil {
+		val, err = val.Add(min)
+	}
+	if err != nil {
+		return types.NewXError(err)
+	}
 
-	return types.NewXNumber(val)
+	return val.Floor()
 }
 
 //------------------------------------------------------------------------------------------
@@ -1211,8 +1236,11 @@ func ParseDateTime(ctx context.Context, env envs.Environment, args ...types.XVal
 //
 // @function datetime_from_epoch(seconds)
 func DateTimeFromEpoch(env envs.Environment, num *types.XNumber) types.XValue {
-	nanos := num.Native().Mul(nanosPerSecond).IntPart()
-	return types.NewXDateTime(time.Unix(0, nanos).In(env.Timezone()))
+	nanos, err := num.Mul(nanosPerSecond)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return types.NewXDateTime(time.Unix(0, nanos.IntPart()).In(env.Timezone()))
 }
 
 // DateTimeDiff returns the duration between `date1` and `date2` in the `unit` specified.
@@ -1377,8 +1405,11 @@ func TZOffset(env envs.Environment, date *types.XDateTime) types.XValue {
 //
 // @function epoch(date)
 func Epoch(env envs.Environment, date *types.XDateTime) types.XValue {
-	nanos := decimal.New(date.Native().UnixNano(), 0)
-	return types.NewXNumber(nanos.Div(nanosPerSecond))
+	seconds, err := types.NewXNumberFromInt64(date.Native().UnixNano()).Div(nanosPerSecond)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return seconds
 }
 
 // Now returns the current date and time in the current timezone.
@@ -1658,17 +1689,21 @@ func Sort(env envs.Environment, array *types.XArray) types.XValue {
 //
 // @function sum(array)
 func Sum(env envs.Environment, array *types.XArray) types.XValue {
-	total := decimal.Zero
+	total := types.XNumberZero
 	for i := 0; i < array.Count(); i++ {
 		itemAsNum, xerr := types.ToXNumber(env, array.Get(i))
 		if xerr != nil {
 			return xerr
 		}
 
-		total = total.Add(itemAsNum.Native())
+		var err error
+		total, err = total.Add(itemAsNum)
+		if err != nil {
+			return types.NewXError(err)
+		}
 	}
 
-	return types.NewXNumber(total)
+	return total
 }
 
 // Unique returns the unique values in `array`.
@@ -2348,18 +2383,18 @@ func LegacyAdd(env envs.Environment, arg1 types.XValue, arg2 types.XValue) types
 
 	// date and int, do a day addition
 	if date1Err == nil && dec2Err == nil {
-		if dec2.Native().IntPart() < math.MinInt32 || dec2.Native().IntPart() > math.MaxInt32 {
+		if dec2.IntPart() < math.MinInt32 || dec2.IntPart() > math.MaxInt32 {
 			return types.NewXErrorf("cannot operate on integers greater than 32 bit")
 		}
-		return types.NewXDateTime(date1.Native().AddDate(0, 0, int(dec2.Native().IntPart())))
+		return types.NewXDateTime(date1.Native().AddDate(0, 0, int(dec2.IntPart())))
 	}
 
 	// int and date, do a day addition
 	if date2Err == nil && dec1Err == nil {
-		if dec1.Native().IntPart() < math.MinInt32 || dec1.Native().IntPart() > math.MaxInt32 {
+		if dec1.IntPart() < math.MinInt32 || dec1.IntPart() > math.MaxInt32 {
 			return types.NewXErrorf("cannot operate on integers greater than 32 bit")
 		}
-		return types.NewXDateTime(date2.Native().AddDate(0, 0, int(dec1.Native().IntPart())))
+		return types.NewXDateTime(date2.Native().AddDate(0, 0, int(dec1.IntPart())))
 	}
 
 	// one of these doesn't look like a valid decimal either, bail
@@ -2372,7 +2407,11 @@ func LegacyAdd(env envs.Environment, arg1 types.XValue, arg2 types.XValue) types
 	}
 
 	// normal decimal addition
-	return types.NewXNumber(dec1.Native().Add(dec2.Native()))
+	sum, err := dec1.Add(dec2)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return sum
 }
 
 // ReadChars converts `text` into something that can be read by IVR systems.

--- a/excellent/operators/builtin.go
+++ b/excellent/operators/builtin.go
@@ -48,7 +48,7 @@ var NotEqual = textualBinary("!=", func(env envs.Environment, text1 *types.XText
 //
 // @operator negate "- (unary)"
 var Negate = numericalUnary("-", func(env envs.Environment, num *types.XNumber) types.XValue {
-	return types.NewXNumber(num.Native().Neg())
+	return num.Neg()
 })
 
 // Add adds two numbers.
@@ -58,7 +58,11 @@ var Negate = numericalUnary("-", func(env envs.Environment, num *types.XNumber) 
 //
 // @operator add "+"
 var Add = numericalBinary("+", func(env envs.Environment, num1 *types.XNumber, num2 *types.XNumber) types.XValue {
-	return types.NewXNumber(num1.Native().Add(num2.Native()))
+	sum, err := num1.Add(num2)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return sum
 })
 
 // Subtract subtracts two numbers.
@@ -68,7 +72,11 @@ var Add = numericalBinary("+", func(env envs.Environment, num1 *types.XNumber, n
 //
 // @operator subtract "- (binary)"
 var Subtract = numericalBinary("-", func(env envs.Environment, num1 *types.XNumber, num2 *types.XNumber) types.XValue {
-	return types.NewXNumber(num1.Native().Sub(num2.Native()))
+	diff, err := num1.Sub(num2)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return diff
 })
 
 // Multiply multiplies two numbers.
@@ -78,7 +86,11 @@ var Subtract = numericalBinary("-", func(env envs.Environment, num1 *types.XNumb
 //
 // @operator multiply "*"
 var Multiply = numericalBinary("*", func(env envs.Environment, num1 *types.XNumber, num2 *types.XNumber) types.XValue {
-	return types.NewXNumber(num1.Native().Mul(num2.Native()))
+	product, err := num1.Mul(num2)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return product
 })
 
 // Divide divides a number by another.
@@ -90,11 +102,11 @@ var Multiply = numericalBinary("*", func(env envs.Environment, num1 *types.XNumb
 //
 // @operator divide "/"
 var Divide = numericalBinary("/", func(env envs.Environment, num1 *types.XNumber, num2 *types.XNumber) types.XValue {
-	if num2.Equals(types.XNumberZero) {
-		return types.NewXErrorf("division by zero")
+	quotient, err := num1.Div(num2)
+	if err != nil {
+		return types.NewXError(err)
 	}
-
-	return types.NewXNumber(num1.Native().Div(num2.Native()))
+	return quotient
 })
 
 // Exponent raises a number to the power of a another number.
@@ -104,7 +116,11 @@ var Divide = numericalBinary("/", func(env envs.Environment, num1 *types.XNumber
 //
 // @operator exponent "^"
 var Exponent = numericalBinary("^", func(env envs.Environment, num1 *types.XNumber, num2 *types.XNumber) types.XValue {
-	return types.NewXNumber(num1.Native().Pow(num2.Native()))
+	result, err := num1.Pow(num2)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return result
 })
 
 // LessThan returns true if the first number is less than the second.

--- a/excellent/types/number.go
+++ b/excellent/types/number.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/shopspring/decimal"
 )
@@ -58,6 +59,11 @@ func NewXNumberFromInt(value int) *XNumber {
 // NewXNumberFromInt64 creates a new XNumber from the given int
 func NewXNumberFromInt64(value int64) *XNumber {
 	return newXNumber(decimal.New(value, 0))
+}
+
+// RandomXNumber creates a new random XNumber in the range [0, 1)
+func RandomXNumber() *XNumber {
+	return newXNumber(random.Decimal())
 }
 
 // RequireXNumberFromString creates a new XNumber from the given string or panics (used for tests)
@@ -132,6 +138,102 @@ func (x *XNumber) Compare(o XValue) int {
 	other := o.(*XNumber)
 
 	return x.Native().Cmp(other.Native())
+}
+
+// Add returns the sum of this number and the given number, or an error if the result is out of range
+func (x *XNumber) Add(o *XNumber) (*XNumber, error) {
+	return checkedXNumber(x.native.Add(o.native))
+}
+
+// Sub returns the difference of this number and the given number, or an error if the result is out of range
+func (x *XNumber) Sub(o *XNumber) (*XNumber, error) {
+	return checkedXNumber(x.native.Sub(o.native))
+}
+
+// Mul returns the product of this number and the given number, or an error if the result is out of range
+func (x *XNumber) Mul(o *XNumber) (*XNumber, error) {
+	return checkedXNumber(x.native.Mul(o.native))
+}
+
+// Div returns this number divided by the given number, or an error if the divisor is zero or the
+// result is out of range
+func (x *XNumber) Div(o *XNumber) (*XNumber, error) {
+	if o.native.IsZero() {
+		return nil, errors.New("division by zero")
+	}
+	return checkedXNumber(x.native.Div(o.native))
+}
+
+// Mod returns the remainder of the division of this number by the given number, or an error if the
+// divisor is zero or the result is out of range
+func (x *XNumber) Mod(o *XNumber) (*XNumber, error) {
+	if o.native.IsZero() {
+		return nil, errors.New("division by zero")
+	}
+	return checkedXNumber(x.native.Mod(o.native))
+}
+
+// Pow returns this number raised to the power of the given number, or an error if the result is out of range
+func (x *XNumber) Pow(o *XNumber) (*XNumber, error) {
+	return checkedXNumber(x.native.Pow(o.native))
+}
+
+// Neg returns the negation of this number
+func (x *XNumber) Neg() *XNumber {
+	return newXNumber(x.native.Neg())
+}
+
+// Abs returns the absolute value of this number
+func (x *XNumber) Abs() *XNumber {
+	return newXNumber(x.native.Abs())
+}
+
+// Floor returns the nearest integer value less than or equal to this number
+func (x *XNumber) Floor() *XNumber {
+	return newXNumber(x.native.Floor())
+}
+
+// IntPart returns the integer component of this number as an int64
+func (x *XNumber) IntPart() int64 {
+	return x.native.IntPart()
+}
+
+// Round rounds this number to the given number of decimal places. If places < 0 it will round the
+// integer part to the nearest 10^(-places). Returns an error if the result is out of range.
+func (x *XNumber) Round(places int) (*XNumber, error) {
+	return checkedXNumber(x.native.Round(int32(places)))
+}
+
+// RoundUp rounds this number up (towards positive infinity) to the given number of decimal places.
+// Returns an error if the result is out of range.
+func (x *XNumber) RoundUp(places int) (*XNumber, error) {
+	if x.native.Round(int32(places)).Equal(x.native) {
+		return x, nil
+	}
+
+	halfPrecision := decimal.New(5, -int32(places)-1)
+
+	return checkedXNumber(x.native.Add(halfPrecision).Round(int32(places)))
+}
+
+// RoundDown rounds this number down (towards negative infinity) to the given number of decimal places.
+// Returns an error if the result is out of range.
+func (x *XNumber) RoundDown(places int) (*XNumber, error) {
+	if x.native.Round(int32(places)).Equal(x.native) {
+		return x, nil
+	}
+
+	halfPrecision := decimal.New(5, -int32(places)-1)
+
+	return checkedXNumber(x.native.Sub(halfPrecision).Round(int32(places)))
+}
+
+// creates a new XNumber from the result of an arithmetic operation, checking that it is in range
+func checkedXNumber(d decimal.Decimal) (*XNumber, error) {
+	if err := CheckDecimalRange(d); err != nil {
+		return nil, errors.New("number value out of range")
+	}
+	return newXNumber(d), nil
 }
 
 // MarshalJSON is called when a struct containing this type is marshaled

--- a/excellent/types/number_test.go
+++ b/excellent/types/number_test.go
@@ -107,6 +107,16 @@ func TestXNumberArithmetic(t *testing.T) {
 	_, err = num("2").Pow(num("400"))
 	assert.EqualError(t, err, "number value out of range")
 
+	maxMagnitude := num("1" + strings.Repeat("0", 100))                  // 1E100
+	_, err = maxMagnitude.Div(num("0." + strings.Repeat("0", 49) + "1")) // 1E100 / 1E-50 = 1E150
+	assert.EqualError(t, err, "number value out of range")
+	_, err = num("5" + strings.Repeat("0", 100)).Round(-101) // rounds up to 1E101
+	assert.EqualError(t, err, "number value out of range")
+	_, err = num("5" + strings.Repeat("0", 100)).RoundUp(-101)
+	assert.EqualError(t, err, "number value out of range")
+	_, err = num("5" + strings.Repeat("0", 100)).Neg().RoundDown(-101)
+	assert.EqualError(t, err, "number value out of range")
+
 	// division by zero
 	_, err = num("3").Div(types.XNumberZero)
 	assert.EqualError(t, err, "division by zero")
@@ -169,11 +179,11 @@ func TestCheckDecimalRange(t *testing.T) {
 		{decimal.New(1, 0), false},
 		{decimal.New(-1, 0), false},
 		{decimal.New(123, 0), false},
-		{decimal.RequireFromString("123456789012345678901234567890123456"), false},                  // 36 significant digits - ok
-		{decimal.RequireFromString("1234567890123456789012345678901234567"), true},                 // 37 significant digits - too many
-		{decimal.RequireFromString("-1234567890123456789012345678901234567"), true},                // negative 37 significant digits
-		{decimal.RequireFromString("1234567895171680000000000000000000000000"), false},             // 40 digits but only 15 significant - ok
-		{decimal.RequireFromString("12345678901234567890123456789012345670000000"), true},          // 37 significant digits with trailing zeros
+		{decimal.RequireFromString("123456789012345678901234567890123456"), false},        // 36 significant digits - ok
+		{decimal.RequireFromString("1234567890123456789012345678901234567"), true},        // 37 significant digits - too many
+		{decimal.RequireFromString("-1234567890123456789012345678901234567"), true},       // negative 37 significant digits
+		{decimal.RequireFromString("1234567895171680000000000000000000000000"), false},    // 40 digits but only 15 significant - ok
+		{decimal.RequireFromString("12345678901234567890123456789012345670000000"), true}, // 37 significant digits with trailing zeros
 		{decimal.RequireFromString("0.000000000000000000000000000000000001"), false},
 		{decimal.New(1, 100), false}, // 1E100 - ok magnitude
 		{decimal.New(1, 200), true},  // 1E200 - too large magnitude

--- a/excellent/types/number_test.go
+++ b/excellent/types/number_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nyaruka/gocommon/jsonx"
@@ -57,6 +58,65 @@ func TestXNumber(t *testing.T) {
 	assert.False(t, types.IsXError(types.NewXNumber(decimal.New(1, 50))))             // within range
 	assert.False(t, types.IsXError(types.NewXNumber(decimal.New(1, -50))))            // within range
 	assert.False(t, types.IsXError(types.NewXNumber(decimal.RequireFromString("0")))) // zero always ok
+}
+
+func TestXNumberArithmetic(t *testing.T) {
+	num := types.RequireXNumberFromString
+
+	// checked operations that succeed
+	checkedTests := []struct {
+		op       func() (*types.XNumber, error)
+		expected string
+	}{
+		{func() (*types.XNumber, error) { return num("2").Add(num("3")) }, "5"},
+		{func() (*types.XNumber, error) { return num("2").Sub(num("3")) }, "-1"},
+		{func() (*types.XNumber, error) { return num("2.5").Mul(num("4")) }, "10"},
+		{func() (*types.XNumber, error) { return num("3").Div(num("2")) }, "1.5"},
+		{func() (*types.XNumber, error) { return num("5").Mod(num("2")) }, "1"},
+		{func() (*types.XNumber, error) { return num("2").Pow(num("8")) }, "256"},
+		{func() (*types.XNumber, error) { return num("12.146").Round(2) }, "12.15"},
+		{func() (*types.XNumber, error) { return num("12.146").Round(-1) }, "10"},
+		{func() (*types.XNumber, error) { return num("12.141").RoundUp(2) }, "12.15"},
+		{func() (*types.XNumber, error) { return num("12.15").RoundUp(2) }, "12.15"},
+		{func() (*types.XNumber, error) { return num("-12.141").RoundUp(2) }, "-12.14"},
+		{func() (*types.XNumber, error) { return num("12.146").RoundDown(2) }, "12.14"},
+		{func() (*types.XNumber, error) { return num("12.14").RoundDown(2) }, "12.14"},
+		{func() (*types.XNumber, error) { return num("-12.146").RoundDown(2) }, "-12.15"},
+	}
+	for i, tc := range checkedTests {
+		result, err := tc.op()
+		assert.NoError(t, err, "unexpected error for test %d", i)
+		assert.Equal(t, tc.expected, result.Render(), "result mismatch for test %d", i)
+	}
+
+	// unchecked operations
+	assert.Equal(t, num("-2").Native(), num("2").Neg().Native())
+	assert.Equal(t, num("2").Native(), num("-2").Abs().Native())
+	assert.Equal(t, num("2").Native(), num("2.7").Floor().Native())
+	assert.Equal(t, num("-3").Native(), num("-2.7").Floor().Native())
+	assert.Equal(t, int64(12), num("12.146").IntPart())
+
+	// checked operations that fail
+	maxDigits := num(strings.Repeat("9", 36)) // maximum number of significant digits
+	_, err := maxDigits.Add(maxDigits)
+	assert.EqualError(t, err, "number value out of range")
+	_, err = maxDigits.Neg().Sub(maxDigits)
+	assert.EqualError(t, err, "number value out of range")
+	_, err = maxDigits.Mul(num("1" + strings.Repeat("0", 66))) // ~9.99E101 exceeds max magnitude
+	assert.EqualError(t, err, "number value out of range")
+	_, err = num("2").Pow(num("400"))
+	assert.EqualError(t, err, "number value out of range")
+
+	// division by zero
+	_, err = num("3").Div(types.XNumberZero)
+	assert.EqualError(t, err, "division by zero")
+	_, err = num("3").Mod(types.XNumberZero)
+	assert.EqualError(t, err, "division by zero")
+
+	// random numbers are in [0, 1)
+	r := types.RandomXNumber()
+	assert.True(t, r.Compare(types.XNumberZero) >= 0)
+	assert.True(t, r.Compare(types.NewXNumberFromInt(1)) < 0)
 }
 
 func TestToXNumberAndInteger(t *testing.T) {

--- a/flows/routers/cases/tests.go
+++ b/flows/routers/cases/tests.go
@@ -16,8 +16,6 @@ import (
 	"github.com/nyaruka/goflow/excellent/functions"
 	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/utils"
-
-	"github.com/shopspring/decimal"
 )
 
 //------------------------------------------------------------------------------------------
@@ -804,7 +802,7 @@ func hasOnlyPhraseTest(env envs.Environment, hays []string, pins []string) types
 // Numerical Test Functions
 //------------------------------------------------------------------------------------------
 
-type decimalTest func(value decimal.Decimal, test1 decimal.Decimal, test2 decimal.Decimal) bool
+type numberTest func(value *types.XNumber, test1 *types.XNumber, test2 *types.XNumber) bool
 
 // compiled number finding regexes, cached by number format so that we don't recompile on every evaluation
 var numberPatterns sync.Map
@@ -826,7 +824,7 @@ func numberPattern(nf *envs.NumberFormat) (*regexp.Regexp, error) {
 	return pattern, nil
 }
 
-func testNumber(env envs.Environment, str *types.XText, testNum1 *types.XNumber, testNum2 *types.XNumber, testFunc decimalTest) types.XValue {
+func testNumber(env envs.Environment, str *types.XText, testNum1 *types.XNumber, testNum2 *types.XNumber, testFunc numberTest) types.XValue {
 	// get a number finding regex based on current environment
 	pattern, err := numberPattern(env.NumberFormat())
 	if err != nil {
@@ -835,10 +833,10 @@ func testNumber(env envs.Environment, str *types.XText, testNum1 *types.XNumber,
 
 	// look for number like things in the input and use the first one that we can actually parse
 	for _, value := range pattern.FindAllString(str.Native(), -1) {
-		num, err := ParseDecimal(value, env.NumberFormat())
+		num, err := ParseNumber(value, env.NumberFormat())
 		if err == nil {
-			if testFunc(num, testNum1.Native(), testNum2.Native()) {
-				return NewTrueResult(types.NewXNumber(num))
+			if testFunc(num, testNum1, testNum2) {
+				return NewTrueResult(num)
 			}
 		}
 	}
@@ -846,32 +844,32 @@ func testNumber(env envs.Environment, str *types.XText, testNum1 *types.XNumber,
 	return FalseResult
 }
 
-func isNumberTest(value decimal.Decimal, _ decimal.Decimal, _ decimal.Decimal) bool {
+func isNumberTest(value *types.XNumber, _ *types.XNumber, _ *types.XNumber) bool {
 	return true
 }
 
-func isNumberLT(value decimal.Decimal, test decimal.Decimal, _ decimal.Decimal) bool {
-	return value.Cmp(test) < 0
+func isNumberLT(value *types.XNumber, test *types.XNumber, _ *types.XNumber) bool {
+	return value.Compare(test) < 0
 }
 
-func isNumberLTE(value decimal.Decimal, test decimal.Decimal, _ decimal.Decimal) bool {
-	return value.Cmp(test) <= 0
+func isNumberLTE(value *types.XNumber, test *types.XNumber, _ *types.XNumber) bool {
+	return value.Compare(test) <= 0
 }
 
-func isNumberEQ(value decimal.Decimal, test decimal.Decimal, _ decimal.Decimal) bool {
-	return value.Cmp(test) == 0
+func isNumberEQ(value *types.XNumber, test *types.XNumber, _ *types.XNumber) bool {
+	return value.Compare(test) == 0
 }
 
-func isNumberGTE(value decimal.Decimal, test decimal.Decimal, _ decimal.Decimal) bool {
-	return value.Cmp(test) >= 0
+func isNumberGTE(value *types.XNumber, test *types.XNumber, _ *types.XNumber) bool {
+	return value.Compare(test) >= 0
 }
 
-func isNumberGT(value decimal.Decimal, test decimal.Decimal, _ decimal.Decimal) bool {
-	return value.Cmp(test) > 0
+func isNumberGT(value *types.XNumber, test *types.XNumber, _ *types.XNumber) bool {
+	return value.Compare(test) > 0
 }
 
-func isNumberBetween(value decimal.Decimal, test1 decimal.Decimal, test2 decimal.Decimal) bool {
-	return value.Cmp(test1) >= 0 && value.Cmp(test2) <= 0
+func isNumberBetween(value *types.XNumber, test1 *types.XNumber, test2 *types.XNumber) bool {
+	return value.Compare(test1) >= 0 && value.Compare(test2) <= 0
 }
 
 //------------------------------------------------------------------------------------------

--- a/flows/routers/cases/utils.go
+++ b/flows/routers/cases/utils.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent/types"
-
-	"github.com/shopspring/decimal"
 )
 
 var altNumerals = map[rune]rune{
@@ -55,8 +53,8 @@ func numeralMapper(r rune) rune {
 	return r
 }
 
-// ParseDecimal parses a decimal from a string
-func ParseDecimal(val string, format *envs.NumberFormat) (decimal.Decimal, error) {
+// ParseNumber parses a number from a string
+func ParseNumber(val string, format *envs.NumberFormat) (*types.XNumber, error) {
 	cleaned := strings.TrimSpace(val)
 
 	// remove digit grouping symbol
@@ -70,9 +68,5 @@ func ParseDecimal(val string, format *envs.NumberFormat) (decimal.Decimal, error
 
 	// parse with the same format restrictions (no scientific notation) and range limits as numbers
 	// elsewhere in the engine
-	n, err := types.NewXNumberFromString(cleaned)
-	if err != nil {
-		return decimal.Zero, err
-	}
-	return n.Native(), nil
+	return types.NewXNumberFromString(cleaned)
 }

--- a/flows/routers/cases/utils_test.go
+++ b/flows/routers/cases/utils_test.go
@@ -4,54 +4,54 @@ import (
 	"testing"
 
 	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows/routers/cases"
 
-	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseDecimal(t *testing.T) {
-	dec := decimal.RequireFromString
+func TestParseNumber(t *testing.T) {
+	num := types.RequireXNumberFromString
 	spaFormat := &envs.NumberFormat{DecimalSymbol: ",", DigitGroupingSymbol: "."}
 
 	parseTests := []struct {
 		input    string
-		expected decimal.Decimal
+		expected *types.XNumber
 		format   *envs.NumberFormat
 	}{
-		{"1", dec("1"), envs.DefaultNumberFormat},
-		{"1234", dec("1234"), envs.DefaultNumberFormat},
-		{"1,234.567", dec("1234.567"), envs.DefaultNumberFormat},
-		{"1.234,567", dec("1234.567"), spaFormat},
-		{".1234", dec("0.1234"), envs.DefaultNumberFormat},
-		{" .1234 ", dec("0.1234"), envs.DefaultNumberFormat},
-		{"100.00", dec("100.00"), envs.DefaultNumberFormat},
+		{"1", num("1"), envs.DefaultNumberFormat},
+		{"1234", num("1234"), envs.DefaultNumberFormat},
+		{"1,234.567", num("1234.567"), envs.DefaultNumberFormat},
+		{"1.234,567", num("1234.567"), spaFormat},
+		{".1234", num("0.1234"), envs.DefaultNumberFormat},
+		{" .1234 ", num("0.1234"), envs.DefaultNumberFormat},
+		{"100.00", num("100.00"), envs.DefaultNumberFormat},
 
 		// Eastern Arabic
-		{"١", dec("1"), envs.DefaultNumberFormat},
-		{"١٢٣٤", dec("1234"), envs.DefaultNumberFormat},
-		{"١,٢٣٤.٥٦٧", dec("1234.567"), envs.DefaultNumberFormat},
-		{"١.٢٣٤,٥٦٧", dec("1234.567"), spaFormat},
-		{"٠.٨٩", dec("0.89"), envs.DefaultNumberFormat},
-		{".١٢٣٤", dec("0.1234"), envs.DefaultNumberFormat},
+		{"١", num("1"), envs.DefaultNumberFormat},
+		{"١٢٣٤", num("1234"), envs.DefaultNumberFormat},
+		{"١,٢٣٤.٥٦٧", num("1234.567"), envs.DefaultNumberFormat},
+		{"١.٢٣٤,٥٦٧", num("1234.567"), spaFormat},
+		{"٠.٨٩", num("0.89"), envs.DefaultNumberFormat},
+		{".١٢٣٤", num("0.1234"), envs.DefaultNumberFormat},
 
 		// Bengali
-		{"১,২৩৪.৫৬৭", dec("1234.567"), envs.DefaultNumberFormat},
-		{"০.৮৯", dec("0.89"), envs.DefaultNumberFormat},
+		{"১,২৩৪.৫৬৭", num("1234.567"), envs.DefaultNumberFormat},
+		{"০.৮৯", num("0.89"), envs.DefaultNumberFormat},
 	}
 
 	for _, test := range parseTests {
-		val, err := cases.ParseDecimal(test.input, test.format)
+		val, err := cases.ParseNumber(test.input, test.format)
 
 		assert.NoError(t, err)
-		assert.Equal(t, test.expected, val, "parse decimal failed for input '%s'", test.input)
+		assert.Equal(t, test.expected, val, "parse number failed for input '%s'", test.input)
 	}
 
 	// test that oversized numbers are rejected
-	_, err := cases.ParseDecimal("1234567890123456789012345678901234567", envs.DefaultNumberFormat)
+	_, err := cases.ParseNumber("1234567890123456789012345678901234567", envs.DefaultNumberFormat)
 	assert.EqualError(t, err, "number has too many digits")
 
 	// test that scientific notation is rejected
-	_, err = cases.ParseDecimal("1e10", envs.DefaultNumberFormat)
+	_, err = cases.ParseNumber("1e10", envs.DefaultNumberFormat)
 	assert.EqualError(t, err, "not a valid number format")
 }

--- a/flows/routers/random.go
+++ b/flows/routers/random.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 
 	"github.com/nyaruka/gocommon/jsonx"
-	"github.com/nyaruka/gocommon/random"
 	"github.com/nyaruka/goflow/core/events"
+	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
-
-	"github.com/shopspring/decimal"
 )
 
 func init() {
@@ -38,12 +36,13 @@ func (r *Random) Validate(flow flows.Flow, exits []flows.Exit) error {
 // Route determines which exit to take from a node
 func (r *Random) Route(ctx context.Context, run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, string, error) {
 	// pick a random category
-	rand := random.Decimal()
-	categoryNum := rand.Mul(decimal.New(int64(len(r.categories)), 0)).IntPart()
+	rand := types.RandomXNumber()
+	scaled, _ := rand.Mul(types.NewXNumberFromInt(len(r.categories))) // rand < 1 so can't be out of range
+	categoryNum := scaled.IntPart()
 	categoryUUID := r.categories[categoryNum].UUID()
 
-	exit, err := r.routeToCategory(run, step, categoryUUID, fmt.Sprintf("%d", categoryNum), rand.String(), nil, logEvent)
-	return exit, rand.String(), err
+	exit, err := r.routeToCategory(run, step, categoryUUID, fmt.Sprintf("%d", categoryNum), rand.Render(), nil, logEvent)
+	return exit, rand.Render(), err
 }
 
 //------------------------------------------------------------------------------------------

--- a/flows/routers/random.go
+++ b/flows/routers/random.go
@@ -37,7 +37,10 @@ func (r *Random) Validate(flow flows.Flow, exits []flows.Exit) error {
 func (r *Random) Route(ctx context.Context, run flows.Run, step flows.Step, logEvent events.EventLogger) (flows.ExitUUID, string, error) {
 	// pick a random category
 	rand := types.RandomXNumber()
-	scaled, _ := rand.Mul(types.NewXNumberFromInt(len(r.categories))) // rand < 1 so can't be out of range
+	scaled, err := rand.Mul(types.NewXNumberFromInt(len(r.categories)))
+	if err != nil {
+		return "", "", err
+	}
 	categoryNum := scaled.IntPart()
 	categoryUUID := r.categories[categoryNum].UUID()
 


### PR DESCRIPTION
Reduces the surface area that the external decimal library (shopspring/decimal) touches, so a future library swap would be confined to essentially the `excellent/types` package.

## Changes

* Adds arithmetic and utility methods to `types.XNumber` (`Add`, `Sub`, `Mul`, `Div`, `Mod`, `Pow`, `Neg`, `Abs`, `Floor`, `IntPart`, `Round`, `RoundUp`, `RoundDown`, and a `RandomXNumber` constructor). Every operation that can grow a value out of range does the range check itself (36 significant digits, magnitude within 1E±100), so the overflow invariant is enforced centrally instead of relying on every call site remembering to wrap results in `NewXNumber`.
* Converts the decimal unwrap/re-wrap call sites in `excellent/functions`, `excellent/operators` and `flows/routers` to use those methods.
* Makes contactql speak `*types.XNumber` instead of `decimal.Decimal`: `Condition.ValueAsNumber()`, the `Queryable` contract for number properties (and its implementations in `core`), the evaluator's number comparisons, and the values embedded in elastic queries. `XNumber` marshals as a bare JSON number so generated elastic queries are unchanged (covered by the existing JSON fixture tests).
* Renames `cases.ParseDecimal` to `cases.ParseNumber`, returning `*types.XNumber`, and converts the number test plumbing in `flows/routers/cases` accordingly.

Note that contactql now imports `excellent/types` directly - that package has no ANTLR dependency so the light-contactql split is preserved (verified via `go list -deps`).

Minor behavior improvements from centralizing the checks: intermediate results in `mean`/`sum`/`rand_between` are now range checked like the equivalent operator chains already were, `percent`/`datetime_from_epoch` on absurdly large inputs now return an error instead of garbage from int64 truncation, and `mod` by zero returns an error instead of panicking.

Deliberately left for follow-up: switching airtime transfer amounts (`map[string]decimal.Decimal`) to `XNumber`, and a CI guard restricting which packages may import shopspring/decimal. Legacy flow definition migrations also keep their decimal usage.