### PR TITLE
Bound exponent and rounding places against unbounded expression work

### DIFF
--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -600,18 +600,23 @@ func TestFunctions(t *testing.T) {
 		{"round", dmy, []types.XValue{xs("not_num"), xs("1")}, ERROR},
 		{"round", dmy, []types.XValue{xs("10.5"), xs("not_num")}, ERROR},
 		{"round", dmy, []types.XValue{xs("10.5"), xs("1"), xs("30")}, ERROR},
+		{"round", dmy, []types.XValue{xn("123.456"), xi(1000)}, xn("123.456")},       // places beyond the value's precision is a no-op
+		{"round", dmy, []types.XValue{xn("123.456"), xi(2000000000)}, xn("123.456")}, // pathological places is clamped, value unchanged
+		{"round", dmy, []types.XValue{xn("123.456"), xi(-2000000000)}, xi(0)},        // pathological places is clamped, rounds to zero
 
 		{"round_down", dmy, []types.XValue{xs("10")}, xi(10)},
 		{"round_down", dmy, []types.XValue{xs("10.5")}, xi(10)},
 		{"round_down", dmy, []types.XValue{xs("10.7")}, xi(10)},
 		{"round_down", dmy, []types.XValue{xs("not_num")}, ERROR},
 		{"round_down", dmy, []types.XValue{}, ERROR},
+		{"round_down", dmy, []types.XValue{xn("1.5"), xi(2000000000)}, xn("1.5")}, // pathological places is clamped, value unchanged
 
 		{"round_up", dmy, []types.XValue{xs("10")}, xi(10)},
 		{"round_up", dmy, []types.XValue{xs("10.5")}, xi(11)},
 		{"round_up", dmy, []types.XValue{xs("10.2")}, xi(11)},
 		{"round_up", dmy, []types.XValue{xs("not_num")}, ERROR},
 		{"round_up", dmy, []types.XValue{}, ERROR},
+		{"round_up", dmy, []types.XValue{xn("1.5"), xi(2000000000)}, xn("1.5")}, // pathological places is clamped, value unchanged
 
 		{"slice", dmy, []types.XValue{xa(xs("a"), xs("b"), xs("c")), xi(0), xi(2)}, xa(xs("a"), xs("b"))},
 		{"slice", dmy, []types.XValue{xa(xs("a"), xs("b"), xs("c")), xi(1), xi(3)}, xa(xs("b"), xs("c"))},

--- a/excellent/operators/builtin_test.go
+++ b/excellent/operators/builtin_test.go
@@ -2,6 +2,7 @@ package operators_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/nyaruka/goflow/envs"
@@ -73,7 +74,11 @@ func TestBinaryOperators(t *testing.T) {
 		{operators.Exponent, xn("2"), xn("32.000"), xn("4294967296")},
 		{operators.Exponent, xn("9"), xn("0.5"), xn("3")},
 		{operators.Exponent, xn("4"), xn("2.5"), xn("32")},
-		{operators.Exponent, xn("2"), xn("400"), ERROR}, // overflow
+		{operators.Exponent, xn("2"), xn("400"), ERROR},                               // overflow
+		{operators.Exponent, xn("10"), xn("100"), xn("1" + strings.Repeat("0", 100))}, // largest exponent allowed
+		{operators.Exponent, xi(2), xn("101"), ERROR},                                 // exponent above the magnitude limit
+		{operators.Exponent, xi(1), xn("101"), ERROR},                                 // limit applies even to a base that couldn't overflow
+		{operators.Exponent, xi(2), xn("1000000000"), ERROR},                          // huge exponent rejected before computing
 		{operators.Exponent, ERROR, xi(1), ERROR},
 		{operators.Exponent, xi(1), ERROR, ERROR},
 

--- a/excellent/types/number.go
+++ b/excellent/types/number.go
@@ -19,6 +19,24 @@ var decimalRegexp = regexp.MustCompile(`^-?(([0-9]+)|([0-9]+\.[0-9]+)|(\.[0-9]+)
 // MaxNumberDigits is the maximum number of significant digits in a number
 const MaxNumberDigits = 36
 
+// maxRoundPlaces bounds the places argument to Round, RoundUp and RoundDown. Numbers are limited to
+// MaxNumberDigits significant digits and a magnitude of ±1E100, so rounding to more (or fewer negative)
+// places than this can never change a representable value - but shopspring's rescale allocates a 10^places
+// big.Int, so a pathological places value like 2 billion would allocate hundreds of megabytes first.
+// Clamping to this range leaves every valid result unchanged whilst keeping the allocation tiny.
+const maxRoundPlaces = 1_000
+
+// clampRoundPlaces bounds a rounding places argument to ±maxRoundPlaces.
+func clampRoundPlaces(places int) int {
+	return min(max(places, -maxRoundPlaces), maxRoundPlaces)
+}
+
+// maxExponentMagnitude is the largest magnitude allowed for an exponent passed to Pow. A number can't exceed
+// ±1E100, so raising anything to a larger power can only ever produce an out-of-range result - and computing
+// it first would burn CPU and memory that grow exponentially with the exponent. This is a templating engine,
+// not a calculator, so exponents are held to the same magnitude limit as numbers themselves.
+var maxExponentMagnitude = decimal.New(100, 0)
+
 func init() {
 	decimal.MarshalJSONWithoutQuotes = true
 }
@@ -173,8 +191,15 @@ func (x *XNumber) Mod(o *XNumber) (*XNumber, error) {
 	return checkedXNumber(x.native.Mod(o.native))
 }
 
-// Pow returns this number raised to the power of the given number, or an error if the result is out of range
+// Pow returns this number raised to the power of the given number, or an error if the exponent is too large
+// or the result is out of range. The exponent is bounded because raising to a power grows the result - and
+// shopspring's intermediate values - exponentially with the exponent, so a large exponent burns huge amounts
+// of CPU and memory before the result's range is ever checked.
 func (x *XNumber) Pow(o *XNumber) (*XNumber, error) {
+	if o.native.Abs().GreaterThan(maxExponentMagnitude) {
+		return nil, errors.New("number value out of range")
+	}
+
 	return checkedXNumber(x.native.Pow(o.native))
 }
 
@@ -201,12 +226,14 @@ func (x *XNumber) IntPart() int64 {
 // Round rounds this number to the given number of decimal places. If places < 0 it will round the
 // integer part to the nearest 10^(-places). Returns an error if the result is out of range.
 func (x *XNumber) Round(places int) (*XNumber, error) {
+	places = clampRoundPlaces(places)
 	return checkedXNumber(x.native.Round(int32(places)))
 }
 
 // RoundUp rounds this number up (towards positive infinity) to the given number of decimal places.
 // Returns an error if the result is out of range.
 func (x *XNumber) RoundUp(places int) (*XNumber, error) {
+	places = clampRoundPlaces(places)
 	if x.native.Round(int32(places)).Equal(x.native) {
 		return x, nil
 	}
@@ -219,6 +246,7 @@ func (x *XNumber) RoundUp(places int) (*XNumber, error) {
 // RoundDown rounds this number down (towards negative infinity) to the given number of decimal places.
 // Returns an error if the result is out of range.
 func (x *XNumber) RoundDown(places int) (*XNumber, error) {
+	places = clampRoundPlaces(places)
 	if x.native.Round(int32(places)).Equal(x.native) {
 		return x, nil
 	}

--- a/excellent/types/number_test.go
+++ b/excellent/types/number_test.go
@@ -82,6 +82,10 @@ func TestXNumberArithmetic(t *testing.T) {
 		{func() (*types.XNumber, error) { return num("12.146").RoundDown(2) }, "12.14"},
 		{func() (*types.XNumber, error) { return num("12.14").RoundDown(2) }, "12.14"},
 		{func() (*types.XNumber, error) { return num("-12.146").RoundDown(2) }, "-12.15"},
+		{func() (*types.XNumber, error) { return num("10").Pow(num("100")) }, "1" + strings.Repeat("0", 100)}, // 1E100, largest exponent allowed
+		{func() (*types.XNumber, error) { return num("123.456").Round(2000000000) }, "123.456"},               // pathological places clamped, value unchanged
+		{func() (*types.XNumber, error) { return num("1.5").RoundUp(2000000000) }, "1.5"},                     //
+		{func() (*types.XNumber, error) { return num("1.5").RoundDown(2000000000) }, "1.5"},                   //
 	}
 	for i, tc := range checkedTests {
 		result, err := tc.op()
@@ -105,6 +109,12 @@ func TestXNumberArithmetic(t *testing.T) {
 	_, err = maxDigits.Mul(num("1" + strings.Repeat("0", 66))) // ~9.99E101 exceeds max magnitude
 	assert.EqualError(t, err, "number value out of range")
 	_, err = num("2").Pow(num("400"))
+	assert.EqualError(t, err, "number value out of range")
+	_, err = num("10").Pow(num("101")) // exponent above the magnitude limit
+	assert.EqualError(t, err, "number value out of range")
+	_, err = num("1").Pow(num("101")) // limit applies even to a base that couldn't overflow
+	assert.EqualError(t, err, "number value out of range")
+	_, err = num("2").Pow(num("1000000000")) // huge exponent rejected before the costly computation
 	assert.EqualError(t, err, "number value out of range")
 
 	maxMagnitude := num("1" + strings.Repeat("0", 100))                  // 1E100


### PR DESCRIPTION
Expressions are evaluated from flow definitions and can embed untrusted text, so their cost must stay bounded regardless of the arguments they contain. Two paths were driven by the *value* of a small numeric argument rather than by input length, so the per-evaluation cost budget - which charges only after a value is produced - never bounded them:

- **`^` with a large exponent.** `x ^ n` computed the full power before the result was range-checked. Since a number can be written with a magnitude up to ~1E100, an expression like `2 ^ 100000000` spent tens of seconds and hundreds of megabytes building a result that was then rejected as out of range.
- **`round` / `round_up` / `round_down` with large `places`.** The `places` argument (up to ~2.1 billion) flowed into the decimal library's rescale, which allocates a `10^places` big.Int - hundreds of megabytes to gigabytes - before returning.

## Fix

Both guards live in `XNumber` (`excellent/types/number.go`), alongside the arithmetic they protect:

- `Pow` rejects any exponent whose magnitude exceeds **100** before computing. This is a templating engine, not a calculator, so exponents are held to the same ±1E100 magnitude limit as numbers themselves - any result needing a larger exponent would be out of range anyway. `10 ^ 100` (the largest representable number) still works; `10 ^ 101` and up error.
- `Round`, `RoundUp` and `RoundDown` clamp `places` to ±1000. Numbers carry at most 36 significant digits within a magnitude of ±1E100 (so ~135 fractional places at the extreme), so this clamp changes no representable result - it only caps the `10^places` allocation.

The exponent limit is uniform: it applies even to bases that could not overflow, so `1 ^ 2000000000` now errors rather than returning `1`. The only inputs affected by either change are pathological ones.

Tests added for the operator, the builtin functions, and the `XNumber` methods directly.