### PR TITLE
Harden legacy flow migration against crafted definitions

### DIFF
--- a/flows/actions/add_contact_urn.go
+++ b/flows/actions/add_contact_urn.go
@@ -41,7 +41,7 @@ type AddContactURN struct {
 	universalAction
 
 	Scheme string `json:"scheme" validate:"urnscheme"`
-	Path   string `json:"path" validate:"required" engine:"evaluated"`
+	Path   string `json:"path" validate:"required,max=1000" engine:"evaluated"`
 }
 
 // NewAddContactURN creates a new add URN action

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -205,11 +205,11 @@ func (a *voiceAction) AllowedFlowTypes() []flows.FlowType {
 
 // utility struct for actions which operate on other contacts
 type otherContactsAction struct {
-	Groups       []*assets.GroupReference `json:"groups,omitempty" validate:"dive"`
-	Contacts     []*core.ContactReference `json:"contacts,omitempty" validate:"dive"`
-	ContactQuery string                   `json:"contact_query,omitempty" engine:"evaluated"`
-	URNs         []urns.URN               `json:"urns,omitempty"`
-	LegacyVars   []string                 `json:"legacy_vars,omitempty" engine:"evaluated"`
+	Groups       []*assets.GroupReference `json:"groups,omitempty" validate:"max=100,dive"`
+	Contacts     []*core.ContactReference `json:"contacts,omitempty" validate:"max=100,dive"`
+	ContactQuery string                   `json:"contact_query,omitempty" validate:"max=10000" engine:"evaluated"`
+	URNs         []urns.URN               `json:"urns,omitempty" validate:"max=100"`
+	LegacyVars   []string                 `json:"legacy_vars,omitempty" validate:"max=100,dive,max=1000" engine:"evaluated"`
 }
 
 func (a *otherContactsAction) Inspect(dependency func(assets.Reference), local func(string), result func(*flows.ResultInfo)) {
@@ -283,7 +283,7 @@ type createMsgAction struct {
 	Attachments       []string                  `json:"attachments,omitempty"      validate:"max=10,dive,attachment" engine:"localized,evaluated"`
 	QuickReplies      []string                  `json:"quick_replies,omitempty"    validate:"max=10,dive,max=1000"   engine:"localized,evaluated"`
 	Template          *assets.TemplateReference `json:"template,omitempty"`
-	TemplateVariables []string                  `json:"template_variables,omitempty" engine:"evaluated"`
+	TemplateVariables []string                  `json:"template_variables,omitempty" validate:"max=100,dive,max=10000" engine:"evaluated"`
 }
 
 func (a *createMsgAction) Inspect(dependency func(assets.Reference), local func(string), result func(*flows.ResultInfo)) {

--- a/flows/actions/call_llm.go
+++ b/flows/actions/call_llm.go
@@ -43,8 +43,8 @@ type CallLLM struct {
 	onlineAction
 
 	LLM          *assets.LLMReference `json:"llm"          validate:"required"`
-	Instructions string               `json:"instructions" validate:"required"            engine:"evaluated"`
-	Input        string               `json:"input"                                       engine:"evaluated"`
+	Instructions string               `json:"instructions" validate:"required,max=10000"  engine:"evaluated"`
+	Input        string               `json:"input"        validate:"max=10000"           engine:"evaluated"`
 	OutputLocal  string               `json:"output_local" validate:"required,local_ref"`
 }
 

--- a/flows/actions/call_resthook.go
+++ b/flows/actions/call_resthook.go
@@ -70,7 +70,7 @@ type CallResthook struct {
 	baseAction
 	onlineAction
 
-	Resthook   string `json:"resthook"              validate:"required"`
+	Resthook   string `json:"resthook"              validate:"required,max=1000"`
 	ResultName string `json:"result_name,omitempty" validate:"omitempty,result_name"`
 }
 

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -58,7 +58,7 @@ type CallWebhook struct {
 
 	Method     string            `json:"method"                                   validate:"required,http_method"`
 	URL        string            `json:"url"                   engine:"evaluated" validate:"required,max=2048"`
-	Headers    map[string]string `json:"headers,omitempty"     engine:"evaluated" validate:"max=100,dive,max=1000"`
+	Headers    map[string]string `json:"headers,omitempty"     engine:"evaluated" validate:"max=100,dive,keys,max=100,endkeys,max=1000"`
 	Body       string            `json:"body,omitempty"        engine:"evaluated" validate:"max=10000"`
 	ResultName string            `json:"result_name,omitempty"                    validate:"omitempty,result_name"`
 }

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -57,9 +57,9 @@ type CallWebhook struct {
 	onlineAction
 
 	Method     string            `json:"method"                                   validate:"required,http_method"`
-	URL        string            `json:"url"                   engine:"evaluated" validate:"required"`
-	Headers    map[string]string `json:"headers,omitempty"     engine:"evaluated"`
-	Body       string            `json:"body,omitempty"        engine:"evaluated"`
+	URL        string            `json:"url"                   engine:"evaluated" validate:"required,max=2048"`
+	Headers    map[string]string `json:"headers,omitempty"     engine:"evaluated" validate:"max=100,dive,max=1000"`
+	Body       string            `json:"body,omitempty"        engine:"evaluated" validate:"max=10000"`
 	ResultName string            `json:"result_name,omitempty"                    validate:"omitempty,result_name"`
 }
 

--- a/flows/actions/play_audio.go
+++ b/flows/actions/play_audio.go
@@ -32,7 +32,7 @@ type PlayAudio struct {
 	baseAction
 	voiceAction
 
-	AudioURL string `json:"audio_url" validate:"required" engine:"localized,evaluated"`
+	AudioURL string `json:"audio_url" validate:"required,max=2048" engine:"localized,evaluated"`
 }
 
 // NewPlayAudio creates a new play message action

--- a/flows/actions/set_run_result.go
+++ b/flows/actions/set_run_result.go
@@ -37,7 +37,7 @@ type SetRunResult struct {
 	universalAction
 
 	Name     string `json:"name"                                  validate:"required,result_name"`
-	Value    string `json:"value"              engine:"evaluated"`
+	Value    string `json:"value"              engine:"evaluated" validate:"max=10000"`
 	Category string `json:"category,omitempty" engine:"localized" validate:"omitempty,result_category"`
 }
 

--- a/flows/actions/testdata/call_webhook.json
+++ b/flows/actions/testdata/call_webhook.json
@@ -10,6 +10,20 @@
         "read_error": "field 'method' is required"
     },
     {
+        "description": "Read fails if a header name is too long",
+        "action": {
+            "type": "call_webhook",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "method": "POST",
+            "url": "http://temba.io/",
+            "body": "Hi there!",
+            "headers": {
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "something"
+            }
+        },
+        "read_error": "field 'headers[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]' must be less than or equal to 100"
+    },
+    {
         "description": "Read fails if header name is invalid",
         "action": {
             "type": "call_webhook",

--- a/flows/actions/testdata/transfer_airtime.json
+++ b/flows/actions/testdata/transfer_airtime.json
@@ -1,5 +1,16 @@
 [
     {
+        "description": "Read error if an amount is out of the permitted range",
+        "action": {
+            "type": "transfer_airtime",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "amounts": {
+                "USD": 1e999
+            }
+        },
+        "read_error": "number value is out of permitted range"
+    },
+    {
         "description": "Error and failed transfer if contact has no tel urn",
         "contact": {
             "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -3,11 +3,13 @@ package actions
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/events"
+	"github.com/nyaruka/goflow/excellent/types"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/shopspring/decimal"
 )
@@ -40,7 +42,19 @@ type TransferAirtime struct {
 	baseAction
 	onlineAction
 
-	Amounts map[string]decimal.Decimal `json:"amounts" validate:"required"`
+	Amounts map[string]decimal.Decimal `json:"amounts" validate:"required,max=100"`
+}
+
+// Validate validates our action is valid
+func (a *TransferAirtime) Validate() error {
+	// bound the magnitude of each amount - an untrusted definition could otherwise carry a decimal
+	// like 1E999999999 which is cheap to parse but expensive to do arithmetic with
+	for currency, amount := range a.Amounts {
+		if err := types.CheckDecimalRange(amount); err != nil {
+			return fmt.Errorf("amount for '%s' is out of range: %w", currency, err)
+		}
+	}
+	return nil
 }
 
 // NewTransferAirtime creates a new airtime transfer action

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -333,6 +333,13 @@ func readFlow(data []byte, mc *migrations.Config, a assets.Flow) (flows.Flow, er
 		mc = migrations.DefaultConfig
 	}
 
+	// reject flows with too many nodes before migrating - migration re-reads and re-marshals the entire
+	// definition once per version step, so this avoids doing that expensive work for a definition that
+	// will be rejected by validation anyway
+	if err := checkFlowSize(data); err != nil {
+		return nil, err
+	}
+
 	var err error
 	data, err = migrations.MigrateToLatest(data, mc)
 	if err != nil {
@@ -361,6 +368,29 @@ func readFlow(data []byte, mc *migrations.Config, a assets.Flow) (flows.Flow, er
 	}
 
 	return NewFlow(e.UUID, e.Name, e.Language, e.Type, e.Revision, time.Duration(e.ExpireAfterMinutes)*time.Minute, e.Localization, nodes, e.UI, a)
+}
+
+// checkFlowSize does a shallow parse of a flow definition (current or legacy format) and returns an error
+// if it contains more nodes than are allowed. It counts array elements without decoding their contents, so
+// it's cheap relative to the full parse and migration that follow.
+func checkFlowSize(data []byte) error {
+	shallow := &struct {
+		Nodes      []json.RawMessage `json:"nodes"`
+		ActionSets []json.RawMessage `json:"action_sets"` // legacy definitions
+		RuleSets   []json.RawMessage `json:"rule_sets"`   // legacy definitions
+	}{}
+
+	// ignore errors - a malformed definition will be rejected with a better error further down
+	if err := jsonx.Unmarshal(data, shallow); err != nil {
+		return nil
+	}
+
+	numNodes := len(shallow.Nodes) + len(shallow.ActionSets) + len(shallow.RuleSets)
+	if numNodes > flows.MaxNodesPerFlow {
+		return fmt.Errorf("flow can't have more than %d nodes (has %d)", flows.MaxNodesPerFlow, numNodes)
+	}
+
+	return nil
 }
 
 // MarshalJSON marshals this flow into JSON

--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/buger/jsonparser"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/uuids"
@@ -370,22 +371,19 @@ func readFlow(data []byte, mc *migrations.Config, a assets.Flow) (flows.Flow, er
 	return NewFlow(e.UUID, e.Name, e.Language, e.Type, e.Revision, time.Duration(e.ExpireAfterMinutes)*time.Minute, e.Localization, nodes, e.UI, a)
 }
 
-// checkFlowSize does a shallow parse of a flow definition (current or legacy format) and returns an error
-// if it contains more nodes than are allowed. It counts array elements without decoding their contents, so
-// it's cheap relative to the full parse and migration that follow.
+// checkFlowSize counts the nodes in a flow definition (current or legacy format) and returns an error if
+// there are more than are allowed. It walks only the relevant arrays without decoding their contents or the
+// rest of the definition, so it's cheap relative to the full parse and migration that follow. Malformed or
+// duplicated input can only make it under-count, so it never rejects a flow that would otherwise be valid -
+// the authoritative check remains the post-migration validation.
 func checkFlowSize(data []byte) error {
-	shallow := &struct {
-		Nodes      []json.RawMessage `json:"nodes"`
-		ActionSets []json.RawMessage `json:"action_sets"` // legacy definitions
-		RuleSets   []json.RawMessage `json:"rule_sets"`   // legacy definitions
-	}{}
+	numNodes := 0
+	countElement := func([]byte, jsonparser.ValueType, int, error) { numNodes++ }
 
-	// ignore errors - a malformed definition will be rejected with a better error further down
-	if err := jsonx.Unmarshal(data, shallow); err != nil {
-		return nil
-	}
+	jsonparser.ArrayEach(data, countElement, "nodes")       // current format
+	jsonparser.ArrayEach(data, countElement, "action_sets") // legacy format
+	jsonparser.ArrayEach(data, countElement, "rule_sets")   // legacy format
 
-	numNodes := len(shallow.Nodes) + len(shallow.ActionSets) + len(shallow.RuleSets)
 	if numNodes > flows.MaxNodesPerFlow {
 		return fmt.Errorf("flow can't have more than %d nodes (has %d)", flows.MaxNodesPerFlow, numNodes)
 	}

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -537,6 +537,19 @@ func TestReadFlow(t *testing.T) {
 	assert.Nil(t, flow.Asset())
 }
 
+func TestReadFlowSizeGuard(t *testing.T) {
+	// an over-sized legacy definition is rejected up front, before the expensive migration passes, by
+	// counting its action_sets and rule_sets
+	ruleSets := make([]string, flows.MaxNodesPerFlow+1)
+	for i := range ruleSets {
+		ruleSets[i] = "{}"
+	}
+	legacyDef := fmt.Sprintf(`{"flow_type":"M","base_language":"eng","metadata":{"uuid":"8ca44c09-791d-453a-9799-a70dd3303306","name":"x"},"action_sets":[],"rule_sets":[%s]}`, strings.Join(ruleSets, ","))
+
+	_, err := definition.ReadFlow([]byte(legacyDef), nil)
+	assert.EqualError(t, err, fmt.Sprintf("flow can't have more than %d nodes (has %d)", flows.MaxNodesPerFlow, flows.MaxNodesPerFlow+1))
+}
+
 func TestExtractTemplatesAndLocalizables(t *testing.T) {
 	env := envs.NewBuilder().Build()
 

--- a/flows/definition/legacy/definition.go
+++ b/flows/definition/legacy/definition.go
@@ -536,6 +536,9 @@ func migrateRuleSet(lang i18n.Language, r RuleSet, validDests map[uuids.UUID]boo
 
 	switch r.Type {
 	case "subflow":
+		if config.Flow == nil {
+			return nil, "", nil, fmt.Errorf("subflow ruleset has no flow in its config")
+		}
 		flowRef := assets.NewFlowReference(assets.FlowUUID(config.Flow.UUID), config.Flow.Name)
 
 		newActions = []migratedAction{

--- a/flows/definition/legacy/definition_test.go
+++ b/flows/definition/legacy/definition_test.go
@@ -356,3 +356,29 @@ func TestMigrateDefinitionMalformed(t *testing.T) {
 		legacy.MigrateDefinition([]byte(def), "")
 	})
 }
+
+func TestMigrateDefinitionSubflowWithoutConfig(t *testing.T) {
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(123456, time.Now))
+
+	// a subflow ruleset with no config used to nil-deref config.Flow - it should now fail cleanly
+	def := `{
+		"base_language": "eng",
+		"flow_type": "M",
+		"version": "11.12",
+		"metadata": {"uuid": "50a9c0c0-0000-0000-0000-000000000001", "name": "L"},
+		"action_sets": [],
+		"rule_sets": [{
+			"uuid": "413868c6-f35b-4a1c-b80e-df0091568b59",
+			"label": "Subflow",
+			"ruleset_type": "subflow",
+			"operand": "",
+			"rules": [{"uuid": "22b5ef86-afad-41aa-8863-c167996083a6", "category": {"eng": "Other"}, "destination": null, "destination_type": null, "test": {"type": "true"}, "label": null}]
+		}]
+	}`
+
+	assert.NotPanics(t, func() {
+		_, err := legacy.MigrateDefinition([]byte(def), "")
+		assert.Error(t, err)
+	})
+}

--- a/flows/definition/legacy/expressions/migrate.go
+++ b/flows/definition/legacy/expressions/migrate.go
@@ -12,7 +12,13 @@ import (
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/utils"
 )
+
+// maxExpressionDepth is the maximum bracket nesting depth allowed in a legacy expression. Beyond this the
+// recursive-descent parser risks exhausting the goroutine stack, which is an unrecoverable fatal error, so
+// we reject over-nested expressions before parsing. Matches the limit enforced by the current parser.
+const maxExpressionDepth = 100
 
 // ContextTopLevels are the allowed top-level identifiers in legacy expressions, i.e. @contact.bar is valid but @foo.bar isn't
 var ContextTopLevels = []string{"channel", "child", "contact", "date", "extra", "flow", "parent", "step"}
@@ -111,6 +117,11 @@ func migrateLegacyTemplateAsString(template string, options *MigrateOptions) (st
 
 // migrates an old expression into a new format expression
 func migrateExpression(env envs.Environment, expression string, options *MigrateOptions) (string, error) {
+	// reject overly nested expressions before parsing to avoid a stack overflow
+	if utils.NestingDepthExceeds(expression, maxExpressionDepth) {
+		return "", fmt.Errorf("expression nesting too deep")
+	}
+
 	errListener := excellent.NewErrorListener(expression)
 
 	input := antlr.NewInputStream(expression)

--- a/flows/definition/legacy/expressions/migrate_test.go
+++ b/flows/definition/legacy/expressions/migrate_test.go
@@ -398,3 +398,13 @@ func TestMigrateStringLiteral(t *testing.T) {
 	assert.Equal(t, `"line1\nline2\ttabbed"`, expressions.MigrateStringLiteral(`"line1\nline2\ttabbed"`))
 	assert.Equal(t, `"\D\w+[\.*]"`, expressions.MigrateStringLiteral(`"\D\w+[\.*]"`))
 }
+
+func TestMigrateTemplateDeeplyNested(t *testing.T) {
+	// a deeply nested legacy expression would previously overflow the parser stack, which is an
+	// unrecoverable fatal error - it must now be rejected without migrating (or crashing)
+	deep := "@(" + strings.Repeat("(", 5000) + "1" + strings.Repeat(")", 5000) + ")"
+
+	migrated, err := expressions.MigrateTemplate(deep, nil)
+	assert.Error(t, err)
+	assert.Equal(t, deep, migrated, "over-nested expression should be left unmigrated")
+}

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -28,7 +28,7 @@ const TypeSwitch string = "switch"
 type Case struct {
 	UUID         uuids.UUID         `json:"uuid"                   validate:"required"`
 	Type         string             `json:"type"                   validate:"required"`
-	Arguments    []string           `json:"arguments,omitempty"    engine:"localized,evaluated"`
+	Arguments    []string           `json:"arguments,omitempty"    validate:"dive,max=10000" engine:"localized,evaluated"`
 	CategoryUUID flows.CategoryUUID `json:"category_uuid"          validate:"required"`
 }
 
@@ -237,7 +237,7 @@ func (r *Switch) EnumerateLocalizables(include func(uuids.UUID, string, []string
 type switchEnvelope struct {
 	baseEnvelope
 
-	Operand             string             `json:"operand"               validate:"required"`
+	Operand             string             `json:"operand"               validate:"required,max=10000"`
 	Cases               []*Case            `json:"cases"`
 	DefaultCategoryUUID flows.CategoryUUID `json:"default_category_uuid" validate:"omitempty,uuid"`
 }


### PR DESCRIPTION
## Summary

Hardening of flow definition handling, found during a security audit. Fixes two reachable crashes in the legacy (pre-13) migration path, plus a set of defense-in-depth size bounds. All with regression tests.

## High severity — legacy migration crashes

Both reachable from `definition.ReadFlow` → `migrations.MigrateToLatest` whenever an old-format flow is read/imported.

**1. Unrecoverable stack overflow from a deeply-nested legacy expression**

`migrateExpression` handed attacker-controlled expression strings (ruleset operands, webhook URLs/headers, test arguments, action fields, etc.) straight to the recursive-descent excellent1 parser with no nesting limit. An operand like `@((((…1…))))` with thousands of nested parens overflows the goroutine stack — a Go *fatal error* that `recover()` cannot catch, so a single crafted definition could crash the migrating process. The JSON depth limit does not help: the nesting lives inside a string field, not the JSON structure.

The current expression parser (`excellent.Parse`) and the contact query parser already reject over-nested input via `utils.NestingDepthExceeds`; the legacy migration parser was the one remaining unguarded ANTLR entry point. It now applies the same depth limit (100). Per-expression migration errors are already tolerated by the caller, so an over-nested expression is left unmigrated instead of crashing.

**2. Nil-pointer panic from a `subflow` ruleset with no config**

The `subflow` ruleset case dereferenced `config.Flow` (a pointer) which is nil whenever the ruleset has no `config` object. It now returns a clean error, consistent with the surrounding nil-config handling.

## Defense-in-depth size bounds

**3. Reject oversized definitions before migration.** `MaxNodesPerFlow` was only enforced during post-migration validation, so an oversized definition was fully migrated (re-read and re-marshalled once per version step — 14 passes from v13 to current) before being rejected. `readFlow` now counts nodes up front (via `jsonparser`, no full parse) for both current and legacy formats.

**4. Bound `transfer_airtime` amounts.** Each amount is now checked against the persistable decimal range (`CheckDecimalRange`) and the number of amounts is capped. A definition could otherwise carry a decimal like `1E999999999` that is cheap to parse but expensive to do arithmetic with.

**5. Add max lengths/counts to evaluated fields that had none.** Limits are generous and consistent with the existing capped fields (e.g. message text at 10000), so they bound abuse without rejecting realistic flows. Full list below.

### Limits introduced

All are new (the field previously had no cap) unless noted.

**Per-field string length caps (chars)**

| Action / router | JSON field | Limit |
|---|---|---|
| `call_llm` | `instructions` | 10000 |
| `call_llm` | `input` | 10000 |
| `call_webhook` | `url` | 2048 |
| `call_webhook` | `body` | 10000 |
| `call_webhook` | each header **name** | 100 |
| `call_webhook` | each header **value** | 1000 |
| `call_resthook` | `resthook` | 1000 |
| `add_contact_urn` | `path` | 1000 |
| `play_audio` | `audio_url` | 2048 |
| `set_run_result` | `value` | 10000 |
| `send_broadcast`, `start_session` | `contact_query` | 10000 |
| `send_broadcast`, `start_session` | each `legacy_vars` entry | 1000 |
| `send_msg`, `send_broadcast` | each `template_variables` entry | 10000 |
| switch router | `operand` | 10000 |
| switch router | each case `arguments` entry | 10000 |

**Per-field collection count caps (elements)**

| Action / router | JSON field | Limit |
|---|---|---|
| `call_webhook` | `headers` | 100 |
| `transfer_airtime` | `amounts` | 100 |
| `send_broadcast`, `start_session` | `groups` | 100 |
| `send_broadcast`, `start_session` | `contacts` | 100 |
| `send_broadcast`, `start_session` | `urns` | 100 |
| `send_broadcast`, `start_session` | `legacy_vars` | 100 |
| `send_msg`, `send_broadcast` | `template_variables` | 100 |

Case `arguments` count was already capped at 10 (`MaxArgumentsPerCase`, in code); the PR only adds the per-element length cap.

**Special (not plain length/count)**

| What | Rule | Notes |
|---|---|---|
| `transfer_airtime` `amounts` values | magnitude ≤ ±1e100, ≤36 significant digits (`CheckDecimalRange`) | Targets `1e999`-style values; won't reject real amounts |
| legacy expression nesting | bracket depth ≤ 100 | Legacy-migration path only — never runs on current-version flows |
| flow node count | ≤ 1000 (`MaxNodesPerFlow`) | Not new — same limit `validate()` always enforced, just checked before migration now |

## Tests

- `TestMigrateTemplateDeeplyNested` — over-nested legacy expression returns an error and is left unmigrated.
- `TestMigrateDefinitionSubflowWithoutConfig` — config-less `subflow` ruleset fails cleanly instead of panicking.
- `TestReadFlowSizeGuard` — an over-sized legacy definition is rejected up front.
- New `transfer_airtime` read-error case for an out-of-range amount, and a `call_webhook` read-error case for an over-long header name.

## Notes for reviewers

The modern definition/actions/routers path was audited and found robust (UUID-based references, enforced structural limits, RE2 regexes, JSON nesting-depth limit, guarded expression parser) — the crashes were specific to the legacy migration path. Items 3–5 are belt-and-suspenders on top of runtime protections (evaluation cost budget, output truncation) and caller-side request bounding.

**The `max=` additions are a read-time contract change** — they run on every `ReadFlow`, including stored flows loaded at runtime, so a definition exceeding a cap that was valid before is now rejected on read. The limits are set well above realistic content, but worth confirming against the stored-flow corpus before merge — the likeliest to hold legitimately-large values are `call_llm.instructions`, `call_webhook.body`/`url`, `set_run_result.value`, and `template_variables` entries.