### PR TITLE
Tighten bounds on transfer_airtime amounts

### DIFF
--- a/flows/actions/testdata/transfer_airtime.json
+++ b/flows/actions/testdata/transfer_airtime.json
@@ -11,6 +11,28 @@
         "read_error": "number value is out of permitted range"
     },
     {
+        "description": "Read error if an amount exceeds the maximum",
+        "action": {
+            "type": "transfer_airtime",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "amounts": {
+                "USD": 1e16
+            }
+        },
+        "read_error": "amount for 'USD' is out of range"
+    },
+    {
+        "description": "Read error if an amount is negative",
+        "action": {
+            "type": "transfer_airtime",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "amounts": {
+                "USD": -1
+            }
+        },
+        "read_error": "amount for 'USD' is out of range"
+    },
+    {
         "description": "Error and failed transfer if contact has no tel urn",
         "contact": {
             "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -25,6 +25,9 @@ const (
 	TransferAirtimeOutputLocal = "_new_transfer"
 )
 
+// maximum allowed value for a single amount - generous enough for even hyperinflated currencies
+var maxAirtimeAmount = decimal.New(1, 15) // 1,000,000,000,000,000
+
 // TransferAirtime attempts to make an airtime transfer to the contact.
 //
 // An [event:airtime_created] event will be created if the airtime transfer could be initiated.
@@ -47,11 +50,16 @@ type TransferAirtime struct {
 
 // Validate validates our action is valid
 func (a *TransferAirtime) Validate() error {
-	// bound the magnitude of each amount - an untrusted definition could otherwise carry a decimal
-	// like 1E999999999 which is cheap to parse but expensive to do arithmetic with
+	// bound each amount - an untrusted definition could otherwise carry a decimal like
+	// 1E999999999 which is cheap to parse but expensive to do arithmetic with. The general
+	// range check comes first because comparing against such an extreme exponent is itself
+	// expensive.
 	for currency, amount := range a.Amounts {
 		if err := types.CheckDecimalRange(amount); err != nil {
 			return fmt.Errorf("amount for '%s' is out of range: %w", currency, err)
+		}
+		if amount.IsNegative() || amount.GreaterThan(maxAirtimeAmount) {
+			return fmt.Errorf("amount for '%s' is out of range", currency)
 		}
 	}
 	return nil


### PR DESCRIPTION
Follow-up to #1560's decimal range check: airtime amounts were only bounded to the general persistable decimal range (±1E100), which is far beyond any plausible currency amount. Amounts must now be non-negative and at most 1E15 — still an order of magnitude above the largest hyperinflation-era banknote ever issued.

Note for reviewers: the general `CheckDecimalRange` call stays as the first gate because comparing a decimal like `1E999999999` against the cap would force a rescale to a common exponent — the exact expensive operation being defended against. The cheap exponent-based check runs first, making the tight comparison safe.

Adds read-error test cases for an over-cap amount and a negative amount.