### PR TITLE
Return read errors instead of panicking when campaign and optin triggers have missing or mismatched events

### DIFF
--- a/flows/triggers/campaign.go
+++ b/flows/triggers/campaign.go
@@ -1,6 +1,8 @@
 package triggers
 
 import (
+	"fmt"
+
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
@@ -87,7 +89,11 @@ func readCampaign(sa flows.SessionAssets, data []byte, missing assets.MissingCal
 		return nil, err
 	}
 
-	campEvt := t.event.(*events.CampaignFired)
+	campEvt, ok := t.event.(*events.CampaignFired)
+	if !ok {
+		return nil, fmt.Errorf("campaign trigger event must be of type %s", events.TypeCampaignFired)
+	}
+
 	t.campaign = sa.Campaigns().Get(campEvt.Campaign.UUID)
 	if t.campaign == nil {
 		missing(campEvt.Campaign, nil)

--- a/flows/triggers/optin.go
+++ b/flows/triggers/optin.go
@@ -1,6 +1,8 @@
 package triggers
 
 import (
+	"fmt"
+
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
@@ -111,7 +113,7 @@ func readOptIn(sa flows.SessionAssets, data []byte, missing assets.MissingCallba
 	case *events.OptInStopped:
 		optInRef = typed.OptIn
 	default:
-		panic("optin trigger event must be of type optin_started or optin_stopped")
+		return nil, fmt.Errorf("optin trigger event must be of type %s or %s", events.TypeOptInStarted, events.TypeOptInStopped)
 	}
 
 	t.optIn = sa.OptIns().Get(optInRef.UUID)

--- a/flows/triggers/testdata/campaign.json
+++ b/flows/triggers/testdata/campaign.json
@@ -8,6 +8,39 @@
         "read_error": "field 'flow' is required"
     },
     {
+        "description": "event is required",
+        "trigger": {
+            "type": "campaign",
+            "flow": {
+                "uuid": "bead76f5-dac4-4c9d-996c-c62b326e8c0a",
+                "name": "Trigger Tester"
+            },
+            "triggered_on": "2000-01-01T00:00:00Z"
+        },
+        "read_error": "campaign trigger event must be of type campaign_fired"
+    },
+    {
+        "description": "event must be campaign_fired",
+        "trigger": {
+            "type": "campaign",
+            "event": {
+                "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+                "type": "chat_started",
+                "created_on": "2000-01-01T00:00:00Z",
+                "channel": {
+                    "uuid": "8cd472c4-bb85-459a-8c9a-c04708af799e",
+                    "name": "Facebook"
+                }
+            },
+            "flow": {
+                "uuid": "bead76f5-dac4-4c9d-996c-c62b326e8c0a",
+                "name": "Trigger Tester"
+            },
+            "triggered_on": "2000-01-01T00:00:00Z"
+        },
+        "read_error": "campaign trigger event must be of type campaign_fired"
+    },
+    {
         "description": "with all required fields",
         "trigger": {
             "type": "campaign",

--- a/flows/triggers/testdata/optin.json
+++ b/flows/triggers/testdata/optin.json
@@ -8,6 +8,39 @@
         "read_error": "field 'flow' is required"
     },
     {
+        "description": "event is required",
+        "trigger": {
+            "type": "optin",
+            "flow": {
+                "uuid": "bead76f5-dac4-4c9d-996c-c62b326e8c0a",
+                "name": "Trigger Tester"
+            },
+            "triggered_on": "2000-01-01T00:00:00Z"
+        },
+        "read_error": "optin trigger event must be of type optin_started or optin_stopped"
+    },
+    {
+        "description": "event must be optin_started or optin_stopped",
+        "trigger": {
+            "type": "optin",
+            "event": {
+                "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
+                "type": "chat_started",
+                "created_on": "2000-01-01T00:00:00Z",
+                "channel": {
+                    "uuid": "8cd472c4-bb85-459a-8c9a-c04708af799e",
+                    "name": "Facebook"
+                }
+            },
+            "flow": {
+                "uuid": "bead76f5-dac4-4c9d-996c-c62b326e8c0a",
+                "name": "Trigger Tester"
+            },
+            "triggered_on": "2000-01-01T00:00:00Z"
+        },
+        "read_error": "optin trigger event must be of type optin_started or optin_stopped"
+    },
+    {
         "description": "with all required fields",
         "trigger": {
             "type": "optin",


### PR DESCRIPTION
## Problem

`readCampaign` did an unchecked type assertion on the trigger's `event` field. That field is optional in the envelope (`json:"event,omitempty"`) and decoded generically, so a `campaign` trigger whose event was absent or of a different event type passed envelope validation and then panicked at the assertion. The optin trigger had the same reachable defect as an explicit `panic(...)` in its event type switch. Since triggers are re-read for every persisted session, a corrupted trigger blob became a process panic instead of a normal "unable to read trigger" error.

## Solution

Both triggers now use the guarded `, ok` assertion pattern already used by the msg and chat triggers, returning a descriptive read error when the event is missing or of the wrong type. Added data-driven `read_error` test cases for both trigger types covering an absent event and a wrong event type.
