### PR TITLE
Fix gofmt formatting in utils/text_test.go

### DIFF
--- a/utils/text_test.go
+++ b/utils/text_test.go
@@ -152,11 +152,11 @@ func TestIndent(t *testing.T) {
 func TestNestingDepthExceeds(t *testing.T) {
 	assert.False(t, utils.NestingDepthExceeds("", 5))
 	assert.False(t, utils.NestingDepthExceeds("no brackets here", 5))
-	assert.False(t, utils.NestingDepthExceeds("(((((", 5))     // depth 5, not > 5
+	assert.False(t, utils.NestingDepthExceeds("(((((", 5))        // depth 5, not > 5
 	assert.False(t, utils.NestingDepthExceeds("()()()()()()", 1)) // flat, max depth 1
 	assert.False(t, utils.NestingDepthExceeds("a[b].c{d}(e)", 1)) // mixed but shallow
-	assert.True(t, utils.NestingDepthExceeds("((((((", 5))     // depth 6
-	assert.True(t, utils.NestingDepthExceeds("([{([{", 5))     // mixed opening brackets, depth 6
+	assert.True(t, utils.NestingDepthExceeds("((((((", 5))        // depth 6
+	assert.True(t, utils.NestingDepthExceeds("([{([{", 5))        // mixed opening brackets, depth 6
 	// unbalanced closers don't push depth negative
 	assert.False(t, utils.NestingDepthExceeds("))))))((", 5))
 }


### PR DESCRIPTION
`utils/text_test.go` was not `gofmt`-formatted (comment alignment). This just applies `gofmt -w`; no behavior change.
