### PR TITLE
Validate input_collation when reading an environment

### DIFF
--- a/envs/environment.go
+++ b/envs/environment.go
@@ -119,7 +119,7 @@ type envEnvelope struct {
 	AllowedLanguages []i18n.Language `json:"allowed_languages,omitempty" validate:"omitempty,dive,language"`
 	NumberFormat     *NumberFormat   `json:"number_format,omitempty"`
 	DefaultCountry   i18n.Country    `json:"default_country,omitempty" validate:"omitempty,country"`
-	InputCollation   Collation       `json:"input_collation"`
+	InputCollation   Collation       `json:"input_collation" validate:"eq=default|eq=confusables|eq=arabic_variants"`
 	RedactionPolicy  RedactionPolicy `json:"redaction_policy" validate:"omitempty,eq=none|eq=urns"`
 	ObfuscationKey   [4]uint32       `json:"obfuscation_key"`
 }

--- a/envs/environment_test.go
+++ b/envs/environment_test.go
@@ -36,6 +36,21 @@ func TestEnvironmentMarshaling(t *testing.T) {
 	_, err = envs.ReadEnvironment([]byte(`{"date_format": "DD-MM-YYYY", "time_format": "tttttt", "timezone": "Cuenca"}`))
 	assert.Error(t, err)
 
+	// can't create with invalid input collation
+	_, err = envs.ReadEnvironment([]byte(`{"date_format": "DD-MM-YYYY", "time_format": "tt:mm", "input_collation": "bogus"}`))
+	assert.Error(t, err)
+
+	// or an empty input collation
+	_, err = envs.ReadEnvironment([]byte(`{"date_format": "DD-MM-YYYY", "time_format": "tt:mm", "input_collation": ""}`))
+	assert.Error(t, err)
+
+	// but can create with any valid input collation
+	for _, col := range []envs.Collation{envs.CollationDefault, envs.CollationConfusables, envs.CollationArabicVariants} {
+		env, err := envs.ReadEnvironment([]byte(`{"date_format": "DD-MM-YYYY", "time_format": "tt:mm", "input_collation": "` + string(col) + `"}`))
+		assert.NoError(t, err)
+		assert.Equal(t, col, env.InputCollation())
+	}
+
 	// empty environment uses all defaults
 	env, err := envs.ReadEnvironment([]byte(`{}`))
 	assert.NoError(t, err)


### PR DESCRIPTION
## Problem

The `input_collation` environment field had no `validate` tag (unlike its sibling enum fields such as `redaction_policy`), so `ReadEnvironment` accepted any value. The first text comparison then looked up a collation transformer that didn't exist and invoked a nil function — a nil pointer panic triggered by data that passed validation.

## Solution

The field is now validated with the same inline `eq=` alternation mechanism used by `redaction_policy`, restricted to the three defined collations. An empty value is also rejected (it would hit the same nil transformer), while an absent field remains fine because the envelope is pre-filled from builder defaults. Tests cover rejection of unknown and empty values and round-tripping of all three valid collations.
