### PR TITLE
Fix silent int64 wraparound when converting expression numbers to ints

### DIFF
--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -24,15 +24,6 @@ import (
 var nanosPerSecond = types.NewXNumberFromInt64(1000000000)
 var nonPrintableRegex = regexp.MustCompile(`[\p{Cc}\p{C}]`)
 
-var minInt64Number = types.NewXNumberFromInt64(math.MinInt64)
-var maxInt64Number = types.NewXNumberFromInt64(math.MaxInt64)
-
-// fitsInInt64 returns whether the integer part of the given number can be represented as an int64 - expression
-// numbers permit up to 36 digits so .IntPart() can otherwise silently wrap around.
-func fitsInInt64(num *types.XNumber) bool {
-	return num.Compare(minInt64Number) >= 0 && num.Compare(maxInt64Number) <= 0
-}
-
 // maxRepeatOutput caps the number of characters that repeat() will build in a single call, to avoid a large
 // transient allocation from an attacker-controlled count (the per-evaluation budget bounds cost across calls,
 // but only after each value is built). Matches the default limit on an evaluated template.
@@ -915,12 +906,13 @@ func Percent(env envs.Environment, num *types.XNumber) types.XValue {
 	if err != nil {
 		return types.NewXError(err)
 	}
-	if !fitsInInt64(percent) {
+	asInt, ok := percent.Int64()
+	if !ok {
 		return types.NewXErrorf("percentage value is out of range")
 	}
 
 	// add on a %
-	return types.NewXText(fmt.Sprintf("%d%%", percent.IntPart()))
+	return types.NewXText(fmt.Sprintf("%d%%", asInt))
 }
 
 // URLEncode encodes `text` for use as a URL parameter.
@@ -1252,10 +1244,11 @@ func DateTimeFromEpoch(env envs.Environment, num *types.XNumber) types.XValue {
 	if err != nil {
 		return types.NewXError(err)
 	}
-	if !fitsInInt64(nanos) {
+	asInt, ok := nanos.Int64()
+	if !ok {
 		return types.NewXErrorf("epoch time is out of range")
 	}
-	return types.NewXDateTime(time.Unix(0, nanos.IntPart()).In(env.Timezone()))
+	return types.NewXDateTime(time.Unix(0, asInt).In(env.Timezone()))
 }
 
 // DateTimeDiff returns the duration between `date1` and `date2` in the `unit` specified.
@@ -2405,18 +2398,20 @@ func LegacyAdd(env envs.Environment, arg1 types.XValue, arg2 types.XValue) types
 
 	// date and int, do a day addition
 	if date1Err == nil && dec2Err == nil {
-		if dec2.IntPart() < math.MinInt32 || dec2.IntPart() > math.MaxInt32 {
+		days, ok := dec2.Int64()
+		if !ok || days < math.MinInt32 || days > math.MaxInt32 {
 			return types.NewXErrorf("cannot operate on integers greater than 32 bit")
 		}
-		return types.NewXDateTime(date1.Native().AddDate(0, 0, int(dec2.IntPart())))
+		return types.NewXDateTime(date1.Native().AddDate(0, 0, int(days)))
 	}
 
 	// int and date, do a day addition
 	if date2Err == nil && dec1Err == nil {
-		if dec1.IntPart() < math.MinInt32 || dec1.IntPart() > math.MaxInt32 {
+		days, ok := dec1.Int64()
+		if !ok || days < math.MinInt32 || days > math.MaxInt32 {
 			return types.NewXErrorf("cannot operate on integers greater than 32 bit")
 		}
-		return types.NewXDateTime(date2.Native().AddDate(0, 0, int(dec1.IntPart())))
+		return types.NewXDateTime(date2.Native().AddDate(0, 0, int(days)))
 	}
 
 	// one of these doesn't look like a valid decimal either, bail

--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -24,6 +24,15 @@ import (
 var nanosPerSecond = types.NewXNumberFromInt64(1000000000)
 var nonPrintableRegex = regexp.MustCompile(`[\p{Cc}\p{C}]`)
 
+var minInt64Number = types.NewXNumberFromInt64(math.MinInt64)
+var maxInt64Number = types.NewXNumberFromInt64(math.MaxInt64)
+
+// fitsInInt64 returns whether the integer part of the given number can be represented as an int64 - expression
+// numbers permit up to 36 digits so .IntPart() can otherwise silently wrap around.
+func fitsInInt64(num *types.XNumber) bool {
+	return num.Compare(minInt64Number) >= 0 && num.Compare(maxInt64Number) <= 0
+}
+
 // maxRepeatOutput caps the number of characters that repeat() will build in a single call, to avoid a large
 // transient allocation from an attacker-controlled count (the per-evaluation budget bounds cost across calls,
 // but only after each value is built). Matches the default limit on an evaluated template.
@@ -906,6 +915,9 @@ func Percent(env envs.Environment, num *types.XNumber) types.XValue {
 	if err != nil {
 		return types.NewXError(err)
 	}
+	if !fitsInInt64(percent) {
+		return types.NewXErrorf("percentage value is out of range")
+	}
 
 	// add on a %
 	return types.NewXText(fmt.Sprintf("%d%%", percent.IntPart()))
@@ -1240,6 +1252,9 @@ func DateTimeFromEpoch(env envs.Environment, num *types.XNumber) types.XValue {
 	if err != nil {
 		return types.NewXError(err)
 	}
+	if !fitsInInt64(nanos) {
+		return types.NewXErrorf("epoch time is out of range")
+	}
 	return types.NewXDateTime(time.Unix(0, nanos.IntPart()).In(env.Timezone()))
 }
 
@@ -1405,11 +1420,18 @@ func TZOffset(env envs.Environment, date *types.XDateTime) types.XValue {
 //
 // @function epoch(date)
 func Epoch(env envs.Environment, date *types.XDateTime) types.XValue {
-	seconds, err := types.NewXNumberFromInt64(date.Native().UnixNano()).Div(nanosPerSecond)
+	// calculate whole seconds and the fractional part separately because UnixNano is only defined for
+	// dates between the years 1678 and 2262 and silently wraps outside that range
+	seconds := types.NewXNumberFromInt64(date.Native().Unix())
+	fraction, err := types.NewXNumberFromInt(date.Native().Nanosecond()).Div(nanosPerSecond)
 	if err != nil {
 		return types.NewXError(err)
 	}
-	return seconds
+	epoch, err := seconds.Add(fraction)
+	if err != nil {
+		return types.NewXError(err)
+	}
+	return epoch
 }
 
 // Now returns the current date and time in the current timezone.

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -225,6 +225,10 @@ func TestFunctions(t *testing.T) {
 		{"datetime_diff", mdy, []types.XValue{xs("03-10-2019 1:00am"), xs("03-11-2019 1:00am"), xs("D")}, xi(1)},
 
 		{"datetime_from_epoch", dmy, []types.XValue{xn("1497286619.000000000")}, xdt(time.Date(2017, 6, 12, 16, 56, 59, 0, time.UTC))},
+		{"datetime_from_epoch", dmy, []types.XValue{xn("-1000000000")}, xdt(time.Date(1938, 4, 24, 22, 13, 20, 0, time.UTC))},
+		{"datetime_from_epoch", dmy, []types.XValue{xn("10000000000000")}, ERROR},                       // out of range for time.Unix
+		{"datetime_from_epoch", dmy, []types.XValue{xn("-10000000000000")}, ERROR},                      // out of range for time.Unix
+		{"datetime_from_epoch", dmy, []types.XValue{xn("123456789012345678901234567890123456")}, ERROR}, // out of range for time.Unix
 		{"datetime_from_epoch", dmy, []types.XValue{ERROR}, ERROR},
 		{"datetime_from_epoch", dmy, []types.XValue{}, ERROR},
 
@@ -273,6 +277,10 @@ func TestFunctions(t *testing.T) {
 		{"extract_object", dmy, []types.XValue{}, ERROR},
 
 		{"epoch", dmy, []types.XValue{xdt(time.Date(2017, 6, 12, 16, 56, 59, 0, time.UTC))}, xn("1497286619")},
+		{"epoch", dmy, []types.XValue{xdt(time.Date(2017, 6, 12, 16, 56, 59, 123456789, time.UTC))}, xn("1497286619.123456789")},
+		{"epoch", dmy, []types.XValue{xdt(time.Date(1969, 12, 31, 23, 59, 59, 500000000, time.UTC))}, xn("-0.5")},
+		{"epoch", dmy, []types.XValue{xdt(time.Date(1500, 1, 1, 0, 0, 0, 0, time.UTC))}, xn("-14831769600")}, // out of range for UnixNano
+		{"epoch", dmy, []types.XValue{xdt(time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))}, xn("32503680000")},  // out of range for UnixNano
 		{"epoch", dmy, []types.XValue{ERROR}, ERROR},
 		{"epoch", dmy, []types.XValue{}, ERROR},
 
@@ -509,6 +517,9 @@ func TestFunctions(t *testing.T) {
 
 		{"percent", dmy, []types.XValue{xs(".54")}, xs("54%")},
 		{"percent", dmy, []types.XValue{xs("1.246")}, xs("125%")},
+		{"percent", dmy, []types.XValue{xn("92233720368547758.07")}, xs("9223372036854775807%")}, // max int64
+		{"percent", dmy, []types.XValue{xn("123456789012345678901")}, ERROR},                     // out of range for int64
+		{"percent", dmy, []types.XValue{xn("-123456789012345678901")}, ERROR},                    // out of range for int64
 		{"percent", dmy, []types.XValue{xs("")}, ERROR},
 		{"percent", dmy, []types.XValue{}, ERROR},
 

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -438,6 +438,8 @@ func TestFunctions(t *testing.T) {
 		{"legacy_add", dmy, []types.XValue{xs("01-12-2017 10:15:33pm"), xs("01-12-2017")}, ERROR},
 		{"legacy_add", dmy, []types.XValue{types.NewXNumberFromInt64(int64(math.MaxInt32 + 1)), xs("01-12-2017 10:15:33pm")}, ERROR},
 		{"legacy_add", dmy, []types.XValue{xs("01-12-2017 10:15:33pm"), types.NewXNumberFromInt64(int64(math.MaxInt32 + 1))}, ERROR},
+		{"legacy_add", dmy, []types.XValue{xn("18446744073709551618"), xs("01-12-2017 10:15:33pm")}, ERROR}, // 2^64 + 2, would wrap to 2 days as an int64
+		{"legacy_add", dmy, []types.XValue{xs("01-12-2017 10:15:33pm"), xn("18446744073709551618")}, ERROR},
 		{"legacy_add", dmy, []types.XValue{xs("xxx"), xs("10")}, ERROR},
 		{"legacy_add", dmy, []types.XValue{xs("10"), xs("xxx")}, ERROR},
 		{"legacy_add", dmy, []types.XValue{}, ERROR},

--- a/excellent/types/number.go
+++ b/excellent/types/number.go
@@ -224,9 +224,16 @@ func (x *XNumber) Floor() *XNumber {
 	return newXNumber(x.native.Floor())
 }
 
-// IntPart returns the integer component of this number as an int64
-func (x *XNumber) IntPart() int64 {
-	return x.native.IntPart()
+var minInt64 = decimal.NewFromInt(math.MinInt64)
+var maxInt64 = decimal.NewFromInt(math.MaxInt64)
+
+// Int64 returns the integer component of this number as an int64, or false if the number is outside the
+// range of int64 - expression numbers permit up to 36 digits and decimal.IntPart() silently wraps around.
+func (x *XNumber) Int64() (int64, bool) {
+	if x.native.Cmp(minInt64) < 0 || x.native.Cmp(maxInt64) > 0 {
+		return 0, false
+	}
+	return x.native.IntPart(), true
 }
 
 // Round rounds this number to the given number of decimal places. If places < 0 it will round the
@@ -366,9 +373,9 @@ func ToInteger(env envs.Environment, x XValue) (int, *XError) {
 		return 0, err
 	}
 
-	intPart := number.Native().IntPart()
+	intPart, ok := number.Int64()
 
-	if intPart < math.MinInt32 || intPart > math.MaxInt32 {
+	if !ok || intPart < math.MinInt32 || intPart > math.MaxInt32 {
 		return 0, NewXErrorf("number value %s is out of range for an integer", number.Render())
 	}
 

--- a/excellent/types/number_test.go
+++ b/excellent/types/number_test.go
@@ -98,7 +98,21 @@ func TestXNumberArithmetic(t *testing.T) {
 	assert.Equal(t, num("2").Native(), num("-2").Abs().Native())
 	assert.Equal(t, num("2").Native(), num("2.7").Floor().Native())
 	assert.Equal(t, num("-3").Native(), num("-2.7").Floor().Native())
-	assert.Equal(t, int64(12), num("12.146").IntPart())
+	asInt, ok := num("12.146").Int64()
+	assert.True(t, ok)
+	assert.Equal(t, int64(12), asInt)
+	asInt, ok = num("-12.146").Int64()
+	assert.True(t, ok)
+	assert.Equal(t, int64(-12), asInt)
+	asInt, ok = num("9223372036854775807").Int64() // max int64
+	assert.True(t, ok)
+	assert.Equal(t, int64(9223372036854775807), asInt)
+	_, ok = num("9223372036854775808").Int64() // max int64 + 1
+	assert.False(t, ok)
+	_, ok = num("18446744073709551617").Int64() // 2^64 + 1, would wrap to 1
+	assert.False(t, ok)
+	_, ok = num("-18446744073709551617").Int64()
+	assert.False(t, ok)
 
 	// checked operations that fail
 	maxDigits := num(strings.Repeat("9", 36)) // maximum number of significant digits
@@ -157,6 +171,7 @@ func TestToXNumberAndInteger(t *testing.T) {
 		}), types.NewXNumberFromInt(123), 123, false},
 		{types.NewXText("12345678901234567890"), types.RequireXNumberFromString("12345678901234567890"), 0, true},                                 // out of int range
 		{types.NewXText("123456789012345678901234567890123456"), types.RequireXNumberFromString("123456789012345678901234567890123456"), 0, true}, // 36 digits, ok as number but out of int range
+		{types.NewXText("18446744073709551617"), types.RequireXNumberFromString("18446744073709551617"), 0, true},                                 // 2^64 + 1, would wrap to 1 as an int64
 		{types.NewXText("1234567890123456789012345678901234567"), types.XNumberZero, 0, true},                                                     // 37 digits, too many
 		{types.NewXText("1E100"), types.XNumberZero, 0, true},                                                                                     // scientific notation not allowed
 		{types.NewXText("1e100"), types.XNumberZero, 0, true},                                                                                     // scientific notation not allowed

--- a/excellent/types/time.go
+++ b/excellent/types/time.go
@@ -96,11 +96,12 @@ func ToXTime(env envs.Environment, x XValue) (*XTime, *XError) {
 		case *XDateTime:
 			return typed.Time(), nil
 		case *XNumber:
-			asInt := typed.Native().IntPart()
-			if asInt >= 0 && asInt <= 23 {
-				return NewXTime(dates.NewTimeOfDay(int(asInt), 0, 0, 0)), nil
-			} else if asInt == 24 {
-				return XTimeZero, nil
+			if asInt, ok := typed.Int64(); ok {
+				if asInt >= 0 && asInt <= 23 {
+					return NewXTime(dates.NewTimeOfDay(int(asInt), 0, 0, 0)), nil
+				} else if asInt == 24 {
+					return XTimeZero, nil
+				}
 			}
 		case *XText:
 			parsed, err := envs.TimeFromString(typed.Native())

--- a/excellent/types/time_test.go
+++ b/excellent/types/time_test.go
@@ -59,6 +59,7 @@ func TestToXTime(t *testing.T) {
 		{types.NewXNumberFromInt(123), types.XTimeZero, true},
 		{types.NewXNumberFromInt(23), types.NewXTime(dates.NewTimeOfDay(23, 0, 0, 0)), false},
 		{types.NewXNumberFromInt(24), types.XTimeZero, false},
+		{types.RequireXNumberFromString("18446744073709551640"), types.XTimeZero, true}, // 2^64 + 24, would wrap to 24 as an int64
 		{types.NewXText("10:30"), types.NewXTime(dates.NewTimeOfDay(10, 30, 0, 0)), false},
 		{types.NewXText("10:30 pm"), types.NewXTime(dates.NewTimeOfDay(22, 30, 0, 0)), false},
 		{types.NewXText("10"), types.NewXTime(dates.NewTimeOfDay(10, 0, 0, 0)), false},

--- a/flows/routers/random.go
+++ b/flows/routers/random.go
@@ -41,7 +41,7 @@ func (r *Random) Route(ctx context.Context, run flows.Run, step flows.Step, logE
 	if err != nil {
 		return "", "", err
 	}
-	categoryNum := scaled.IntPart()
+	categoryNum, _ := scaled.Int64() // in range by construction (rand in [0, 1))
 	categoryUUID := r.categories[categoryNum].UUID()
 
 	exit, err := r.routeToCategory(run, step, categoryUUID, fmt.Sprintf("%d", categoryNum), rand.Render(), nil, logEvent)


### PR DESCRIPTION
## Problem

Three expression functions converted arbitrary-precision decimals to int64 without range checks, and `decimal.IntPart()` / `time.UnixNano()` silently wrap on overflow (expression numbers permit up to 36 digits):

- `percent(123456789012345678901)` rendered garbage like `4807115922854775807%`
- `datetime_from_epoch(10000000000000)` returned an arbitrary wrong date (year ~2029) instead of an error
- `epoch(datetime("1500-01-01"))` returned a garbage value because `UnixNano()` is undefined outside years 1678–2262

The same unchecked-`IntPart()` pattern existed beyond these three functions: `types.ToInteger` (which feeds `char`, `repeat`, indexing etc.) applied its int32 range guard to an already-wrapped value, so e.g. 2^64+1 wrapped to 1 and passed; `types.ToXTime` could accept a 36-digit number as a valid time of day; and `LegacyAdd`'s own explicit guard compared wrapped values.

## Solution

`XNumber.IntPart()` is replaced by a range-checked `Int64() (int64, bool)`, and every place that extracts an int from an expression number now goes through it: `percent`, `datetime_from_epoch`, `legacy_add`, `types.ToInteger` and `types.ToXTime`. Out-of-range values return descriptive errors instead of silently wrapping.

`epoch` no longer uses `UnixNano()` at all — it computes whole seconds via `Unix()` plus the fractional part from `Nanosecond()`, so dates outside the previous range now return *correct* values.

Tests cover the out-of-range triggers, the int64 boundary, values that would previously wrap into the guarded range (2^64+k), sub-second fractions and pre-1970 dates.
