### PR TITLE
Fix infinite loop in jsonpath parsing on unexpected characters

### DIFF
--- a/utils/jsonpath/path.go
+++ b/utils/jsonpath/path.go
@@ -13,6 +13,7 @@ package jsonpath
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -57,6 +58,8 @@ func parsePath(path string) ([]string, error) {
 				return nil, errors.New("subscript value can't be empty")
 			}
 			steps = append(steps, s)
+		} else {
+			return nil, fmt.Errorf("unexpected character %q in path", runes[i])
 		}
 	}
 

--- a/utils/jsonpath/path_test.go
+++ b/utils/jsonpath/path_test.go
@@ -18,6 +18,9 @@ func TestParsePath(t *testing.T) {
 		{"$[*]", []string{"*"}, ""},
 		{"$[2]", []string{"2"}, ""},
 		{"$[]", []string{"2"}, "subscript value can't be empty"},
+		{"$foo", []string{}, `unexpected character 'f' in path`},
+		{"$ .foo", []string{}, `unexpected character ' ' in path`},
+		{"$.foo bar", []string{"foo bar"}, ""},
 		{"$.foo[*]", []string{"foo", "*"}, ""},
 		{"$.foo[*].bar", []string{"foo", "*", "bar"}, ""},
 		{"$.foo[*].bar[5]", []string{"foo", "*", "bar", "5"}, ""},
@@ -65,8 +68,10 @@ func TestVisit(t *testing.T) {
 		assert.Equal(t, tc.expected, matches)
 	}
 
-	// a path with no steps is an error rather than a panic
+	// malformed paths are errors rather than hangs or panics
 	assert.EqualError(t, Visit(data, "$", func(m any) {}), "path must contain at least one step")
+	assert.EqualError(t, Visit(data, "$foo", func(m any) {}), `unexpected character 'f' in path`)
+	assert.EqualError(t, Visit(data, "$ .foo", func(m any) {}), `unexpected character ' ' in path`)
 }
 
 func TestTransform(t *testing.T) {
@@ -87,7 +92,10 @@ func TestTransform(t *testing.T) {
 		assert.Equal(t, tc.expected, tc.data)
 	}
 
-	// a path with no steps is an error rather than a panic
+	// malformed paths are errors rather than hangs or panics
 	err := Transform(map[string]any{"foo": "bar"}, "$", func(c, k, m any) any { return "baz" })
 	assert.EqualError(t, err, "path must contain at least one step")
+
+	err = Transform(map[string]any{"foo": "bar"}, "$foo", func(c, k, m any) any { return "baz" })
+	assert.EqualError(t, err, `unexpected character 'f' in path`)
 }


### PR DESCRIPTION
## Problem

`parsePath` in `utils/jsonpath` only advanced its index when the current character started a `.` or `[` step, so a malformed path like `"$foo"` or `"$ .foo"` made `Visit`/`Transform` spin forever in an infinite loop. Currently latent — the only caller builds well-formed paths — but a single malformed path would turn flow migration into a hang rather than an error.

## Solution

`parsePath` now returns an "unexpected character" error for any rune after `$` that doesn't start a valid step; `Visit`/`Transform` already propagate parse errors before recursing. Tests assert the malformed paths error promptly and that spaces inside a dot step remain valid.
