### PR TITLE
Remove dead legacyWaitCount field and its no-op sprint count fallback

### DIFF
--- a/flows/engine/run.go
+++ b/flows/engine/run.go
@@ -44,8 +44,7 @@ type run struct {
 	modifiedOn time.Time
 	exitedOn   *time.Time
 
-	legacyExtra     *legacyExtra
-	legacyWaitCount int
+	legacyExtra *legacyExtra
 }
 
 func newRun(session *session, flow flows.Flow, parent *run) *run {

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -657,13 +657,6 @@ func readSession(eng flows.Engine, sa flows.SessionAssets, data []byte, env envs
 		}
 	}
 
-	// older sessions won't have a sprints count but will have events and will have set legacyWaitCount
-	if s.sprints == 0 {
-		for _, r := range s.runsByUUID {
-			s.sprints += r.legacyWaitCount
-		}
-	}
-
 	return s, nil
 }
 


### PR DESCRIPTION
## Problem

`run.legacyWaitCount` was never assigned anywhere — the code that populated it was removed along with legacy run event support (84f0c666) — so the fallback in `readSession` claiming to reconstruct sprint counts for older persisted sessions was a provable no-op, and its comment described behavior that no longer exists.

## Solution

Removed the dead field and the no-op fallback block. Old sessions genuinely cannot carry the data anymore since the run envelope no longer parses persisted `events`, so reconstruction is impossible without reverting that deliberate removal.
