### PR TITLE
Return error when reading location hierarchy with more than 4 levels

### DIFF
--- a/envs/location_test.go
+++ b/envs/location_test.go
@@ -112,3 +112,37 @@ func TestLocationHierarchy(t *testing.T) {
 	assert.Equal(t, gasabo, hierarchy.FindByPath("rwanda > kigali city > gasabo"))
 	assert.Equal(t, ndera, hierarchy.FindByPath("rwanda > kigali city > gasabo > ndera"))
 }
+
+func TestLocationHierarchyTooDeep(t *testing.T) {
+	env := envs.NewBuilder().Build()
+
+	// hierarchy with 5 levels (country > state > district > ward > sub-ward)
+	tooDeepJSON := `
+	{
+		"name": "Rwanda",
+		"children": [
+			{
+				"name": "Kigali City",
+				"children": [
+					{
+						"name": "Gasabo",
+						"children": [
+							{
+								"name": "Gisozi",
+								"children": [
+									{
+										"name": "Cell A"
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+		]
+	}`
+
+	hierarchy, err := envs.ReadLocationHierarchy(env, []byte(tooDeepJSON))
+	assert.EqualError(t, err, "location hierarchy can have at most 4 levels, found 5")
+	assert.Nil(t, hierarchy)
+}

--- a/envs/locations.go
+++ b/envs/locations.go
@@ -1,6 +1,7 @@
 package envs
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -22,6 +23,9 @@ type LocationResolver interface {
 
 const (
 	LocationPathSeparator = ">"
+
+	// maximum number of levels that a location hierarchy read from JSON can have
+	maxLocationLevels = 4
 )
 
 var spaceRegex = regexp.MustCompile(`\s+`)
@@ -225,8 +229,12 @@ func (h *LocationHierarchy) UnmarshalJSON(data []byte) error {
 	// TODO this method is only used to load static assets and they're only used for testing.. but this isn't ideal
 	env := NewBuilder().Build()
 
+	if depth := le.maxDepth(); depth > maxLocationLevels {
+		return fmt.Errorf("location hierarchy can have at most %d levels, found %d", maxLocationLevels, depth)
+	}
+
 	root := locationFromEnvelope(&le, LocationLevel(0), nil)
-	h.initializeFromRoot(env, root, 4)
+	h.initializeFromRoot(env, root, maxLocationLevels)
 	return nil
 }
 
@@ -238,6 +246,15 @@ type locationEnvelope struct {
 	Name     string              `json:"name" validate:"required"`
 	Aliases  []string            `json:"aliases,omitempty"`
 	Children []*locationEnvelope `json:"children,omitempty"`
+}
+
+// maxDepth returns the number of levels in this envelope, e.g. 1 for an envelope with no children
+func (le *locationEnvelope) maxDepth() int {
+	depth := 0
+	for _, child := range le.Children {
+		depth = max(depth, child.maxDepth())
+	}
+	return depth + 1
 }
 
 func locationFromEnvelope(envelope *locationEnvelope, currentLevel LocationLevel, parent *Location) *Location {
@@ -263,7 +280,11 @@ func ReadLocationHierarchy(env Environment, data []byte) (*LocationHierarchy, er
 		return nil, err
 	}
 
+	if depth := le.maxDepth(); depth > maxLocationLevels {
+		return nil, fmt.Errorf("location hierarchy can have at most %d levels, found %d", maxLocationLevels, depth)
+	}
+
 	root := locationFromEnvelope(&le, LocationLevel(0), nil)
 
-	return NewLocationHierarchy(env, root, 4), nil
+	return NewLocationHierarchy(env, root, maxLocationLevels), nil
 }


### PR DESCRIPTION
## Problem

Location hierarchies support 4 levels, but `locationFromEnvelope` recursed to unbounded depth while the name-lookup tables were hardcoded to 4 levels with no bounds check on the build path (`addNameLookups`). A hierarchy JSON nested 5+ levels deep passed validation and then panicked with `index out of range [4] with length 4` inside `NewLocationHierarchy`. (`FindByName` had the level guard; the build path did not.)

## Solution

Added a `maxLocationLevels` constant (replacing the hardcoded 4s) and a depth check in both build paths (`ReadLocationHierarchy` and `UnmarshalJSON`): hierarchies deeper than 4 levels now return a clear error instead of panicking. Test added with a 5-level hierarchy asserting the error.
