### PR TITLE
Fix 13.6.1 migration to trim trailing underscore from truncated result lookups when that matches an actual result key

### DIFF
--- a/flows/definition/migrations/13.x.go
+++ b/flows/definition/migrations/13.x.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/excellent"
 	"github.com/nyaruka/goflow/excellent/refactor"
+	"github.com/nyaruka/goflow/utils"
 )
 
 func init() {
@@ -27,6 +28,40 @@ func init() {
 func Migrate13_6_1(f Flow, cfg *Config) (Flow, error) {
 	const maxResultRef = 64
 
+	// collect the context keys of the results created by this flow - the previous migration has already
+	// truncated and trimmed their names so these are the keys that lookups need to match at runtime
+	keys := make(map[string]bool)
+	addKey := func(name string) {
+		if name != "" {
+			keys[utils.Snakify(name)] = true
+		}
+	}
+	for _, node := range f.Nodes() {
+		for _, action := range node.Actions() {
+			if action.Type() == "set_run_result" {
+				name, _ := action["name"].(string)
+				addKey(name)
+			}
+		}
+		if router := node.Router(); router != nil {
+			name, _ := router["result_name"].(string)
+			addKey(name)
+		}
+	}
+
+	truncate := func(lookup string) string {
+		truncated := stringsx.Truncate(lookup, maxResultRef)
+
+		// a truncated lookup can keep a trailing _ that the key of the truncated and trimmed result
+		// name loses, so prefer a trimmed lookup if it matches an actual result key and the
+		// truncated one doesn't
+		trimmed := strings.TrimRight(truncated, "_")
+		if trimmed != truncated && !keys[strings.ToLower(truncated)] && keys[strings.ToLower(trimmed)] {
+			return trimmed
+		}
+		return truncated
+	}
+
 	RewriteTemplates(f, GetTemplateCatalog(semver.MustParse("13.6.0")), func(s string) string {
 		// refactor any @result.* or @(...) template to find result lookups that need to be truncated
 		refactored, _ := refactor.Template(s, []string{"results"}, func(exp excellent.Expression) bool {
@@ -38,7 +73,7 @@ func Migrate13_6_1(f Flow, cfg *Config) (Flow, error) {
 					if asRef, isRef := typed.Container.(*excellent.ContextReference); isRef {
 						if asRef.Name == "results" {
 							old := typed.Lookup
-							typed.Lookup = stringsx.Truncate(old, maxResultRef)
+							typed.Lookup = truncate(old)
 							if typed.Lookup != old {
 								changed = true
 							}

--- a/flows/definition/migrations/testdata/migrations/13.6.1.json
+++ b/flows/definition/migrations/testdata/migrations/13.6.1.json
@@ -67,5 +67,169 @@
                 }
             ]
         }
+    },
+    {
+        "description": "lookup with _ at truncation boundary that came from a space in the result name - Snakify(TrimSpace(Truncate(name, 64))) drops the space so the key has no trailing _ and the truncated lookup must be trimmed to match it",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "13.5.0",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": [
+                {
+                    "uuid": "32bc60ad-5c86-465e-a6b8-049c44ecce49",
+                    "actions": [
+                        {
+                            "uuid": "9d9290a7-3713-4c22-8821-4af0a64c0821",
+                            "type": "set_run_result",
+                            "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bcdefg",
+                            "value": "yes"
+                        },
+                        {
+                            "uuid": "2461c6a1-4dd8-4b8f-9b2a-9087f7cf6c1a",
+                            "type": "send_msg",
+                            "text": "Hi @results.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bcdefg"
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "2d481ce6-efcf-4898-a825-f76208e32f2a"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "13.6.1",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": [
+                {
+                    "uuid": "32bc60ad-5c86-465e-a6b8-049c44ecce49",
+                    "actions": [
+                        {
+                            "uuid": "9d9290a7-3713-4c22-8821-4af0a64c0821",
+                            "type": "set_run_result",
+                            "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                            "value": "yes"
+                        },
+                        {
+                            "uuid": "2461c6a1-4dd8-4b8f-9b2a-9087f7cf6c1a",
+                            "type": "send_msg",
+                            "text": "Hi @results.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "2d481ce6-efcf-4898-a825-f76208e32f2a"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "description": "lookup with _ at truncation boundary that is a literal _ in the result name - Snakify does not strip trailing underscores so the key keeps its _ and the truncated lookup must not be trimmed",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "13.5.0",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": [
+                {
+                    "uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82",
+                    "router": {
+                        "type": "switch",
+                        "wait": {
+                            "type": "msg"
+                        },
+                        "categories": [
+                            {
+                                "uuid": "37d8813f-1402-4ad2-9cc2-e9054a96525b",
+                                "name": "All Responses",
+                                "exit_uuid": "fc2fcd23-7c4a-44bd-a8c6-6c88e6ed09f8"
+                            }
+                        ],
+                        "default_category_uuid": "37d8813f-1402-4ad2-9cc2-e9054a96525b",
+                        "result_name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bcdefg",
+                        "operand": "@input.text",
+                        "cases": []
+                    },
+                    "exits": [
+                        {
+                            "uuid": "fc2fcd23-7c4a-44bd-a8c6-6c88e6ed09f8"
+                        }
+                    ]
+                },
+                {
+                    "uuid": "32bc60ad-5c86-465e-a6b8-049c44ecce49",
+                    "actions": [
+                        {
+                            "uuid": "9d9290a7-3713-4c22-8821-4af0a64c0821",
+                            "type": "send_msg",
+                            "text": "Hi @results.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bcdefg"
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "2d481ce6-efcf-4898-a825-f76208e32f2a"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "13.6.1",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": [
+                {
+                    "uuid": "3dcccbb4-d29c-41dd-a01f-16d814c9ab82",
+                    "router": {
+                        "type": "switch",
+                        "wait": {
+                            "type": "msg"
+                        },
+                        "categories": [
+                            {
+                                "uuid": "37d8813f-1402-4ad2-9cc2-e9054a96525b",
+                                "name": "All Responses",
+                                "exit_uuid": "fc2fcd23-7c4a-44bd-a8c6-6c88e6ed09f8"
+                            }
+                        ],
+                        "default_category_uuid": "37d8813f-1402-4ad2-9cc2-e9054a96525b",
+                        "result_name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_",
+                        "operand": "@input.text",
+                        "cases": []
+                    },
+                    "exits": [
+                        {
+                            "uuid": "fc2fcd23-7c4a-44bd-a8c6-6c88e6ed09f8"
+                        }
+                    ]
+                },
+                {
+                    "uuid": "32bc60ad-5c86-465e-a6b8-049c44ecce49",
+                    "actions": [
+                        {
+                            "uuid": "9d9290a7-3713-4c22-8821-4af0a64c0821",
+                            "type": "send_msg",
+                            "text": "Hi @results.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_"
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "2d481ce6-efcf-4898-a825-f76208e32f2a"
+                        }
+                    ]
+                }
+            ]
+        }
     }
 ]


### PR DESCRIPTION
## Problem

`Migrate13_6_1` truncated `@results.X` context lookups with a bare `Truncate(old, 64)`, which doesn't match how the migrated result keys are derived (`Snakify(TrimSpace(Truncate(name, 64)))`). When a result name has whitespace at the 64-char truncation boundary, the migrated key loses a trailing underscore that the truncated lookup keeps — so a previously-working `@results.x` reference silently breaks (context lookups are exact, case-insensitive).

A blind "trim trailing underscores" fix would be wrong too: `Snakify` preserves literal underscores, and a name with a real `_` at the boundary legitimately produces a key ending in `_`. The two cases are indistinguishable from the lookup string alone.

## Solution

Since 13.6.1 runs after 13.6.0, the flow's result names are already in their final form, so the migration now collects the flow's actual runtime result keys (from `set_run_result` actions and router `result_name`s) and, after truncating a lookup, trims trailing underscores only when the untrimmed form matches no real key and the trimmed form does. Lookups referencing results not defined in the flow behave exactly as before.

Two end-to-end migration test cases document both sides: a whitespace-boundary name where the lookup must be trimmed to match, and a literal-underscore name where it must not be.
