### PR TITLE
Fix reading PO files whose last line has no trailing newline

### DIFF
--- a/utils/po/po.go
+++ b/utils/po/po.go
@@ -302,14 +302,16 @@ func readEntry(nextLine func() (string, error)) (*Entry, error) {
 	lines := make([]string, 0)
 	for {
 		line, err := nextLine()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
 		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
 		if err == io.EOF || line == "" {
 			break
 		}
-		if err != nil {
-			return nil, err
-		}
-		lines = append(lines, line)
 	}
 
 	// there wasn't another entry to read

--- a/utils/po/po_test.go
+++ b/utils/po/po_test.go
@@ -141,6 +141,29 @@ func TestReadAndWritePO(t *testing.T) {
 	test.AssertSnapshot(t, "write_po", b.String())
 }
 
+func TestReadPOWithoutFinalNewline(t *testing.T) {
+	// last line has no trailing newline so is returned by the reader along with io.EOF
+	poFile := strings.NewReader(`msgid ""
+msgstr ""
+"Language: es\n"
+
+msgid "Red"
+msgstr "Rojo"
+
+msgid "Blue"
+msgstr "Azul"`)
+
+	p, err := po.ReadPO(poFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(p.Entries))
+	assert.Equal(t, "Red", p.Entries[0].MsgID)
+	assert.Equal(t, "Rojo", p.Entries[0].MsgStr)
+	assert.Equal(t, "Blue", p.Entries[1].MsgID)
+	assert.Equal(t, "Azul", p.Entries[1].MsgStr)
+	assert.Equal(t, "Azul", p.GetText("", "Blue"))
+}
+
 func TestGetText(t *testing.T) {
 	poFile, err := os.Open("testdata/locale/es/simple.po")
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

`readEntry` in the PO file reader broke out of its line loop on `io.EOF` before processing the returned line. When a PO file's last line has no trailing newline, `bufio.ReadString` returns that final line together with `io.EOF`, so it was silently discarded — e.g. a file ending `msgstr "translated"` without a newline lost the translation, which silently reverted to the source text.

## Solution

The loop now returns on real errors first, appends any non-empty line, and only then terminates on EOF or a blank line, so the final line is kept. Test added reading a PO document whose last `msgstr` line lacks a trailing newline.
