### PR TITLE
Fix panic in prompt() when passed a null argument

### DIFF
--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -2149,7 +2149,7 @@ func Prompt(env envs.Environment, name *types.XText, args ...types.XValue) types
 
 	tplArgs := make(map[string]string, len(args))
 	for i, arg := range args {
-		tplArgs[fmt.Sprintf("arg%d", i+1)] = arg.Render()
+		tplArgs[fmt.Sprintf("arg%d", i+1)] = types.Render(arg)
 	}
 
 	var buf strings.Builder

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -513,6 +513,7 @@ func TestFunctions(t *testing.T) {
 		{"percent", dmy, []types.XValue{}, ERROR},
 
 		{"prompt", dmy, []types.XValue{xs("categorize"), xa(xs("Positive"), xs("Negative"))}, xs("Categorize the following text into one of the following: [Positive, Negative]")},
+		{"prompt", dmy, []types.XValue{xs("categorize"), nil}, xs("Categorize the following text into one of the following: ")},
 		{"prompt", dmy, []types.XValue{xs("categorize")}, xs("Categorize the following text into one of the following: <no value>")},
 		{"prompt", dmy, []types.XValue{xs("xxx")}, ERROR},
 		{"prompt", dmy, []types.XValue{}, ERROR},


### PR DESCRIPTION
## Problem

`prompt()` takes raw (unconverted) arguments and called `arg.Render()` directly. The `null` literal evaluates to a nil interface, so `@(prompt("name", null))` panicked with a nil interface method call — and there is no `recover()` anywhere in the engine.

## Solution

Use the nil-safe `types.Render(arg)` instead, so a null argument renders as an empty string. A scan of the other raw-argument functions found no other unguarded direct method calls on raw args. Test added for the null-argument case.
