### PR TITLE
Fix read_chars corrupting multi-byte characters by slicing bytes instead of runes

### DIFF
--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -2427,19 +2427,26 @@ func LegacyAdd(env envs.Environment, arg1 types.XValue, arg2 types.XValue) types
 func ReadChars(env envs.Environment, val *types.XText) types.XValue {
 	var output bytes.Buffer
 
-	// remove any leading +
-	val = types.NewXText(strings.TrimLeft(val.Native(), "+"))
+	// remove any leading + and operate on runes so multi-byte characters aren't split
+	runes := []rune(strings.TrimLeft(val.Native(), "+"))
+	length := len(runes)
 
-	length := val.Length()
+	writeGroup := func(group []rune) {
+		for j, c := range group {
+			if j > 0 {
+				output.WriteString(" ")
+			}
+			output.WriteRune(c)
+		}
+	}
 
 	// groups of three
 	if length%3 == 0 {
-		// groups of 3
 		for i := 0; i < length; i += 3 {
 			if i > 0 {
 				output.WriteString(" , ")
 			}
-			output.WriteString(strings.Join(strings.Split(val.Native()[i:i+3], ""), " "))
+			writeGroup(runes[i : i+3])
 		}
 		return types.NewXText(output.String())
 	}
@@ -2450,13 +2457,13 @@ func ReadChars(env envs.Environment, val *types.XText) types.XValue {
 			if i > 0 {
 				output.WriteString(" , ")
 			}
-			output.WriteString(strings.Join(strings.Split(val.Native()[i:i+4], ""), " "))
+			writeGroup(runes[i : i+4])
 		}
 		return types.NewXText(output.String())
 	}
 
 	// default, just do one at a time
-	for i, c := range val.Native() {
+	for i, c := range runes {
 		if i > 0 {
 			output.WriteString(" , ")
 		}

--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -527,6 +527,9 @@ func TestFunctions(t *testing.T) {
 		{"read_chars", dmy, []types.XValue{xs("abcd")}, xs("a b c d")},
 		{"read_chars", dmy, []types.XValue{xs("12345678")}, xs("1 2 3 4 , 5 6 7 8")},
 		{"read_chars", dmy, []types.XValue{xs("12")}, xs("1 , 2")},
+		{"read_chars", dmy, []types.XValue{xs("ééé")}, xs("é é é")},
+		{"read_chars", dmy, []types.XValue{xs("héllo!")}, xs("h é l , l o !")},
+		{"read_chars", dmy, []types.XValue{xs("héllo123")}, xs("h é l l , o 1 2 3")},
 		{"read_chars", dmy, []types.XValue{}, ERROR},
 
 		{"regex_match", dmy, []types.XValue{xs("zAbc"), xs(`a\w`)}, xs(`Ab`)},


### PR DESCRIPTION
## Problem

`read_chars` computed the input length in runes but sliced the underlying string by bytes (`val.Native()[i:i+3]`), so non-ASCII input was corrupted: `read_chars("ééé")` returned an invalid-UTF-8 fragment and dropped the rest of the string; `read_chars("héllo!")` dropped the `!`.

## Solution

The input is converted to `[]rune` once and all grouping/slicing operates on that slice, so counts and indices use the same unit. Tests cover all-non-ASCII input, mixed input with rune lengths that are multiples of 3 and 4, and unchanged ASCII behavior.
