### PR TITLE
Fix request_optin action to log dependency error when optin no longer exists

### DIFF
--- a/flows/actions/request_optin.go
+++ b/flows/actions/request_optin.go
@@ -47,6 +47,11 @@ func NewRequestOptIn(uuid flows.ActionUUID, optIn *assets.OptInReference) *Reque
 // Execute creates the optin events
 func (a *RequestOptIn) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
 	optIn := run.Session().Assets().OptIns().Get(a.OptIn.UUID)
+	if optIn == nil {
+		log(events.NewDependencyError(a.OptIn))
+		return nil
+	}
+
 	route := run.Contact().ResolveRoute()
 
 	if route != nil && route.Channel.HasFeature(assets.ChannelFeatureOptIns) {

--- a/flows/actions/testdata/request_optin.json
+++ b/flows/actions/testdata/request_optin.json
@@ -1,5 +1,56 @@
 [
     {
+        "description": "Error event for invalid optin reference",
+        "action": {
+            "type": "request_optin",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "optin": {
+                "uuid": "e0f463b9-2704-4d9c-b04a-bfc1187430ba",
+                "name": "Deleted"
+            }
+        },
+        "events": [
+            {
+                "uuid": "01969b47-307b-76f8-a7eb-cc4cc9ec3e6b",
+                "type": "error",
+                "created_on": "2025-05-04T12:30:57.123456789Z",
+                "text": "Missing dependency: optin[uuid=e0f463b9-2704-4d9c-b04a-bfc1187430ba,name=Deleted]",
+                "code": "dependency:missing"
+            }
+        ],
+        "locals_after": {},
+        "inspection": {
+            "counts": {
+                "languages": 0,
+                "nodes": 1
+            },
+            "dependencies": [
+                {
+                    "uuid": "e0f463b9-2704-4d9c-b04a-bfc1187430ba",
+                    "name": "Deleted",
+                    "type": "optin",
+                    "missing": true
+                }
+            ],
+            "locals": [],
+            "results": [],
+            "parent_refs": [],
+            "issues": [
+                {
+                    "type": "missing_dependency",
+                    "node_uuid": "72a1f5df-49f9-45df-94c9-d86f7ea064e5",
+                    "action_uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+                    "description": "missing optin dependency 'e0f463b9-2704-4d9c-b04a-bfc1187430ba'",
+                    "dependency": {
+                        "uuid": "e0f463b9-2704-4d9c-b04a-bfc1187430ba",
+                        "name": "Deleted",
+                        "type": "optin"
+                    }
+                }
+            ]
+        }
+    },
+    {
         "description": "NOOP when channel doesn't support optins feature",
         "action": {
             "type": "request_optin",


### PR DESCRIPTION
## Problem

The `request_optin` action didn't check whether the optin asset still exists. If it had been deleted since the flow was authored, and the contact's channel has the optins feature, the action logged an `optin_requested` event with `"optin": null` — violating the event's own `validate:"required"` schema and breaking downstream consumers. Every other action handles missing assets by logging a dependency error.

## Solution

`Execute` now checks the asset lookup result and logs a `dependency_error` event (the same pattern as other actions resolving assets) when the optin is missing. Added a missing-asset test case to the action's fixtures asserting the error event and the missing-dependency inspection issue.
