### PR TITLE
Don't re-exit already ended runs when a terminal flow is pushed

### DIFF
--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -350,8 +350,10 @@ func (s *session) continueUntilWait(ctx context.Context, sprint *sprint, current
 			// if this is terminal, then we need to mark all other runs as completed so we don't try to resume them
 			if s.pushedFlow.terminal {
 				for _, run := range s.runs {
-					run.Exit(core.RunStatusCompleted)
-					sprint.logEvent(events.NewRunEnded(run.UUID(), run.FlowReference(), core.RunStatusCompleted))
+					if run.Status() == core.RunStatusActive || run.Status() == core.RunStatusWaiting {
+						run.Exit(core.RunStatusCompleted)
+						sprint.logEvent(events.NewRunEnded(run.UUID(), run.FlowReference(), core.RunStatusCompleted))
+					}
 				}
 			}
 

--- a/test/testdata/runner/enter_flow_loop.test.json
+++ b/test/testdata/runner/enter_flow_loop.test.json
@@ -152,18 +152,6 @@
                 {
                     "created_on": "2025-05-04T12:31:26.123456789Z",
                     "flow": {
-                        "name": "Start Actions Parent",
-                        "revision": 15,
-                        "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
-                    },
-                    "run_uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                    "status": "completed",
-                    "type": "run_ended",
-                    "uuid": "01969b47-a1c3-76f8-bffe-b26e15b12b0f"
-                },
-                {
-                    "created_on": "2025-05-04T12:31:29.123456789Z",
-                    "flow": {
                         "name": "Start Actions Child",
                         "revision": 15,
                         "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
@@ -171,36 +159,36 @@
                     "run_uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343",
                     "status": "completed",
                     "type": "run_ended",
-                    "uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627"
+                    "uuid": "01969b47-a1c3-76f8-bffe-b26e15b12b0f"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:33.123456789Z",
+                    "created_on": "2025-05-04T12:31:30.123456789Z",
                     "flow": {
                         "name": "Start Actions Parent",
                         "revision": 15,
                         "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                     },
                     "parent_uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343",
-                    "run_uuid": "01969b47-b933-76f8-9aeb-7faa667f1355",
+                    "run_uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627",
                     "terminal": true,
                     "type": "run_started",
-                    "uuid": "01969b47-bd1b-76f8-a58f-30ba497b0d21"
+                    "uuid": "01969b47-b163-76f8-9aeb-7faa667f1355"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:36.123456789Z",
+                    "created_on": "2025-05-04T12:31:33.123456789Z",
                     "msg": {
                         "locale": "eng-US",
                         "text": "Enter command: name or exit",
                         "unsendable_reason": "no_route"
                     },
                     "type": "msg_created",
-                    "uuid": "01969b47-c8d3-76f8-aab8-757fffa552e6"
+                    "uuid": "01969b47-bd1b-76f8-a8c9-d76ecec32717"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:41.123456789Z",
-                    "expires_on": "2025-05-11T12:31:39.123456789Z",
+                    "created_on": "2025-05-04T12:31:38.123456789Z",
+                    "expires_on": "2025-05-11T12:31:36.123456789Z",
                     "type": "msg_wait",
-                    "uuid": "01969b47-dc5b-76f8-bbf4-9afbc59f7bb4"
+                    "uuid": "01969b47-d0a3-76f8-95d6-85696b970f6a"
                 }
             ],
             "segments": [
@@ -231,7 +219,7 @@
                     "exit_uuid": "8e322829-80f0-459e-b8f4-05a4318f4eba",
                     "flow_uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69",
                     "node_uuid": "79ed409a-96bc-4feb-a3f6-b81e18d8ca73",
-                    "time": "2025-05-04T12:31:37.123456789Z"
+                    "time": "2025-05-04T12:31:34.123456789Z"
                 }
             ],
             "session": {
@@ -247,14 +235,14 @@
                 "runs": [
                     {
                         "created_on": "2025-05-04T12:30:47.123456789Z",
-                        "exited_on": "2025-05-04T12:31:24.123456789Z",
+                        "exited_on": "2025-05-04T12:31:08.123456789Z",
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:31:24.123456789Z",
+                        "modified_on": "2025-05-04T12:31:08.123456789Z",
                         "path": [
                             {
                                 "arrived_on": "2025-05-04T12:30:51.123456789Z",
@@ -289,13 +277,13 @@
                     },
                     {
                         "created_on": "2025-05-04T12:31:11.123456789Z",
-                        "exited_on": "2025-05-04T12:31:27.123456789Z",
+                        "exited_on": "2025-05-04T12:31:24.123456789Z",
                         "flow": {
                             "name": "Start Actions Child",
                             "revision": 15,
                             "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
                         },
-                        "modified_on": "2025-05-04T12:31:27.123456789Z",
+                        "modified_on": "2025-05-04T12:31:24.123456789Z",
                         "parent_uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
                         "path": [
                             {
@@ -320,30 +308,30 @@
                         "uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343"
                     },
                     {
-                        "created_on": "2025-05-04T12:31:30.123456789Z",
+                        "created_on": "2025-05-04T12:31:27.123456789Z",
                         "exited_on": null,
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
-                        "modified_on": "2025-05-04T12:31:42.123456789Z",
+                        "modified_on": "2025-05-04T12:31:39.123456789Z",
                         "parent_uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:31:34.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:31.123456789Z",
                                 "exit_uuid": "8e322829-80f0-459e-b8f4-05a4318f4eba",
                                 "node_uuid": "79ed409a-96bc-4feb-a3f6-b81e18d8ca73",
-                                "uuid": "0eb7b963-22e8-463f-a8c9-d76ecec32717"
+                                "uuid": "3ac3bb12-16c6-42b2-a58f-30ba497b0d21"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:38.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:35.123456789Z",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
-                                "uuid": "77c27f9f-cee2-4c0a-95d6-85696b970f6a"
+                                "uuid": "99d743e0-7972-4b93-aab8-757fffa552e6"
                             }
                         ],
                         "status": "waiting",
-                        "uuid": "01969b47-b933-76f8-9aeb-7faa667f1355"
+                        "uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627"
                     }
                 ],
                 "sprints": 2,
@@ -364,147 +352,87 @@
             "events": [
                 {
                     "category": "Name",
-                    "created_on": "2025-05-04T12:31:48.123456789Z",
+                    "created_on": "2025-05-04T12:31:45.123456789Z",
                     "name": "Command",
                     "type": "run_result_changed",
-                    "uuid": "01969b47-f7b3-76f8-8a21-0c8b658d7ece",
+                    "uuid": "01969b47-ebfb-76f8-ab7b-b7ab5b0dc119",
                     "value": "name"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:53.123456789Z",
+                    "created_on": "2025-05-04T12:31:50.123456789Z",
                     "flow": {
                         "name": "Start Actions Parent",
                         "revision": 15,
                         "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                     },
-                    "run_uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
+                    "run_uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627",
                     "status": "completed",
                     "type": "run_ended",
-                    "uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5"
+                    "uuid": "01969b47-ff83-76f8-a851-494c098c6807"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:56.123456789Z",
+                    "created_on": "2025-05-04T12:31:54.123456789Z",
                     "flow": {
                         "name": "Start Actions Child",
                         "revision": 15,
                         "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
                     },
-                    "run_uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343",
-                    "status": "completed",
-                    "type": "run_ended",
-                    "uuid": "01969b48-16f3-76f8-a96b-7a2ea92d0f00"
-                },
-                {
-                    "created_on": "2025-05-04T12:31:59.123456789Z",
-                    "flow": {
-                        "name": "Start Actions Parent",
-                        "revision": 15,
-                        "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
-                    },
-                    "run_uuid": "01969b47-b933-76f8-9aeb-7faa667f1355",
-                    "status": "completed",
-                    "type": "run_ended",
-                    "uuid": "01969b48-22ab-76f8-88c7-56bcb29ae35a"
-                },
-                {
-                    "created_on": "2025-05-04T12:32:03.123456789Z",
-                    "flow": {
-                        "name": "Start Actions Child",
-                        "revision": 15,
-                        "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
-                    },
-                    "parent_uuid": "01969b47-b933-76f8-9aeb-7faa667f1355",
-                    "run_uuid": "01969b48-2e63-76f8-bc1e-a15dedcb8e98",
+                    "parent_uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627",
+                    "run_uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5",
                     "terminal": true,
                     "type": "run_started",
-                    "uuid": "01969b48-324b-76f8-9ea3-78702727831a"
+                    "uuid": "01969b48-0f23-76f8-a96b-7a2ea92d0f00"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:06.123456789Z",
+                    "created_on": "2025-05-04T12:31:57.123456789Z",
                     "msg": {
                         "locale": "und-US",
                         "text": "Clearing name",
                         "unsendable_reason": "no_route"
                     },
                     "type": "msg_created",
-                    "uuid": "01969b48-3e03-76f8-aa6f-a957c6de8daa"
+                    "uuid": "01969b48-1adb-76f8-bc1e-a15dedcb8e98"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:13.123456789Z",
-                    "flow": {
-                        "name": "Start Actions Parent",
-                        "revision": 15,
-                        "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
-                    },
-                    "run_uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                    "status": "completed",
-                    "type": "run_ended",
-                    "uuid": "01969b48-595b-76f8-838e-7d5caf016400"
-                },
-                {
-                    "created_on": "2025-05-04T12:32:16.123456789Z",
+                    "created_on": "2025-05-04T12:32:04.123456789Z",
                     "flow": {
                         "name": "Start Actions Child",
                         "revision": 15,
                         "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
                     },
-                    "run_uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343",
+                    "run_uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5",
                     "status": "completed",
                     "type": "run_ended",
-                    "uuid": "01969b48-6513-76f8-b806-699460e5ca92"
+                    "uuid": "01969b48-3633-76f8-aa6f-a957c6de8daa"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:19.123456789Z",
+                    "created_on": "2025-05-04T12:32:08.123456789Z",
                     "flow": {
                         "name": "Start Actions Parent",
                         "revision": 15,
                         "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                     },
-                    "run_uuid": "01969b47-b933-76f8-9aeb-7faa667f1355",
-                    "status": "completed",
-                    "type": "run_ended",
-                    "uuid": "01969b48-70cb-76f8-b9dc-d2d10bd9afd1"
-                },
-                {
-                    "created_on": "2025-05-04T12:32:22.123456789Z",
-                    "flow": {
-                        "name": "Start Actions Child",
-                        "revision": 15,
-                        "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
-                    },
-                    "run_uuid": "01969b48-2e63-76f8-bc1e-a15dedcb8e98",
-                    "status": "completed",
-                    "type": "run_ended",
-                    "uuid": "01969b48-7c83-76f8-9170-73aa5f656389"
-                },
-                {
-                    "created_on": "2025-05-04T12:32:26.123456789Z",
-                    "flow": {
-                        "name": "Start Actions Parent",
-                        "revision": 15,
-                        "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
-                    },
-                    "parent_uuid": "01969b48-2e63-76f8-bc1e-a15dedcb8e98",
-                    "run_uuid": "01969b48-883b-76f8-a150-3428ae2cd5bf",
+                    "parent_uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5",
+                    "run_uuid": "01969b48-41eb-76f8-a502-6fb7f5d04e3f",
                     "terminal": true,
                     "type": "run_started",
-                    "uuid": "01969b48-8c23-76f8-af42-abb6278d787f"
+                    "uuid": "01969b48-45d3-76f8-8e47-34e3393ba6d0"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:29.123456789Z",
+                    "created_on": "2025-05-04T12:32:11.123456789Z",
                     "msg": {
                         "locale": "eng-US",
                         "text": "Enter command: name or exit",
                         "unsendable_reason": "no_route"
                     },
                     "type": "msg_created",
-                    "uuid": "01969b48-97db-76f8-9ad1-04953223c01c"
+                    "uuid": "01969b48-518b-76f8-b806-699460e5ca92"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:34.123456789Z",
-                    "expires_on": "2025-05-11T12:32:32.123456789Z",
+                    "created_on": "2025-05-04T12:32:16.123456789Z",
+                    "expires_on": "2025-05-11T12:32:14.123456789Z",
                     "type": "msg_wait",
-                    "uuid": "01969b48-ab63-76f8-afc7-28aa8c70780e"
+                    "uuid": "01969b48-6513-76f8-9170-73aa5f656389"
                 }
             ],
             "segments": [
@@ -514,28 +442,28 @@
                     "flow_uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69",
                     "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
                     "operand": "name",
-                    "time": "2025-05-04T12:31:49.123456789Z"
+                    "time": "2025-05-04T12:31:46.123456789Z"
                 },
                 {
                     "destination_uuid": "9b24a837-6c15-4231-8661-72971bb00a61",
                     "exit_uuid": "05bf0466-7632-42da-8008-06f12f8b46b8",
                     "flow_uuid": "9010b833-d598-4b31-97eb-3151f25020c6",
                     "node_uuid": "8d4144fc-c189-4b3c-82ee-0a176b26cd97",
-                    "time": "2025-05-04T12:32:07.123456789Z"
+                    "time": "2025-05-04T12:31:58.123456789Z"
                 },
                 {
                     "destination_uuid": "f7ae0d89-ca23-4f7c-8b3b-6adfbc619a08",
                     "exit_uuid": "742a1400-6a89-46d6-9667-d5dac0900778",
                     "flow_uuid": "9010b833-d598-4b31-97eb-3151f25020c6",
                     "node_uuid": "9b24a837-6c15-4231-8661-72971bb00a61",
-                    "time": "2025-05-04T12:32:09.123456789Z"
+                    "time": "2025-05-04T12:32:00.123456789Z"
                 },
                 {
                     "destination_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
                     "exit_uuid": "8e322829-80f0-459e-b8f4-05a4318f4eba",
                     "flow_uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69",
                     "node_uuid": "79ed409a-96bc-4feb-a3f6-b81e18d8ca73",
-                    "time": "2025-05-04T12:32:30.123456789Z"
+                    "time": "2025-05-04T12:32:12.123456789Z"
                 }
             ],
             "session": {
@@ -551,14 +479,14 @@
                 "runs": [
                     {
                         "created_on": "2025-05-04T12:30:47.123456789Z",
-                        "exited_on": "2025-05-04T12:32:11.123456789Z",
+                        "exited_on": "2025-05-04T12:31:08.123456789Z",
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:32:11.123456789Z",
+                        "modified_on": "2025-05-04T12:31:08.123456789Z",
                         "path": [
                             {
                                 "arrived_on": "2025-05-04T12:30:51.123456789Z",
@@ -593,13 +521,13 @@
                     },
                     {
                         "created_on": "2025-05-04T12:31:11.123456789Z",
-                        "exited_on": "2025-05-04T12:32:14.123456789Z",
+                        "exited_on": "2025-05-04T12:31:24.123456789Z",
                         "flow": {
                             "name": "Start Actions Child",
                             "revision": 15,
                             "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
                         },
-                        "modified_on": "2025-05-04T12:32:14.123456789Z",
+                        "modified_on": "2025-05-04T12:31:24.123456789Z",
                         "parent_uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
                         "path": [
                             {
@@ -624,39 +552,39 @@
                         "uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343"
                     },
                     {
-                        "created_on": "2025-05-04T12:31:30.123456789Z",
-                        "exited_on": "2025-05-04T12:32:17.123456789Z",
+                        "created_on": "2025-05-04T12:31:27.123456789Z",
+                        "exited_on": "2025-05-04T12:31:48.123456789Z",
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:32:17.123456789Z",
+                        "modified_on": "2025-05-04T12:31:48.123456789Z",
                         "parent_uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:31:34.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:31.123456789Z",
                                 "exit_uuid": "8e322829-80f0-459e-b8f4-05a4318f4eba",
                                 "node_uuid": "79ed409a-96bc-4feb-a3f6-b81e18d8ca73",
-                                "uuid": "0eb7b963-22e8-463f-a8c9-d76ecec32717"
+                                "uuid": "3ac3bb12-16c6-42b2-a58f-30ba497b0d21"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:38.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:35.123456789Z",
                                 "exit_uuid": "54e64906-5d5a-4bbf-8549-3c5b2a09f612",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
-                                "uuid": "77c27f9f-cee2-4c0a-95d6-85696b970f6a"
+                                "uuid": "99d743e0-7972-4b93-aab8-757fffa552e6"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:50.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:47.123456789Z",
                                 "node_uuid": "407b256c-b7d3-402d-88e5-acd265e250ba",
-                                "uuid": "b87ff1cf-63b4-427d-a851-494c098c6807"
+                                "uuid": "95481033-bb40-4073-8a21-0c8b658d7ece"
                             }
                         ],
                         "results": {
                             "command": {
                                 "category": "Name",
-                                "created_on": "2025-05-04T12:31:45.123456789Z",
+                                "created_on": "2025-05-04T12:31:42.123456789Z",
                                 "input": "name",
                                 "name": "Command",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
@@ -664,65 +592,65 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-b933-76f8-9aeb-7faa667f1355"
+                        "uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627"
                     },
                     {
-                        "created_on": "2025-05-04T12:32:00.123456789Z",
-                        "exited_on": "2025-05-04T12:32:20.123456789Z",
+                        "created_on": "2025-05-04T12:31:51.123456789Z",
+                        "exited_on": "2025-05-04T12:32:02.123456789Z",
                         "flow": {
                             "name": "Start Actions Child",
                             "revision": 15,
                             "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
                         },
-                        "modified_on": "2025-05-04T12:32:20.123456789Z",
-                        "parent_uuid": "01969b47-b933-76f8-9aeb-7faa667f1355",
+                        "modified_on": "2025-05-04T12:32:02.123456789Z",
+                        "parent_uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:32:04.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:55.123456789Z",
                                 "exit_uuid": "05bf0466-7632-42da-8008-06f12f8b46b8",
                                 "node_uuid": "8d4144fc-c189-4b3c-82ee-0a176b26cd97",
-                                "uuid": "4e4f4885-bbd0-4f4b-88a0-aff178d69252"
+                                "uuid": "307bd433-68df-49b3-88c7-56bcb29ae35a"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:32:08.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:59.123456789Z",
                                 "exit_uuid": "742a1400-6a89-46d6-9667-d5dac0900778",
                                 "node_uuid": "9b24a837-6c15-4231-8661-72971bb00a61",
-                                "uuid": "88502a09-150b-4986-a502-6fb7f5d04e3f"
+                                "uuid": "3eb38eb7-ae7b-4c15-9ea3-78702727831a"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:32:10.123456789Z",
+                                "arrived_on": "2025-05-04T12:32:01.123456789Z",
                                 "node_uuid": "f7ae0d89-ca23-4f7c-8b3b-6adfbc619a08",
-                                "uuid": "07a24205-e8df-4850-8e47-34e3393ba6d0"
+                                "uuid": "4e4f4885-bbd0-4f4b-88a0-aff178d69252"
                             }
                         ],
                         "status": "completed",
-                        "uuid": "01969b48-2e63-76f8-bc1e-a15dedcb8e98"
+                        "uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5"
                     },
                     {
-                        "created_on": "2025-05-04T12:32:23.123456789Z",
+                        "created_on": "2025-05-04T12:32:05.123456789Z",
                         "exited_on": null,
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
-                        "modified_on": "2025-05-04T12:32:35.123456789Z",
-                        "parent_uuid": "01969b48-2e63-76f8-bc1e-a15dedcb8e98",
+                        "modified_on": "2025-05-04T12:32:17.123456789Z",
+                        "parent_uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:32:27.123456789Z",
+                                "arrived_on": "2025-05-04T12:32:09.123456789Z",
                                 "exit_uuid": "8e322829-80f0-459e-b8f4-05a4318f4eba",
                                 "node_uuid": "79ed409a-96bc-4feb-a3f6-b81e18d8ca73",
-                                "uuid": "c38a0d3d-5da4-4217-a284-24686e628a7b"
+                                "uuid": "d770cf6c-bb6d-40c0-838e-7d5caf016400"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:32:31.123456789Z",
+                                "arrived_on": "2025-05-04T12:32:13.123456789Z",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
-                                "uuid": "f44f96c8-17c3-4550-9e32-5b7ee54bb315"
+                                "uuid": "f1ba3a15-cca1-4d1c-b9dc-d2d10bd9afd1"
                             }
                         ],
                         "status": "waiting",
-                        "uuid": "01969b48-883b-76f8-a150-3428ae2cd5bf"
+                        "uuid": "01969b48-41eb-76f8-a502-6fb7f5d04e3f"
                     }
                 ],
                 "sprints": 3,
@@ -743,23 +671,23 @@
             "events": [
                 {
                     "category": "Exit",
-                    "created_on": "2025-05-04T12:32:41.123456789Z",
+                    "created_on": "2025-05-04T12:32:23.123456789Z",
                     "name": "Command",
                     "type": "run_result_changed",
-                    "uuid": "01969b48-c6bb-76f8-8876-bd2f7154ab08",
+                    "uuid": "01969b48-806b-76f8-af42-abb6278d787f",
                     "value": "exit"
                 },
                 {
-                    "created_on": "2025-05-04T12:32:44.123456789Z",
+                    "created_on": "2025-05-04T12:32:26.123456789Z",
                     "flow": {
                         "name": "Start Actions Parent",
                         "revision": 15,
                         "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                     },
-                    "run_uuid": "01969b48-883b-76f8-a150-3428ae2cd5bf",
+                    "run_uuid": "01969b48-41eb-76f8-a502-6fb7f5d04e3f",
                     "status": "completed",
                     "type": "run_ended",
-                    "uuid": "01969b48-d273-76f8-a014-bfd905bd3906"
+                    "uuid": "01969b48-8c23-76f8-a284-24686e628a7b"
                 }
             ],
             "segments": [],
@@ -776,14 +704,14 @@
                 "runs": [
                     {
                         "created_on": "2025-05-04T12:30:47.123456789Z",
-                        "exited_on": "2025-05-04T12:32:11.123456789Z",
+                        "exited_on": "2025-05-04T12:31:08.123456789Z",
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:32:11.123456789Z",
+                        "modified_on": "2025-05-04T12:31:08.123456789Z",
                         "path": [
                             {
                                 "arrived_on": "2025-05-04T12:30:51.123456789Z",
@@ -818,13 +746,13 @@
                     },
                     {
                         "created_on": "2025-05-04T12:31:11.123456789Z",
-                        "exited_on": "2025-05-04T12:32:14.123456789Z",
+                        "exited_on": "2025-05-04T12:31:24.123456789Z",
                         "flow": {
                             "name": "Start Actions Child",
                             "revision": 15,
                             "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
                         },
-                        "modified_on": "2025-05-04T12:32:14.123456789Z",
+                        "modified_on": "2025-05-04T12:31:24.123456789Z",
                         "parent_uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
                         "path": [
                             {
@@ -849,39 +777,39 @@
                         "uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343"
                     },
                     {
-                        "created_on": "2025-05-04T12:31:30.123456789Z",
-                        "exited_on": "2025-05-04T12:32:17.123456789Z",
+                        "created_on": "2025-05-04T12:31:27.123456789Z",
+                        "exited_on": "2025-05-04T12:31:48.123456789Z",
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:32:17.123456789Z",
+                        "modified_on": "2025-05-04T12:31:48.123456789Z",
                         "parent_uuid": "01969b47-6efb-76f8-8f55-b7788ac5e343",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:31:34.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:31.123456789Z",
                                 "exit_uuid": "8e322829-80f0-459e-b8f4-05a4318f4eba",
                                 "node_uuid": "79ed409a-96bc-4feb-a3f6-b81e18d8ca73",
-                                "uuid": "0eb7b963-22e8-463f-a8c9-d76ecec32717"
+                                "uuid": "3ac3bb12-16c6-42b2-a58f-30ba497b0d21"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:38.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:35.123456789Z",
                                 "exit_uuid": "54e64906-5d5a-4bbf-8549-3c5b2a09f612",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
-                                "uuid": "77c27f9f-cee2-4c0a-95d6-85696b970f6a"
+                                "uuid": "99d743e0-7972-4b93-aab8-757fffa552e6"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:50.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:47.123456789Z",
                                 "node_uuid": "407b256c-b7d3-402d-88e5-acd265e250ba",
-                                "uuid": "b87ff1cf-63b4-427d-a851-494c098c6807"
+                                "uuid": "95481033-bb40-4073-8a21-0c8b658d7ece"
                             }
                         ],
                         "results": {
                             "command": {
                                 "category": "Name",
-                                "created_on": "2025-05-04T12:31:45.123456789Z",
+                                "created_on": "2025-05-04T12:31:42.123456789Z",
                                 "input": "name",
                                 "name": "Command",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
@@ -889,69 +817,69 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-b933-76f8-9aeb-7faa667f1355"
+                        "uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627"
                     },
                     {
-                        "created_on": "2025-05-04T12:32:00.123456789Z",
-                        "exited_on": "2025-05-04T12:32:20.123456789Z",
+                        "created_on": "2025-05-04T12:31:51.123456789Z",
+                        "exited_on": "2025-05-04T12:32:02.123456789Z",
                         "flow": {
                             "name": "Start Actions Child",
                             "revision": 15,
                             "uuid": "9010b833-d598-4b31-97eb-3151f25020c6"
                         },
-                        "modified_on": "2025-05-04T12:32:20.123456789Z",
-                        "parent_uuid": "01969b47-b933-76f8-9aeb-7faa667f1355",
+                        "modified_on": "2025-05-04T12:32:02.123456789Z",
+                        "parent_uuid": "01969b47-ad7b-76f8-b4dd-bb13b355a627",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:32:04.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:55.123456789Z",
                                 "exit_uuid": "05bf0466-7632-42da-8008-06f12f8b46b8",
                                 "node_uuid": "8d4144fc-c189-4b3c-82ee-0a176b26cd97",
-                                "uuid": "4e4f4885-bbd0-4f4b-88a0-aff178d69252"
+                                "uuid": "307bd433-68df-49b3-88c7-56bcb29ae35a"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:32:08.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:59.123456789Z",
                                 "exit_uuid": "742a1400-6a89-46d6-9667-d5dac0900778",
                                 "node_uuid": "9b24a837-6c15-4231-8661-72971bb00a61",
-                                "uuid": "88502a09-150b-4986-a502-6fb7f5d04e3f"
+                                "uuid": "3eb38eb7-ae7b-4c15-9ea3-78702727831a"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:32:10.123456789Z",
+                                "arrived_on": "2025-05-04T12:32:01.123456789Z",
                                 "node_uuid": "f7ae0d89-ca23-4f7c-8b3b-6adfbc619a08",
-                                "uuid": "07a24205-e8df-4850-8e47-34e3393ba6d0"
+                                "uuid": "4e4f4885-bbd0-4f4b-88a0-aff178d69252"
                             }
                         ],
                         "status": "completed",
-                        "uuid": "01969b48-2e63-76f8-bc1e-a15dedcb8e98"
+                        "uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5"
                     },
                     {
-                        "created_on": "2025-05-04T12:32:23.123456789Z",
-                        "exited_on": "2025-05-04T12:32:42.123456789Z",
+                        "created_on": "2025-05-04T12:32:05.123456789Z",
+                        "exited_on": "2025-05-04T12:32:24.123456789Z",
                         "flow": {
                             "name": "Start Actions Parent",
                             "revision": 15,
                             "uuid": "0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:32:42.123456789Z",
-                        "parent_uuid": "01969b48-2e63-76f8-bc1e-a15dedcb8e98",
+                        "modified_on": "2025-05-04T12:32:24.123456789Z",
+                        "parent_uuid": "01969b48-0b3b-76f8-99b2-e3c62e5695d5",
                         "path": [
                             {
-                                "arrived_on": "2025-05-04T12:32:27.123456789Z",
+                                "arrived_on": "2025-05-04T12:32:09.123456789Z",
                                 "exit_uuid": "8e322829-80f0-459e-b8f4-05a4318f4eba",
                                 "node_uuid": "79ed409a-96bc-4feb-a3f6-b81e18d8ca73",
-                                "uuid": "c38a0d3d-5da4-4217-a284-24686e628a7b"
+                                "uuid": "d770cf6c-bb6d-40c0-838e-7d5caf016400"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:32:31.123456789Z",
+                                "arrived_on": "2025-05-04T12:32:13.123456789Z",
                                 "exit_uuid": "5530b3d4-64e5-44ee-b68d-ab0913aab2b0",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
-                                "uuid": "f44f96c8-17c3-4550-9e32-5b7ee54bb315"
+                                "uuid": "f1ba3a15-cca1-4d1c-b9dc-d2d10bd9afd1"
                             }
                         ],
                         "results": {
                             "command": {
                                 "category": "Exit",
-                                "created_on": "2025-05-04T12:32:38.123456789Z",
+                                "created_on": "2025-05-04T12:32:20.123456789Z",
                                 "input": "exit",
                                 "name": "Command",
                                 "node_uuid": "e546f5ce-8f17-439f-af49-b5046d7c8069",
@@ -959,7 +887,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b48-883b-76f8-a150-3428ae2cd5bf"
+                        "uuid": "01969b48-41eb-76f8-a502-6fb7f5d04e3f"
                     }
                 ],
                 "sprints": 4,


### PR DESCRIPTION
## Problem

When a flow marked `terminal` was pushed, `continueUntilWait` exited *all* runs in the session with no status guard, so runs that had already ended were re-exited: their `exited_on` was rewritten, duplicate `run_ended` events were emitted, and a previously *expired* run could silently flip to *completed*. The bug was visible in the `enter_flow_loop` runner fixture, where one run had four `run_ended` events.

## Solution

The loop now only exits runs that are still active or waiting — the same guard `failSession` already uses. Regenerated golden fixtures: the only change is in `enter_flow_loop.test.json`, where the 6 duplicate `run_ended` events disappear and already-exited runs keep their original exit timestamps (plus the resulting deterministic UUID/timestamp shifts). No run status values changed and no other event types were affected.
