### PR TITLE
Fix time parsing to reject out of range hour, minute and second values

### DIFF
--- a/envs/dates.go
+++ b/envs/dates.go
@@ -215,13 +215,13 @@ func parseTime(str string) (bool, dates.TimeOfDay) {
 		}
 
 		// is our time valid?
-		if hour > 24 {
+		if hour > 23 {
 			continue
 		}
-		if minute > 60 {
+		if minute > 59 {
 			continue
 		}
-		if second > 60 {
+		if second > 59 {
 			continue
 		}
 

--- a/envs/dates_test.go
+++ b/envs/dates_test.go
@@ -82,6 +82,11 @@ func TestDateTimeFromString(t *testing.T) {
 		{envs.DateFormatYearMonthDay, envs.TimeFormatHourMinute, "UTC", false, "2001-02-01 03:15:34", "01-02-2001 03:15:34 +0000 UTC", false},
 		{envs.DateFormatYearMonthDay, envs.TimeFormatHourMinute, "UTC", false, "2001-02-01 03:15:34.123", "01-02-2001 03:15:34.123 +0000 UTC", false},
 		{envs.DateFormatYearMonthDay, envs.TimeFormatHourMinute, "UTC", false, "2001-02-01 03:15:34.123456", "01-02-2001 03:15:34.123456 +0000 UTC", false},
+
+		// 24 can be used to mean midnight but any other time with hour 24 is invalid and ignored
+		{envs.DateFormatDayMonthYear, envs.TimeFormatHourMinute, "UTC", false, "02-02-2020 24:00", "02-02-2020 00:00:00 +0000 UTC", false},
+		{envs.DateFormatDayMonthYear, envs.TimeFormatHourMinute, "UTC", false, "02-02-2020 24:30", "02-02-2020 00:00:00 +0000 UTC", false},
+		{envs.DateFormatDayMonthYear, envs.TimeFormatHourMinute, "UTC", false, "02-02-2020 10:60", "02-02-2020 00:00:00 +0000 UTC", false},
 	}
 
 	dates.SetNowFunc(dates.NewFixedNow(time.Date(2018, 9, 13, 13, 36, 30, 123456789, time.UTC)))
@@ -184,8 +189,12 @@ func TestTimeFromString(t *testing.T) {
 		{"it's 24:00:00 ok", dates.NewTimeOfDay(0, 0, 0, 0), false},
 
 		{"it's ok", dates.ZeroTimeOfDay, true},
+		{"it's 24:30", dates.ZeroTimeOfDay, true},
+		{"it's 24:00:30", dates.ZeroTimeOfDay, true},
 		{"it's 25:30", dates.ZeroTimeOfDay, true},
+		{"it's 10:60", dates.ZeroTimeOfDay, true},
 		{"it's 10:61", dates.ZeroTimeOfDay, true},
+		{"it's 10:30:60", dates.ZeroTimeOfDay, true},
 		{"it's 10:30:61", dates.ZeroTimeOfDay, true},
 	}
 


### PR DESCRIPTION
## Problem

`parseTime`'s validity checks were off by one: guards of `hour > 24` / `minute > 60` / `second > 60` (with the 24:00 midnight special case only applying when minutes/seconds are zero) meant invalid times were accepted — `"02-02-2020 24:30"` parsed and rolled over into the next day (Feb 3 00:30) via `time.Date` normalization, and `"10:60"` parsed as 11:00.

## Solution

Tightened the bounds to `hour > 23` / `minute > 59` / `second > 59`. The exact `24:00(:00.0)` midnight case is handled before these checks and still parses as midnight; other hour-24 or out-of-range values now fail the parse like any invalid match. Tests cover the rejected values, midnight still parsing, and datetime parsing no longer rolling into the next day.


Note: this also rejects previously-accepted rollover cases like `24:00:60`, and leap-second strings (`23:59:60`) are now rejected rather than rolled over to midnight of the next day — nothing in the repo consumed them.
