### PR TITLE
Fix XTime and XDate truthiness to compare by value instead of pointer identity

### DIFF
--- a/excellent/functions/builtin_test.go
+++ b/excellent/functions/builtin_test.go
@@ -97,6 +97,11 @@ func TestFunctions(t *testing.T) {
 		{"boolean", dmy, []types.XValue{xs("FALSE")}, types.XBooleanFalse},
 		{"boolean", dmy, []types.XValue{xa()}, types.XBooleanFalse},
 		{"boolean", dmy, []types.XValue{xa(xi(1))}, types.XBooleanTrue},
+		{"boolean", dmy, []types.XValue{xt(dates.NewTimeOfDay(0, 0, 0, 0))}, types.XBooleanFalse}, // e.g. time_from_parts(0, 0, 0)
+		{"boolean", dmy, []types.XValue{types.XTimeZero}, types.XBooleanFalse},                    // e.g. time(24)
+		{"boolean", dmy, []types.XValue{xt(dates.NewTimeOfDay(0, 0, 1, 0))}, types.XBooleanTrue},
+		{"boolean", dmy, []types.XValue{xd(dates.ZeroDate)}, types.XBooleanFalse},
+		{"boolean", dmy, []types.XValue{types.XDateZero}, types.XBooleanFalse},
 		{"boolean", dmy, []types.XValue{ERROR}, ERROR},
 		{"boolean", dmy, []types.XValue{}, ERROR},
 

--- a/excellent/types/date.go
+++ b/excellent/types/date.go
@@ -31,7 +31,7 @@ func (x *XDate) Describe() string { return "date" }
 
 // Truthy determines truthiness for this type
 func (x *XDate) Truthy() bool {
-	return x != XDateZero
+	return !x.Native().Equal(dates.ZeroDate)
 }
 
 // Render returns the canonical text representation

--- a/excellent/types/date_test.go
+++ b/excellent/types/date_test.go
@@ -21,6 +21,10 @@ func TestXDate(t *testing.T) {
 	assert.Equal(t, `20-02-2019`, d1.Format(env))
 
 	assert.True(t, d1.Truthy())
+
+	// the zero date is not truthy, regardless of how it was constructed
+	assert.False(t, types.XDateZero.Truthy())
+	assert.False(t, types.NewXDate(dates.ZeroDate).Truthy())
 	assert.Equal(t, `XDate(2019, 2, 20)`, d1.String())
 
 	formatted, err := d1.FormatCustom(env, "EEE, DD-MM-YYYY")

--- a/excellent/types/time.go
+++ b/excellent/types/time.go
@@ -31,7 +31,7 @@ func (x *XTime) Describe() string { return "time" }
 
 // Truthy determines truthiness for this type
 func (x *XTime) Truthy() bool {
-	return x != XTimeZero
+	return !x.Native().Equal(dates.ZeroTimeOfDay)
 }
 
 // Render returns the canonical text representation

--- a/excellent/types/time_test.go
+++ b/excellent/types/time_test.go
@@ -18,6 +18,11 @@ func TestXTime(t *testing.T) {
 	t1 := types.NewXTime(dates.NewTimeOfDay(17, 1, 30, 0))
 	assert.Equal(t, `time`, t1.Describe())
 	assert.True(t, t1.Truthy())
+
+	// midnight is not truthy, regardless of how it was constructed
+	assert.False(t, types.XTimeZero.Truthy())
+	assert.False(t, types.NewXTime(dates.NewTimeOfDay(0, 0, 0, 0)).Truthy())
+	assert.False(t, types.NewXTime(dates.ZeroTimeOfDay).Truthy())
 	assert.Equal(t, `17:01:30.000000`, types.NewXTime(dates.NewTimeOfDay(17, 1, 30, 0)).Render())
 	assert.Equal(t, `17:01`, types.NewXTime(dates.NewTimeOfDay(17, 1, 30, 0)).Format(env))
 	assert.Equal(t, `XTime(17, 1, 30, 0)`, types.NewXTime(dates.NewTimeOfDay(17, 1, 30, 0)).String())


### PR DESCRIPTION
## Problem

`XTime.Truthy()` and `XDate.Truthy()` compared pointer identity against the shared zero singletons (`x != XTimeZero`), so equal values had different truthiness depending on how they were constructed: `boolean(time_from_parts(0, 0, 0))` → `true` (fresh pointer) but `boolean(time(24))` → `false` (returns the singleton), though both are midnight.

## Solution

Both now compare the native value against the zero value, so midnight and the zero date are consistently falsy regardless of construction path. Tests assert all construction paths agree for both types, including the original `boolean()` repro cases.
