### PR TITLE
Make evaluation budget a parameter of Evaluator

### DIFF
--- a/excellent/base.go
+++ b/excellent/base.go
@@ -18,19 +18,22 @@ import (
 // Real expressions are written by humans and nest a handful of levels deep at most.
 const maxExpressionDepth = 100
 
-// maxEvaluationCost is the cost budget for a single expression evaluation. Cost accrues as values are
-// produced - text costs its length in bytes, everything else costs 1 - so this bounds both the memory and
-// the number of operations a single evaluation can consume, no matter how per-function limits are composed.
-// It's set generously: real expressions cost a few hundred units at most, so this is many orders of magnitude
-// of headroom whilst still bounding an attack to a few MB. It can be tightened later based on real-world usage.
-const maxEvaluationCost = 10_000_000
+// DefaultEvaluationBudget is the default cost budget for a single expression evaluation. Cost accrues as
+// values are produced - text costs its length in bytes, everything else costs 1 - so this bounds both the
+// memory and the number of operations a single evaluation can consume, no matter how per-function limits are
+// composed. It's set generously: real expressions cost a few hundred units at most, so this is many orders of
+// magnitude of headroom whilst still bounding an attack to a few MB. It can be tightened later based on
+// real-world usage.
+const DefaultEvaluationBudget = 10_000_000
 
 // Evaluator evaluates templates and expressions.
-type Evaluator struct{}
+type Evaluator struct {
+	budget int // cost budget for a single expression evaluation
+}
 
-// NewEvaluator creates a new evaluator
-func NewEvaluator() *Evaluator {
-	return &Evaluator{}
+// NewEvaluator creates a new evaluator with the given evaluation cost budget
+func NewEvaluator(budget int) *Evaluator {
+	return &Evaluator{budget: budget}
 }
 
 // Escaping is a function applied to expressions in a template after they've been evaluated
@@ -112,7 +115,7 @@ func (e *Evaluator) Expression(ctx context.Context, env envs.Environment, root *
 
 	// a per-evaluation cost budget is added to the caller's context so that its deadline (if any) is honoured
 	// alongside the budget
-	ctx = budget.With(ctx, budget.New(maxEvaluationCost))
+	ctx = budget.With(ctx, budget.New(e.budget))
 
 	return parsed.Evaluate(ctx, env, scope, warnings), warnings.all
 }

--- a/excellent/base_test.go
+++ b/excellent/base_test.go
@@ -205,7 +205,7 @@ func TestEvaluateTemplateValue(t *testing.T) {
 	}
 
 	for _, tc := range evaluateTests {
-		eval := excellent.NewEvaluator()
+		eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 		result, _, err := eval.TemplateValue(t.Context(), env, ctx, tc.template)
 		assert.NoError(t, err)
 
@@ -345,7 +345,7 @@ func TestEvaluateTemplate(t *testing.T) {
 			}
 		}()
 
-		eval := excellent.NewEvaluator()
+		eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 		val, _, err := eval.Template(t.Context(), env, ctx, tc.template, nil)
 
 		if tc.hasError {
@@ -366,7 +366,7 @@ func TestEvaluateTemplateWithEscaping(t *testing.T) {
 		return strings.Replace(s, `"`, `\"`, -1)
 	}
 
-	eval := excellent.NewEvaluator()
+	eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 	env := envs.NewBuilder().Build()
 	val, _, err := eval.Template(t.Context(), env, ctx, `Hi @string1`, escaping)
 	assert.NoError(t, err)
@@ -388,7 +388,7 @@ func TestEvaluateTemplateWithDeprecatedValues(t *testing.T) {
 		"yyy": dep2,
 	})
 
-	eval := excellent.NewEvaluator()
+	eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 	env := envs.NewBuilder().Build()
 
 	val, warnings, err := eval.Template(t.Context(), env, ctx, `Hi @foo.bar`, nil)
@@ -458,7 +458,7 @@ func TestEvaluationErrors(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		eval := excellent.NewEvaluator()
+		eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 		result, _, err := eval.Template(t.Context(), env, ctx, tc.template, nil)
 		assert.Equal(t, "", result)
 		assert.NotNil(t, err)
@@ -472,7 +472,7 @@ func TestEvaluationErrors(t *testing.T) {
 func TestEvaluationBudget(t *testing.T) {
 	env := envs.NewBuilder().Build()
 	ctx := types.NewXObject(map[string]types.XValue{"name": types.NewXText("bob jones")})
-	eval := excellent.NewEvaluator()
+	eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 
 	// expressions that stay within budget evaluate normally
 	allowed := []string{
@@ -500,6 +500,15 @@ func TestEvaluationBudget(t *testing.T) {
 		if assert.Error(t, err, "expected %s to exceed budget", tc.desc) {
 			assert.Contains(t, err.Error(), "expression is too complex to evaluate", "for %s", tc.desc)
 		}
+	}
+
+	// the budget is per-evaluator, so a smaller one makes exhaustion easy to reach with modest values
+	small := excellent.NewEvaluator(100)
+	_, _, err := small.Template(t.Context(), env, ctx, `@(repeat("x", 50))`, nil)
+	assert.NoError(t, err)
+	_, _, err = small.Template(t.Context(), env, ctx, `@(repeat("x", 200))`, nil)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "expression is too complex to evaluate")
 	}
 
 	// the budget is also wired for the Expression() entry point, and empty text can't be produced for free

--- a/excellent/refactor/base_test.go
+++ b/excellent/refactor/base_test.go
@@ -34,7 +34,7 @@ func TestRefactorTemplate(t *testing.T) {
 		{`test@@example.com`, `test@@example.com`, false}, // escaped @ unchanged
 	}
 
-	eval := excellent.NewEvaluator()
+	eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 	env := envs.NewBuilder().Build()
 	ctx := types.NewXObject(map[string]types.XValue{
 		"foo": types.NewXObject(map[string]types.XValue{

--- a/excellent/template.go
+++ b/excellent/template.go
@@ -12,7 +12,7 @@ import (
 
 // Template is a parsed representation of a template string, e.g. "Hi @contact.name!". It is immutable after parsing
 // and thus safe for concurrent use - parsing a template once and evaluating it many times is equivalent to passing
-// the original string to Evaluator.Template each time.
+// the original string to Evaluator.Template each time, using the default evaluation budget.
 type Template struct {
 	segments []templateSegment
 }

--- a/excellent/template.go
+++ b/excellent/template.go
@@ -146,7 +146,7 @@ func (s *expressionSegment) evaluate(env envs.Environment, root *types.XObject) 
 
 	// evaluation is context-aware so that per-evaluation limits can be enforced; the context originates here
 	// rather than being threaded in from the caller until there's a caller-side deadline worth honouring
-	ctx := budget.With(context.Background(), budget.New(maxEvaluationCost))
+	ctx := budget.With(context.Background(), budget.New(DefaultEvaluationBudget))
 
 	value := s.expression.Evaluate(ctx, env, NewScope(root, nil), warnings)
 	return value, warnings.all

--- a/excellent/template_test.go
+++ b/excellent/template_test.go
@@ -102,7 +102,7 @@ func assertTemplateEquivalent(t *testing.T, env envs.Environment, ctx *types.XOb
 	template := excellent.ParseTemplate(src)
 	require.Equal(t, src, template.String(), "round trip mismatch for template %q", src)
 
-	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(t.Context(), env, ctx, src, escaping)
+	expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator(excellent.DefaultEvaluationBudget).Template(t.Context(), env, ctx, src, escaping)
 	actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, escaping)
 
 	assert.Equal(t, expectedVal, actualVal, "output mismatch for template %q", src)
@@ -231,7 +231,7 @@ func FuzzParseTemplate(f *testing.F) {
 			return
 		}
 
-		expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator().Template(t.Context(), env, ctx, src, nil)
+		expectedVal, expectedWarns, expectedErr := excellent.NewEvaluator(excellent.DefaultEvaluationBudget).Template(t.Context(), env, ctx, src, nil)
 		actualVal, actualWarns, actualErr := template.Evaluate(env, ctx, nil)
 
 		if actualVal != expectedVal {
@@ -251,7 +251,7 @@ const benchmarkTemplate = `Hello @string1, @thing.foo is @(int1 + 2) @@here with
 func BenchmarkEvaluatorTemplate(b *testing.B) {
 	env := envs.NewBuilder().Build()
 	ctx := makeTemplateContext()
-	eval := excellent.NewEvaluator()
+	eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 
 	b.ResetTimer()
 	for range b.N {

--- a/excellent/types/json_test.go
+++ b/excellent/types/json_test.go
@@ -78,7 +78,7 @@ func TestXJSONResolve(t *testing.T) {
 		fragment := types.JSONToXValue(tc.JSON)
 		ctx := types.NewXObject(map[string]types.XValue{"j": fragment})
 
-		eval := excellent.NewEvaluator()
+		eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 		value, _ := eval.Expression(t.Context(), env, ctx, tc.expression)
 		err, _ := value.(error)
 

--- a/flows/definition/legacy/expressions/migrate_test.go
+++ b/flows/definition/legacy/expressions/migrate_test.go
@@ -381,7 +381,7 @@ func TestLegacyTests(t *testing.T) {
 			migratedVars := tc.Context.Variables.Migrate().Context(env)
 			migratedVarsJSON := jsonx.MustMarshal(migratedVars)
 
-			eval := excellent.NewEvaluator()
+			eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 			_, _, err = eval.Template(t.Context(), env, migratedVars, migratedTemplate, nil)
 
 			if len(tc.Errors) > 0 {

--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -90,7 +90,7 @@ type Builder struct {
 func NewBuilder() *Builder {
 	return &Builder{
 		eng: &engine{
-			evaluator:  excellent.NewEvaluator(),
+			evaluator:  excellent.NewEvaluator(excellent.DefaultEvaluationBudget),
 			services:   newEmptyServices(),
 			httpClient: http.DefaultClient,
 			options: &flows.EngineOptions{

--- a/flows/routers/cases/tests_test.go
+++ b/flows/routers/cases/tests_test.go
@@ -482,7 +482,7 @@ func TestEvaluateTemplate(t *testing.T) {
 
 	env := envs.NewBuilder().Build()
 	for _, test := range evalTests {
-		eval := excellent.NewEvaluator()
+		eval := excellent.NewEvaluator(excellent.DefaultEvaluationBudget)
 		val, _, err := eval.Template(t.Context(), env, ctx, test.template, nil)
 
 		if test.hasError {


### PR DESCRIPTION
The per-evaluation cost budget was previously a package-private constant, so it couldn't be adjusted by callers and testing budget exhaustion required expressions that manufacture megabytes of values.

- `Evaluator` now carries the budget as a field, passed to `NewEvaluator(budget int)`.
- The previous value is exported as `DefaultEvaluationBudget`, which the engine passes when constructing its evaluator - so default behavior is unchanged.
- The preparsed `Template` path doesn't involve an `Evaluator` and continues to use the default.
- `TestEvaluationBudget` gains a small-budget case showing exhaustion is now reachable with modest values.