### PR TITLE
Add form type for quick replies

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -215,7 +215,7 @@ func RunFlow(eng flows.Engine, assetsPath string, flowUUID assets.FlowUUID, init
 }
 
 func createMessage(contact *core.Contact, text string) *core.MsgIn {
-	return core.NewMsgIn(contact.URNs()[0].Identity(), nil, text, []utils.Attachment{}, "")
+	return core.NewMsgIn(contact.URNs()[0].Identity(), nil, text, []utils.Attachment{}, "", nil)
 }
 
 func printEvents(log []events.Event, out io.Writer) {

--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -286,6 +286,7 @@ func TestEventMarshaling(t *testing.T) {
 						"hi there",
 						nil,
 						"",
+						nil,
 					),
 					"",
 				)
@@ -301,6 +302,7 @@ func TestEventMarshaling(t *testing.T) {
 						"hi there",
 						[]utils.Attachment{"image/jpeg:https://s3.amazon.com/mybucket/attachment.jpg"},
 						"ext-id-123",
+						nil,
 					),
 					"7481888c-07dd-47dc-bf22-ef7448696ffe",
 				)

--- a/core/msg.go
+++ b/core/msg.go
@@ -157,6 +157,8 @@ func NewMsgTemplating(template *assets.TemplateReference, components []*Templati
 	return &MsgTemplating{Template: template, Components: components, Variables: variables}
 }
 
+// QuickReply is a suggested reply or action attached to an outgoing message. For type text, extra is an optional
+// description, and for type form, extra is the channel-specific ID of the form to be opened (e.g. a WhatsApp flow ID).
 type QuickReply struct {
 	Type  string `json:"type"`
 	Text  string `json:"text,omitempty"`
@@ -168,10 +170,15 @@ func (q QuickReply) MarshalText() (text []byte, err error) {
 	if q.Type == "location" {
 		return []byte("<location>" + q.Text), nil
 	}
+
+	s := q.Text
 	if q.Extra != "" {
-		return []byte(q.Text + "<extra>" + q.Extra), nil
+		s += "<extra>" + q.Extra
 	}
-	return []byte(q.Text), nil
+	if q.Type == "form" {
+		s = "<form>" + s
+	}
+	return []byte(s), nil
 }
 
 func (q *QuickReply) UnmarshalText(text []byte) error {
@@ -182,7 +189,13 @@ func (q *QuickReply) UnmarshalText(text []byte) error {
 		return nil
 	}
 
-	q.Type = "text"
+	if strings.HasPrefix(s, "<form>") {
+		q.Type = "form"
+		s = strings.TrimPrefix(s, "<form>")
+	} else {
+		q.Type = "text"
+	}
+
 	parts := strings.SplitN(s, "<extra>", 2)
 	q.Text = parts[0]
 	if len(parts) > 1 {

--- a/core/msg.go
+++ b/core/msg.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -42,7 +43,8 @@ type BaseMsg struct {
 type MsgIn struct {
 	BaseMsg
 
-	ExternalID_ string `json:"external_id,omitempty"`
+	ExternalID_ string          `json:"external_id,omitempty"`
+	Payload_    json.RawMessage `json:"payload,omitempty"`
 }
 
 // MsgOut represents a outgoing message to the session contact
@@ -56,7 +58,7 @@ type MsgOut struct {
 }
 
 // NewMsgIn creates a new incoming message
-func NewMsgIn(urn urns.URN, channel *assets.ChannelReference, text string, attachments []utils.Attachment, externalID string) *MsgIn {
+func NewMsgIn(urn urns.URN, channel *assets.ChannelReference, text string, attachments []utils.Attachment, externalID string, payload json.RawMessage) *MsgIn {
 	return &MsgIn{
 		BaseMsg: BaseMsg{
 			URN_:         urn,
@@ -65,6 +67,7 @@ func NewMsgIn(urn urns.URN, channel *assets.ChannelReference, text string, attac
 			Attachments_: attachments,
 		},
 		ExternalID_: externalID,
+		Payload_:    payload,
 	}
 }
 
@@ -121,6 +124,9 @@ func (m *BaseMsg) Attachments() []utils.Attachment { return m.Attachments_ }
 
 // ExternalID returns the optional external ID of this incoming message
 func (m *MsgIn) ExternalID() string { return m.ExternalID_ }
+
+// Payload returns the optional structured data of this incoming message, e.g. a form submission
+func (m *MsgIn) Payload() json.RawMessage { return m.Payload_ }
 
 // QuickReplies returns the quick replies of this outgoing message
 func (m *MsgOut) QuickReplies() []QuickReply { return m.QuickReplies_ }

--- a/core/msg_test.go
+++ b/core/msg_test.go
@@ -262,6 +262,8 @@ func TestQuickReplies(t *testing.T) {
 		{"Yes<extra>Really", core.QuickReply{Type: "text", Text: "Yes", Extra: "Really"}},
 		{"<location>", core.QuickReply{Type: "location"}},
 		{"<location>Click", core.QuickReply{Type: "location", Text: "Click"}},
+		{"<form>", core.QuickReply{Type: "form"}},
+		{"<form>Book now<extra>123456", core.QuickReply{Type: "form", Text: "Book now", Extra: "123456"}},
 	}
 	for _, tc := range texts {
 		qr := core.QuickReply{}
@@ -284,6 +286,8 @@ func TestQuickReplies(t *testing.T) {
 		{[]byte(`{"text": "Yes", "extra": "Really"}`), core.QuickReply{Text: "Yes", Extra: "Really"}},
 		{[]byte(`{"type": "location"}`), core.QuickReply{Type: "location"}},
 		{[]byte(`{"type": "location", "text": "Click"}`), core.QuickReply{Type: "location", Text: "Click"}},
+		{[]byte(`"<form>Book now<extra>123456"`), core.QuickReply{Type: "form", Text: "Book now", Extra: "123456"}},
+		{[]byte(`{"type": "form", "text": "Book now", "extra": "123456"}`), core.QuickReply{Type: "form", Text: "Book now", Extra: "123456"}},
 	}
 	for _, tc := range jsons {
 		qr := core.QuickReply{}
@@ -296,5 +300,6 @@ func TestQuickReplies(t *testing.T) {
 	assert.Equal(t, []byte(`{"type":"text","text":"Yes"}`), jsonx.MustMarshal(core.QuickReply{Text: "Yes"}))
 	assert.Equal(t, []byte(`{"type":"text","text":"Yes","extra":"Really"}`), jsonx.MustMarshal(core.QuickReply{Text: "Yes", Extra: "Really"}))
 	assert.Equal(t, []byte(`{"type":"location"}`), jsonx.MustMarshal(core.QuickReply{Type: "location"}))
+	assert.Equal(t, []byte(`{"type":"form","text":"Book now","extra":"123456"}`), jsonx.MustMarshal(core.QuickReply{Type: "form", Text: "Book now", Extra: "123456"}))
 	assert.Equal(t, []byte(`[{"type":"text","text":"Yes"},{"type":"text","text":"No"}]`), jsonx.MustMarshal([]core.QuickReply{{Text: "Yes"}, {Text: "No"}}))
 }

--- a/core/msg_test.go
+++ b/core/msg_test.go
@@ -28,6 +28,7 @@ func TestMsgIn(t *testing.T) {
 			utils.Attachment("audio/mp3:https://example.com/test.mp3"),
 		},
 		"EX346436734",
+		json.RawMessage(`{"service": "checkup"}`),
 	)
 
 	// test marshaling our msg
@@ -41,7 +42,8 @@ func TestMsgIn(t *testing.T) {
 		"text":"Hi there",
 		"attachments":["image/jpeg:https://example.com/test.jpg",
 		"audio/mp3:https://example.com/test.mp3"],
-		"external_id":"EX346436734"
+		"external_id":"EX346436734",
+		"payload":{"service": "checkup"}
 	}`), marshaled, "JSON mismatch")
 
 	// test unmarshaling
@@ -53,6 +55,7 @@ func TestMsgIn(t *testing.T) {
 	assert.Equal(t, assets.ChannelUUID("61f38f46-a856-4f90-899e-905691784159"), msg.Channel().UUID)
 	assert.Equal(t, "My Android", msg.Channel().Name)
 	assert.Equal(t, "EX346436734", msg.ExternalID())
+	assert.JSONEq(t, `{"service": "checkup"}`, string(msg.Payload()))
 }
 
 func TestMsgOut(t *testing.T) {

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -210,6 +210,7 @@ func testActionType(t *testing.T, assetsJSON []byte, typeName string) {
 					"audio/mp3:http://s3.amazon.com/bucket/test.mp3",
 				},
 				"",
+				nil,
 			)
 			trigger = triggers.NewBuilder(flow.Reference(false)).MsgReceived(events.NewMsgReceived(msg, "")).Build()
 		}
@@ -983,7 +984,7 @@ func TestStartSessionLoopProtectionWithInput(t *testing.T) {
 		}
 
 		if session.Status() == flows.SessionStatusWaiting {
-			resume := resumes.NewMsg(events.NewMsgReceived(core.NewMsgIn(urns.NilURN, nil, "Hi there", nil, "SMS1234"), ""))
+			resume := resumes.NewMsg(events.NewMsgReceived(core.NewMsgIn(urns.NilURN, nil, "Hi there", nil, "SMS1234", nil), ""))
 			sprint, err = session.Resume(ctx, resume)
 			require.NoError(t, err)
 		}

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -373,7 +373,7 @@ func TestMaxSprintsPerSession(t *testing.T) {
 
 	numResumes := 0
 	for {
-		msg := core.NewMsgIn("tel:+593979123456", nil, "Teal", nil, "SMS1234")
+		msg := core.NewMsgIn("tel:+593979123456", nil, "Teal", nil, "SMS1234", nil)
 		resume := resumes.NewMsg(events.NewMsgReceived(msg, ""))
 		numResumes++
 

--- a/flows/engine/testdata/templates.json
+++ b/flows/engine/testdata/templates.json
@@ -617,6 +617,7 @@
             },
             "created_on": "2017-12-31T11:35:09.123456Z",
             "external_id": "",
+            "payload": null,
             "text": "Hi there",
             "type": "msg",
             "urn": "tel:+12065551212",

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -1,6 +1,7 @@
 package inputs
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/nyaruka/gocommon/jsonx"
@@ -29,6 +30,7 @@ type Msg struct {
 	text        string
 	attachments []utils.Attachment
 	externalID  string
+	payload     json.RawMessage
 }
 
 // NewMsg creates a new user input based on a message event
@@ -45,6 +47,7 @@ func NewMsg(sa flows.SessionAssets, evt *events.MsgReceived) *Msg {
 		text:        evt.Msg.Text(),
 		attachments: evt.Msg.Attachments(),
 		externalID:  evt.Msg.ExternalID(),
+		payload:     evt.Msg.Payload(),
 	}
 }
 
@@ -58,6 +61,7 @@ func NewMsg(sa flows.SessionAssets, evt *events.MsgReceived) *Msg {
 //	text:text -> the text part of the input
 //	attachments:[]text -> any attachments on the input
 //	external_id:text -> the external ID of the input
+//	payload:any -> any structured data on the input, e.g. a form submission
 //
 // @context input
 func (i *Msg) Context(env envs.Environment) map[string]types.XValue {
@@ -72,6 +76,11 @@ func (i *Msg) Context(env envs.Environment) map[string]types.XValue {
 		urn = i.urn.ToXValue(env)
 	}
 
+	var payload types.XValue
+	if len(i.payload) > 0 {
+		payload = types.JSONToXValue(i.payload)
+	}
+
 	return map[string]types.XValue{
 		"__default__": types.NewXText(i.format()),
 		"type":        types.NewXText(i.type_),
@@ -82,6 +91,7 @@ func (i *Msg) Context(env envs.Environment) map[string]types.XValue {
 		"text":        types.NewXText(i.text),
 		"attachments": types.NewXArray(attachments...),
 		"external_id": types.NewXText(i.externalID),
+		"payload":     payload,
 	}
 }
 
@@ -109,6 +119,7 @@ type msgEnvelope struct {
 	Text        string             `json:"text"`
 	Attachments []utils.Attachment `json:"attachments,omitempty"`
 	ExternalID  string             `json:"external_id,omitempty"`
+	Payload     json.RawMessage    `json:"payload,omitempty"`
 }
 
 func readMsg(sa flows.SessionAssets, data []byte, missing assets.MissingCallback) (flows.Input, error) {
@@ -122,6 +133,7 @@ func readMsg(sa flows.SessionAssets, data []byte, missing assets.MissingCallback
 		text:        e.Text,
 		attachments: e.Attachments,
 		externalID:  e.ExternalID,
+		payload:     e.Payload,
 	}
 
 	if err := i.unmarshal(sa, &e.baseEnvelope, missing); err != nil {
@@ -138,6 +150,7 @@ func (i *Msg) MarshalJSON() ([]byte, error) {
 		Text:        i.text,
 		Attachments: i.attachments,
 		ExternalID:  i.externalID,
+		Payload:     i.payload,
 	}
 
 	i.marshal(&e.baseEnvelope)

--- a/flows/inputs/msg_test.go
+++ b/flows/inputs/msg_test.go
@@ -1,6 +1,7 @@
 package inputs_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/nyaruka/gocommon/jsonx"
@@ -33,6 +34,7 @@ func TestMsgInput(t *testing.T) {
 			"video/mp4:http://example.com/test.mp4",
 		},
 		"ext12345",
+		json.RawMessage(`{"service": "checkup", "count": 2}`),
 	), "")
 
 	input := inputs.NewMsg(session.Assets(), msgEvt)
@@ -52,10 +54,14 @@ func TestMsgInput(t *testing.T) {
 		"text":        types.NewXText("Hi there!"),
 		"attachments": types.NewXArray(types.NewXText("image/jpg:http://example.com/test.jpg"), types.NewXText("video/mp4:http://example.com/test.mp4")),
 		"external_id": types.NewXText("ext12345"),
+		"payload": types.NewXObject(map[string]types.XValue{
+			"service": types.NewXText("checkup"),
+			"count":   types.RequireXNumberFromString("2"),
+		}),
 	}), core.Context(env, input))
 
 	// check marshaling to JSON
 	marshaled, err := jsonx.Marshal(input)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"type":"msg","uuid":"01969b47-76cb-76f8-b384-a4094c3d60be","channel":{"uuid":"57f1078f-88aa-46f4-a59a-948a5739c03d","name":"My Android Phone"},"created_on":"2025-05-04T12:31:15.123456789Z","urn":"tel:+1234567890","text":"Hi there!","attachments":["image/jpg:http://example.com/test.jpg","video/mp4:http://example.com/test.mp4"],"external_id":"ext12345"}`, string(marshaled))
+	assert.Equal(t, `{"type":"msg","uuid":"01969b47-76cb-76f8-b384-a4094c3d60be","channel":{"uuid":"57f1078f-88aa-46f4-a59a-948a5739c03d","name":"My Android Phone"},"created_on":"2025-05-04T12:31:15.123456789Z","urn":"tel:+1234567890","text":"Hi there!","attachments":["image/jpg:http://example.com/test.jpg","video/mp4:http://example.com/test.mp4"],"external_id":"ext12345","payload":{"service":"checkup","count":2}}`, string(marshaled))
 }

--- a/flows/resumes/base_test.go
+++ b/flows/resumes/base_test.go
@@ -166,7 +166,7 @@ func TestResumeContext(t *testing.T) {
 	env := envs.NewBuilder().Build()
 
 	var resume flows.Resume = resumes.NewMsg(
-		events.NewMsgReceived(core.NewMsgIn(urns.URN("tel:1234567890"), nil, "Hello", nil, "SMS1234"), ""),
+		events.NewMsgReceived(core.NewMsgIn(urns.URN("tel:1234567890"), nil, "Hello", nil, "SMS1234", nil), ""),
 	)
 
 	assert.Equal(t, map[string]types.XValue{

--- a/flows/triggers/base_test.go
+++ b/flows/triggers/base_test.go
@@ -286,7 +286,7 @@ func TestTriggerMarshaling(t *testing.T) {
 		},
 		{
 			triggers.NewBuilder(flow).
-				MsgReceived(events.NewMsgReceived(core.NewMsgIn(urns.URN("tel:+1234567890"), channel, "Hi there", nil, "SMS1234"), "")).
+				MsgReceived(events.NewMsgReceived(core.NewMsgIn(urns.URN("tel:+1234567890"), channel, "Hi there", nil, "SMS1234", nil), "")).
 				WithMatch(triggers.NewKeywordMatch(triggers.KeywordMatchTypeFirstWord, "hi")).
 				Build(),
 			"msg",

--- a/test/session.go
+++ b/test/session.go
@@ -717,7 +717,7 @@ func (b *SessionBuilder) Build() (flows.SessionAssets, flows.Session, flows.Spri
 
 	var trigger flows.Trigger
 	if b.triggerMsg != "" {
-		msg := core.NewMsgIn(urns.URN("tel:+12065551212"), nil, b.triggerMsg, nil, "SMS1234")
+		msg := core.NewMsgIn(urns.URN("tel:+12065551212"), nil, b.triggerMsg, nil, "SMS1234", nil)
 		trigger = triggers.NewBuilder(flow.Reference(false)).MsgReceived(events.NewMsgReceived(msg, "")).Build()
 	} else {
 		trigger = triggers.NewBuilder(flow.Reference(false)).Manual().Build()
@@ -753,7 +753,7 @@ func ResumeSession(session flows.Session, sa flows.SessionAssets, msgText string
 		return nil, nil, err
 	}
 
-	msg := core.NewMsgIn(urns.NilURN, nil, msgText, nil, "")
+	msg := core.NewMsgIn(urns.NilURN, nil, msgText, nil, "", nil)
 
 	sprint, err := session.Resume(ctx, resumes.NewMsg(events.NewMsgReceived(msg, "")))
 


### PR DESCRIPTION
Adds both halves of engine support for channel forms (e.g. [WhatsApp Flows](https://developers.facebook.com/docs/whatsapp/flows/)).

## Outgoing: `form` quick reply type

A message can offer a form to be opened via a call-to-action button, using the existing quick reply text markup:

```
<form>Book now<extra>123456
```

parses to `{"type": "form", "text": "Book now", "extra": "123456"}` — following the `<location>` prefix precedent, with `extra` carrying the channel-specific form ID for this type (for `text` replies it remains an optional description).

The generic name is deliberate: on WhatsApp channels this will be backed by WhatsApp Flows (`extra` = flow ID, sent as an `interactive`/`flow` message), but the engine is channel-agnostic and "flow" already means something else entirely in this codebase.

Because quick replies are localized and template-evaluated, each language translation can reference a different form — matching the fact that WhatsApp's Flow JSON has no localization support.

## Incoming: `payload` on messages, exposed as `@input.payload`

`MsgIn` gains an optional `payload` field: a JSON object of structured data attached to the message, exposed in expressions as an object at `@input.payload`. Channel handlers are expected to normalize channel-specific replies into this (for WhatsApp Flows: parse `nfm_reply.response_json`, drop `flow_token`, forward the rest). Routers need no changes — a switch can operate on `@input.payload.whatever` with existing tests.

The field is deliberately generic rather than form-specific — it's *the* slot for attaching structured data to an incoming message, whatever prompted it (form submission today; button postbacks etc tomorrow).

Reviewer notes:
- Not validated here: WhatsApp can't render a form button alongside other reply buttons, so that constraint needs enforcing downstream (channel handler or editor).
- Form seed data / entry screen params are out of scope — the flat markup only carries button label + form ID.
- Media form fields (photo/document pickers) are out of scope — the expectation is channels will eventually resolve those into ordinary attachments on the same message.