### PR TITLE
Add 14.4.2 migration to wrap webhook status router operands in default()

### DIFF
--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -24,7 +24,7 @@ import (
 )
 
 // CurrentSpecVersion is the flow spec version supported by this library
-var CurrentSpecVersion = semver.MustParse("14.4.1")
+var CurrentSpecVersion = semver.MustParse("14.4.2")
 var CurrentSupportedSpecs, _ = semver.NewConstraint(">= 11.0.0, < 14.5.0")
 
 // IsVersionSupported checks the given version is supported

--- a/flows/definition/migrations/14.x.go
+++ b/flows/definition/migrations/14.x.go
@@ -10,6 +10,7 @@ import (
 )
 
 func init() {
+	registerMigration(semver.MustParse("14.4.2"), Migrate14_4_2)
 	registerMigration(semver.MustParse("14.4.1"), Migrate14_4_1)
 	registerMigration(semver.MustParse("14.4.0"), Migrate14_4_0)
 	registerMigration(semver.MustParse("14.3.1"), Migrate14_3_1)
@@ -17,6 +18,31 @@ func init() {
 	registerMigration(semver.MustParse("14.2.0"), Migrate14_2_0)
 	registerMigration(semver.MustParse("14.1.0"), Migrate14_1_0)
 	registerMigration(semver.MustParse("14.0.0"), Migrate14_0_0)
+}
+
+// Migrate14_4_2 changes webhook and resthook split routers to use @(default(webhook.status, 0)) as their operand
+// instead of @webhook.status. If a webhook call doesn't happen (e.g. the request exceeds the engine's size limit),
+// @webhook is null and looking up .status on it generates an error event. Wrapping the lookup in default(..) means
+// the operand evaluates to 0 in that case and the contact routes to the failure category without errors.
+//
+// @version 14_4_2 "14.4.2"
+func Migrate14_4_2(f Flow, cfg *Config) (Flow, error) {
+	webhookActions := []string{"call_webhook", "call_resthook"}
+
+	for _, node := range f.Nodes() {
+		actions := node.Actions()
+		router := node.Router()
+
+		if len(actions) != 1 || !slices.Contains(webhookActions, actions[0].Type()) || router == nil || router.Type() != "switch" {
+			continue
+		}
+
+		if operand, _ := router["operand"].(string); operand == "@webhook.status" {
+			router["operand"] = "@(default(webhook.status, 0))"
+		}
+	}
+
+	return f, nil
 }
 
 // Migrate14_4_1 normalises webhook and resthook split routers to the canonical shape: operand @webhook.status with a

--- a/flows/definition/migrations/specdata/templates.json
+++ b/flows/definition/migrations/specdata/templates.json
@@ -1,4 +1,101 @@
 {
+    "14.4.2": {
+        "actions": {
+            "add_contact_groups": [
+                ".groups[*].name_match"
+            ],
+            "add_contact_urn": [
+                ".path"
+            ],
+            "add_input_labels": [
+                ".labels[*].name_match"
+            ],
+            "call_classifier": [
+                ".input"
+            ],
+            "call_llm": [
+                ".input",
+                ".instructions"
+            ],
+            "call_resthook": [],
+            "call_webhook": [
+                ".body",
+                ".headers.*",
+                ".url"
+            ],
+            "enter_flow": [],
+            "open_ticket": [
+                ".assignee.email",
+                ".note"
+            ],
+            "play_audio": [
+                ".audio_url"
+            ],
+            "remove_contact_groups": [
+                ".groups[*].name_match"
+            ],
+            "request_optin": [],
+            "say_msg": [
+                ".text"
+            ],
+            "send_broadcast": [
+                ".attachments[*]",
+                ".contact_query",
+                ".groups[*].name_match",
+                ".legacy_vars[*]",
+                ".quick_replies[*]",
+                ".template_variables[*]",
+                ".text"
+            ],
+            "send_email": [
+                ".addresses[*]",
+                ".body",
+                ".subject"
+            ],
+            "send_msg": [
+                ".attachments[*]",
+                ".quick_replies[*]",
+                ".template_variables[*]",
+                ".text"
+            ],
+            "set_contact_channel": [],
+            "set_contact_field": [
+                ".value"
+            ],
+            "set_contact_language": [
+                ".language"
+            ],
+            "set_contact_name": [
+                ".name"
+            ],
+            "set_contact_status": [],
+            "set_contact_timezone": [
+                ".timezone"
+            ],
+            "set_run_local": [
+                ".value"
+            ],
+            "set_run_result": [
+                ".value"
+            ],
+            "start_session": [
+                ".contact_query",
+                ".groups[*].name_match",
+                ".legacy_vars[*]"
+            ],
+            "transfer_airtime": []
+        },
+        "routers": {
+            "random": [
+                ".operand",
+                ".cases[*].arguments[*]"
+            ],
+            "switch": [
+                ".operand",
+                ".cases[*].arguments[*]"
+            ]
+        }
+    },
     "14.4.1": {
         "actions": {
             "add_contact_groups": [

--- a/flows/definition/migrations/testdata/migrations/14.4.2.json
+++ b/flows/definition/migrations/testdata/migrations/14.4.2.json
@@ -1,0 +1,337 @@
+[
+    {
+        "description": "flow with webhook split on @webhook.status",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.1",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "type": "call_webhook",
+                            "method": "GET",
+                            "url": "http://example.com/"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.2",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "type": "call_webhook",
+                            "method": "GET",
+                            "url": "http://example.com/"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@(default(webhook.status, 0))",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "description": "flow with resthook split on @webhook.status",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.1",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "type": "call_resthook",
+                            "resthook": "new-registration"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.2",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [
+                        {
+                            "uuid": "c766e805-da3a-46f4-97c4-7ce54b16bf71",
+                            "type": "call_resthook",
+                            "resthook": "new-registration"
+                        }
+                    ],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@(default(webhook.status, 0))",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "description": "flow with non-webhook split left unchanged",
+        "original": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.1",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        },
+        "migrated": {
+            "uuid": "25a2d8b2-ae7c-4fed-964a-506fb8c3f0c0",
+            "name": "Test Flow",
+            "spec_version": "14.4.2",
+            "language": "eng",
+            "type": "messaging",
+            "localization": {},
+            "nodes": [
+                {
+                    "uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
+                    "actions": [],
+                    "router": {
+                        "type": "switch",
+                        "operand": "@webhook.status",
+                        "cases": [
+                            {
+                                "uuid": "ff810df6-23c2-4dff-9be1-eebffae2bb9d",
+                                "type": "has_number_between",
+                                "arguments": [
+                                    "200",
+                                    "299"
+                                ],
+                                "category_uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c"
+                            }
+                        ],
+                        "categories": [
+                            {
+                                "uuid": "be4ad508-3afb-4c4a-80ba-86b61518411c",
+                                "name": "Success",
+                                "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                            },
+                            {
+                                "uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551",
+                                "name": "Failure",
+                                "exit_uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                            }
+                        ],
+                        "default_category_uuid": "501fc0c1-28a8-45b2-84f1-b6f9ea17d551"
+                    },
+                    "exits": [
+                        {
+                            "uuid": "24493dc0-687e-4d16-98e5-6e422624729b"
+                        },
+                        {
+                            "uuid": "09f2e979-e6d2-4d0c-b28d-88a836a41d2e"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_ara.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_ara.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "14.4.1",
+    "spec_version": "14.4.2",
     "language": "ara",
     "type": "messaging",
     "revision": 16,

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_kin.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_kin.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "14.4.1",
+    "spec_version": "14.4.2",
     "language": "kin",
     "type": "messaging",
     "revision": 16,

--- a/flows/definition/testdata/TestChangeLanguage_change_language_to_spa.snap
+++ b/flows/definition/testdata/TestChangeLanguage_change_language_to_spa.snap
@@ -1,7 +1,7 @@
 {
     "uuid": "19cad1f2-9110-4271-98d4-1b968bf19410",
     "name": "Change Language",
-    "spec_version": "14.4.1",
+    "spec_version": "14.4.2",
     "language": "spa",
     "type": "messaging",
     "revision": 16,


### PR DESCRIPTION
Follow-on from #1586. Adds a patch spec version (14.4.2) whose migration rewrites webhook and resthook split routers that use `@webhook.status` as their operand to use `@(default(webhook.status, 0))` instead.

If a webhook call doesn't happen (e.g. the request exceeds the engine's size limit), `@webhook` is null and looking up `.status` on it generates error events during routing. With the `default(..)` wrapper the operand evaluates to 0 in that case, so the status check simply fails and the contact routes to the failure category without errors.

Notes for review:
* The migration only touches nodes with a single `call_webhook`/`call_resthook` action and a switch router whose operand is exactly `@webhook.status` — the shape 14.4.1 canonicalised these routers to.
* The 14.4.2 template catalog entry is a copy of 14.4.1's since no action/router schemas changed.
* `TestChangeLanguage` snapshots only change in their `spec_version` field.