### PR TITLE
Remove types.IsNil

### DIFF
--- a/core/expressions.go
+++ b/core/expressions.go
@@ -14,7 +14,8 @@ type Contextable interface {
 
 // Context generates a lazy object for use in expressions
 func Context(env envs.Environment, contextable Contextable) types.XValue {
-	// we allow passing nil pointers which will become non-nil Contextables
+	// this is the one place where callers may pass nil pointers boxed into non-nil Contextables, and we scrub
+	// them to true nils here - XValues themselves are never non-nil interfaces to nil pointers
 	if contextable == nil || reflect.ValueOf(contextable).IsNil() {
 		return nil
 	}

--- a/excellent/functions/builtin.go
+++ b/excellent/functions/builtin.go
@@ -1890,7 +1890,7 @@ func JSON(env envs.Environment, value types.XValue) types.XValue {
 //
 // @function format(value)
 func Format(env envs.Environment, value types.XValue) types.XValue {
-	if !types.IsNil(value) {
+	if value != nil {
 		return types.NewXText(value.Format(env))
 	}
 	return types.XTextEmpty
@@ -2202,7 +2202,7 @@ func IsError(env envs.Environment, value types.XValue) types.XValue {
 // @function count(value)
 func Count(env envs.Environment, value types.XValue) types.XValue {
 	// a nil has count of zero
-	if types.IsNil(value) {
+	if value == nil {
 		return types.XNumberZero
 	}
 

--- a/excellent/tools/context_walk.go
+++ b/excellent/tools/context_walk.go
@@ -20,7 +20,7 @@ func ContextWalkObjects(context *types.XObject, callback func(*types.XObject)) {
 }
 
 func contextWalk(v types.XValue, callback func(types.XValue)) {
-	if types.IsNil(v) {
+	if v == nil {
 		return
 	}
 

--- a/excellent/tools/context_walk_test.go
+++ b/excellent/tools/context_walk_test.go
@@ -23,7 +23,7 @@ func TestContextWalk(t *testing.T) {
 		"zed": types.NewXObject(map[string]types.XValue{
 			"bar": types.NewXNumberFromInt(345),
 		}),
-		"nil": (*types.XObject)(nil), // non-nil interface to a nil struct
+		"nil": nil,
 	})
 
 	// test finding all non-nil values

--- a/excellent/tree.go
+++ b/excellent/tree.go
@@ -45,7 +45,7 @@ func (x *ContextReference) Evaluate(ctx context.Context, env envs.Environment, s
 		return types.NewXErrorf("context has no property '%s'", x.Name)
 	}
 
-	if !types.IsNil(value) && value.Deprecated() != "" {
+	if value != nil && value.Deprecated() != "" {
 		warnings.deprecatedContext(value)
 	}
 
@@ -331,7 +331,7 @@ func resolveLookup(env envs.Environment, container types.XValue, lookup types.XV
 	object, isObject := container.(*types.XObject)
 	var resolved types.XValue
 
-	if isArray && array != nil {
+	if isArray {
 		// if left-hand side is an array, then this is an index
 		index, xerr := types.ToInteger(env, lookup)
 		if xerr != nil {
@@ -347,7 +347,7 @@ func resolveLookup(env envs.Environment, container types.XValue, lookup types.XV
 
 		resolved = array.Get(index)
 
-	} else if isObject && object != nil {
+	} else if isObject {
 		// if left-hand side is an object, then this is a property lookup
 		property, xerr := types.ToXText(env, lookup)
 		if xerr != nil {
@@ -367,7 +367,7 @@ func resolveLookup(env envs.Environment, container types.XValue, lookup types.XV
 		return types.NewXErrorf("%s doesn't support lookups", types.Describe(container))
 	}
 
-	if !types.IsNil(resolved) && resolved.Deprecated() != "" {
+	if resolved != nil && resolved.Deprecated() != "" {
 		warnings.deprecatedContext(resolved)
 	}
 

--- a/excellent/types/array.go
+++ b/excellent/types/array.go
@@ -139,7 +139,7 @@ var XArrayEmpty = NewXArray()
 
 // ToXArray converts the given value to an array
 func ToXArray(env envs.Environment, x XValue) (*XArray, *XError) {
-	if IsNil(x) {
+	if x == nil {
 		return XArrayEmpty, nil
 	}
 	if IsXError(x) {

--- a/excellent/types/base.go
+++ b/excellent/types/base.go
@@ -8,7 +8,9 @@ import (
 	"github.com/nyaruka/goflow/envs"
 )
 
-// XValue is the base interface of all excellent types
+// XValue is the base interface of all excellent types. A nil value is always a true nil interface - never a non-nil
+// interface to a nil pointer - so nil checks are plain x == nil. Code that produces XValues must uphold this, e.g. by
+// nil-checking concrete pointers before boxing (see core.Context which scrubs nil Contextables for this reason).
 type XValue interface {
 	// How type is rendered in console for debugging
 	fmt.Stringer

--- a/excellent/types/base.go
+++ b/excellent/types/base.go
@@ -53,9 +53,9 @@ type XComparable interface {
 // specifically means text(x) == text(y)
 func Equals(x1 XValue, x2 XValue) bool {
 	// nil == nil
-	if IsNil(x1) && IsNil(x2) {
+	if x1 == nil && x2 == nil {
 		return true
-	} else if IsNil(x1) || IsNil(x2) {
+	} else if x1 == nil || x2 == nil {
 		return false
 	}
 
@@ -70,11 +70,11 @@ func Equals(x1 XValue, x2 XValue) bool {
 // Compare compares two given values
 func Compare(x1 XValue, x2 XValue) int {
 	// nil == nil
-	if IsNil(x1) && IsNil(x2) {
+	if x1 == nil && x2 == nil {
 		return 0
-	} else if IsNil(x1) {
+	} else if x1 == nil {
 		return -1
-	} else if IsNil(x2) {
+	} else if x2 == nil {
 		return 1
 	}
 
@@ -98,7 +98,7 @@ func SameType(x1 XValue, x2 XValue) bool {
 
 // Describe returns a representation of the given value for use in error messages
 func Describe(x XValue) string {
-	if IsNil(x) {
+	if x == nil {
 		return "null"
 	}
 	return x.Describe()
@@ -106,7 +106,7 @@ func Describe(x XValue) string {
 
 // Truthy determines truthiness for the given value
 func Truthy(x XValue) bool {
-	if IsNil(x) {
+	if x == nil {
 		return false
 	}
 	return x.Truthy()
@@ -114,7 +114,7 @@ func Truthy(x XValue) bool {
 
 // Render returns the canonical text representation
 func Render(x XValue) string {
-	if IsNil(x) {
+	if x == nil {
 		return ""
 	}
 	return x.Render()
@@ -122,7 +122,7 @@ func Render(x XValue) string {
 
 // Format returns the pretty text representation
 func Format(env envs.Environment, x XValue) string {
-	if IsNil(x) {
+	if x == nil {
 		return ""
 	}
 	return x.Format(env)
@@ -130,16 +130,10 @@ func Format(env envs.Environment, x XValue) string {
 
 // String returns a representation of the given value for use in debugging
 func String(x XValue) string {
-	if IsNil(x) {
+	if x == nil {
 		return "nil"
 	}
 	return x.String()
-}
-
-// IsNil returns whether the given value is nil... because of golang's love of autoboxing nil pointers into non-nil
-// interfaces, we need to check if interface itself is nil or the underlying pointer is nil.
-func IsNil(x XValue) bool {
-	return x == nil || reflect.ValueOf(x).IsNil()
 }
 
 // CostOf returns the cost of producing a value, for the purposes of the per-evaluation budget. Text costs

--- a/excellent/types/boolean.go
+++ b/excellent/types/boolean.go
@@ -89,7 +89,7 @@ var _ XValue = XBooleanFalse
 
 // ToXBoolean converts the given value to a boolean
 func ToXBoolean(x XValue) (*XBoolean, *XError) {
-	if IsNil(x) {
+	if x == nil {
 		return XBooleanFalse, nil
 	}
 	if IsXError(x) {

--- a/excellent/types/date.go
+++ b/excellent/types/date.go
@@ -81,7 +81,7 @@ var _ XValue = XDateZero
 
 // ToXDate converts the given value to a time or returns an error if that isn't possible
 func ToXDate(env envs.Environment, x XValue) (*XDate, *XError) {
-	if !IsNil(x) {
+	if x != nil {
 		switch typed := x.(type) {
 		case *XError:
 			return XDateZero, typed

--- a/excellent/types/datetime.go
+++ b/excellent/types/datetime.go
@@ -134,7 +134,7 @@ func ToXDateTimeWithTimeFill(env envs.Environment, x XValue) (*XDateTime, *XErro
 
 // converts the given value to a time or returns an error if that isn't possible
 func toXDateTime(env envs.Environment, x XValue, fillTime bool) (*XDateTime, *XError) {
-	if !IsNil(x) {
+	if x != nil {
 		switch typed := x.(type) {
 		case *XError:
 			return XDateTimeZero, typed

--- a/excellent/types/json.go
+++ b/excellent/types/json.go
@@ -80,7 +80,7 @@ func jsonToArray(data []byte) *XArray {
 
 // ToXJSON converts the given value to a JSON string
 func ToXJSON(x XValue) (*XText, *XError) {
-	if IsNil(x) {
+	if x == nil {
 		return NewXText(`null`), nil
 	}
 	if IsXError(x) {

--- a/excellent/types/number.go
+++ b/excellent/types/number.go
@@ -345,7 +345,7 @@ func newXNumberFromString(s string) (*XNumber, error) {
 
 // ToXNumber converts the given value to a number or returns an error if that isn't possible
 func ToXNumber(env envs.Environment, x XValue) (*XNumber, *XError) {
-	if !IsNil(x) {
+	if x != nil {
 		switch typed := x.(type) {
 		case *XError:
 			return XNumberZero, typed

--- a/excellent/types/object.go
+++ b/excellent/types/object.go
@@ -99,7 +99,7 @@ func (x *XObject) Format(env envs.Environment) string {
 func (x *XObject) MarshalJSON() ([]byte, error) {
 	marshaled := make(map[string]json.RawMessage, x.Count())
 	for p, v := range x.properties() {
-		if IsNil(v) || x.marshalDeprecated || v.Deprecated() == "" {
+		if v == nil || x.marshalDeprecated || v.Deprecated() == "" {
 			asJSON, err := ToXJSON(v)
 			if err == nil {
 				marshaled[p] = json.RawMessage(asJSON.Native())
@@ -245,7 +245,7 @@ var _ json.Marshaler = (*XObject)(nil)
 
 // ToXObject converts the given value to an object
 func ToXObject(env envs.Environment, x XValue) (*XObject, *XError) {
-	if IsNil(x) {
+	if x == nil {
 		return XObjectEmpty, nil
 	}
 	if IsXError(x) {

--- a/excellent/types/object.go
+++ b/excellent/types/object.go
@@ -253,7 +253,7 @@ func ToXObject(env envs.Environment, x XValue) (*XObject, *XError) {
 	}
 
 	object, isObject := x.(*XObject)
-	if isObject && object != nil {
+	if isObject {
 		return object, nil
 	}
 

--- a/excellent/types/text.go
+++ b/excellent/types/text.go
@@ -88,7 +88,7 @@ var _ XValue = XTextEmpty
 
 // ToXText converts the given value to a string
 func ToXText(env envs.Environment, x XValue) (*XText, *XError) {
-	if IsNil(x) {
+	if x == nil {
 		return XTextEmpty, nil
 	}
 	if IsXError(x) {

--- a/excellent/types/time.go
+++ b/excellent/types/time.go
@@ -87,7 +87,7 @@ var _ XValue = XTimeZero
 
 // ToXTime converts the given value to a time or returns an error if that isn't possible
 func ToXTime(env envs.Environment, x XValue) (*XTime, *XError) {
-	if !IsNil(x) {
+	if x != nil {
 		switch typed := x.(type) {
 		case *XError:
 			return XTimeZero, typed


### PR DESCRIPTION
The reflect-based \`types.IsNil\` helper existed to defend against concrete nil pointers boxed into non-nil \`XValue\` interfaces. Analysis (static enumeration of all ~600 concrete→\`XValue\` conversion sites, plus running the test suite with \`IsNil\` replaced by \`x == nil\`) shows nothing produces such values anymore: conversion functions return non-nil sentinels on every path, and context builders either guard or use \`XValue\`-typed locals.

This makes "an \`XValue\` is nil iff the interface is nil" an enforced invariant:

* \`types.IsNil\` is removed and all call sites use plain \`== nil\` checks, which also removes reflection from hot paths like \`Render\`/\`Format\`/\`Truthy\`.
* The typed-nil guards in \`resolveLookup\` are removed - a typed nil sneaking in would now panic loudly instead of being silently absorbed.
* \`core.Context()\` keeps its reflect scrub and is now documented as the one sanctioned boundary where nil pointers boxed as \`Contextable\` are accepted (callers pass things like \`contact.PreferredChannel()\` unguarded).
* The context walk test manufactured a typed nil to prove the old tolerance - now uses a plain nil.