### PR TITLE
Make @input.payload an empty object instead of null when not set

### DIFF
--- a/flows/engine/testdata/templates.json
+++ b/flows/engine/testdata/templates.json
@@ -617,7 +617,7 @@
             },
             "created_on": "2017-12-31T11:35:09.123456Z",
             "external_id": "",
-            "payload": null,
+            "payload": {},
             "text": "Hi there",
             "type": "msg",
             "urn": "tel:+12065551212",

--- a/flows/inputs/msg.go
+++ b/flows/inputs/msg.go
@@ -76,9 +76,9 @@ func (i *Msg) Context(env envs.Environment) map[string]types.XValue {
 		urn = i.urn.ToXValue(env)
 	}
 
-	var payload types.XValue
-	if len(i.payload) > 0 {
-		payload = types.JSONToXValue(i.payload)
+	payload := types.JSONToXValue(i.payload)
+	if payload == nil {
+		payload = types.XObjectEmpty
 	}
 
 	return map[string]types.XValue{

--- a/flows/inputs/msg_test.go
+++ b/flows/inputs/msg_test.go
@@ -60,6 +60,20 @@ func TestMsgInput(t *testing.T) {
 		}),
 	}), core.Context(env, input))
 
+	// a msg without a payload has an empty payload object in its context
+	noPayloadEvt := events.NewMsgReceived(core.NewMsgIn(
+		urns.URN("tel:+1234567890"),
+		assets.NewChannelReference("57f1078f-88aa-46f4-a59a-948a5739c03d", "Nexmo"),
+		"Hi there!",
+		nil,
+		"",
+		nil,
+	), "")
+	noPayloadInput := inputs.NewMsg(session.Assets(), noPayloadEvt)
+	noPayloadContext, _ := core.Context(env, noPayloadInput).(*types.XObject)
+	payload, _ := noPayloadContext.Get("payload")
+	test.AssertXEqual(t, types.XObjectEmpty, payload)
+
 	// check marshaling to JSON
 	marshaled, err := jsonx.Marshal(input)
 	assert.NoError(t, err)


### PR DESCRIPTION
Since `payload` is always an object when present, expose it as `{}` rather than `null` when the message has no payload — matching the convention used by `@trigger.params`. Fields with a guaranteed shape default to the empty value of that shape (`attachments` → `[]`, `params` → `{}`), while null remains for genuinely any-shaped fields like `@webhook.json` and result `extra`.

This also makes lookups more forgiving: `@(input.payload["x"])`, `count()` and `foreach` behave sensibly on messages without a payload.