### PR TITLE
Make @webhook a zero valued object instead of null when no call recorded

### DIFF
--- a/flows/engine/run.go
+++ b/flows/engine/run.go
@@ -215,6 +215,13 @@ func (r *run) RootContext(env envs.Environment) map[string]types.XValue {
 		node = core.ContextFunc(env, r.nodeContext)
 	}
 
+	// a zero valued call rather than null if no call has been recorded, so that expressions like @webhook.status
+	// evaluate without errors and a flow can route on status == 0 as a failure
+	webhook := r.webhook
+	if webhook == nil {
+		webhook = &flows.WebhookCall{}
+	}
+
 	return map[string]types.XValue{
 		// the available runs
 		"run":    core.Context(env, r),
@@ -234,7 +241,7 @@ func (r *run) RootContext(env envs.Environment) map[string]types.XValue {
 		"resume":       core.Context(env, r.Session().CurrentResume()),
 		"input":        core.Context(env, r.Session().Input()),
 		"globals":      core.Context(env, r.Session().Assets().Globals()),
-		"webhook":      core.Context(env, r.webhook),
+		"webhook":      core.Context(env, webhook),
 		"node":         node,
 		"legacy_extra": r.legacyExtra.ToXValue(env),
 	}

--- a/flows/engine/run_test.go
+++ b/flows/engine/run_test.go
@@ -222,6 +222,26 @@ func TestRunContext(t *testing.T) {
 		assert.Equal(t, tc.expected, actual, "template mismatch for %s", tc.template)
 	}
 
+	// a run with no recorded webhook call presents a zero valued @webhook instead of null
+	run.SetWebhook(nil)
+
+	webhookCases := []struct {
+		template string
+		expected string
+	}{
+		{`@webhook`, ``},
+		{`@webhook.status`, `0`},
+		{`@webhook.headers`, `{}`},
+		{`@webhook.json`, ``},
+		{`@(default(webhook.status, 0))`, `0`},
+	}
+	for _, tc := range webhookCases {
+		log := test.NewEventLog()
+		actual, _ := run.EvaluateTemplate(t.Context(), tc.template, log.Log)
+		assert.NoError(t, log.Error())
+		assert.Equal(t, tc.expected, actual, "template mismatch for %s", tc.template)
+	}
+
 	// test with escaping
 	log := test.NewEventLog()
 	evaluated, _ := run.EvaluateTemplateText(t.Context(), `gender = @("M\" OR")`, contactql.EscapeValue, true, log.Log)

--- a/flows/webhook.go
+++ b/flows/webhook.go
@@ -69,8 +69,13 @@ func (w *WebhookCall) Context(env envs.Environment) map[string]types.XValue {
 		json = nil
 	}
 
+	def := ""
+	if w.Method != "" {
+		def = fmt.Sprintf("%s %s", w.Method, w.URL)
+	}
+
 	return map[string]types.XValue{
-		"__default__": types.NewXText(fmt.Sprintf("%s %s", w.Method, w.URL)),
+		"__default__": types.NewXText(def),
 		"status":      types.NewXNumberFromInt(w.ResponseStatus),
 		"headers":     headers,
 		"json":        json,

--- a/flows/webhook_test.go
+++ b/flows/webhook_test.go
@@ -65,4 +65,12 @@ func TestWebhookCall(t *testing.T) {
 		"headers":     types.XObjectEmpty,
 		"json":        nil,
 	}), core.Context(env, call3))
+
+	// a zero valued call still presents a complete context
+	test.AssertXEqual(t, types.NewXObject(map[string]types.XValue{
+		"__default__": types.XTextEmpty,
+		"status":      types.NewXNumberFromInt(0),
+		"headers":     types.XObjectEmpty,
+		"json":        nil,
+	}), core.Context(env, &flows.WebhookCall{}))
 }

--- a/test/testdata/runner/webhook_results.test.json
+++ b/test/testdata/runner/webhook_results.test.json
@@ -169,27 +169,17 @@
                     "value": "Ok"
                 },
                 {
-                    "code": "expression",
                     "created_on": "2025-05-04T12:31:19.123456789Z",
-                    "extra": {
-                        "expression": "@webhook.json"
-                    },
-                    "text": "Error evaluating expression: null doesn't support lookups",
-                    "type": "error",
-                    "uuid": "01969b47-866b-76f8-b384-a4094c3d60be"
-                },
-                {
-                    "created_on": "2025-05-04T12:31:21.123456789Z",
                     "msg": {
                         "locale": "eng-US",
                         "text": "1. \n2. ",
                         "unsendable_reason": "no_route"
                     },
                     "type": "msg_created",
-                    "uuid": "01969b47-8e3b-76f8-b3a5-b9dac4767740"
+                    "uuid": "01969b47-866b-76f8-b384-a4094c3d60be"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:27.123456789Z",
+                    "created_on": "2025-05-04T12:31:25.123456789Z",
                     "elapsed_ms": 1000,
                     "request": "GET /2 HTTP/1.1\r\nHost: temba.io\r\nUser-Agent: goflow-testing\r\nContent-Type: application/json\r\nAccept-Encoding: gzip\r\n\r\n",
                     "response": "HTTP/1.0 200 OK\r\nContent-Length: 20\r\n\r\n{\"greeting\":\"hello\"}",
@@ -202,34 +192,34 @@
                     "status_code": 200,
                     "type": "webhook_called",
                     "url": "http://temba.io/2",
-                    "uuid": "01969b47-a5ab-76f8-a98e-1c65c9788658"
+                    "uuid": "01969b47-9ddb-76f8-87c7-10f327cbfde2"
                 },
                 {
                     "category": "Success",
-                    "created_on": "2025-05-04T12:31:31.123456789Z",
+                    "created_on": "2025-05-04T12:31:29.123456789Z",
                     "extra": {
                         "greeting": "hello"
                     },
                     "name": "Call 2",
                     "type": "run_result_changed",
-                    "uuid": "01969b47-b54b-76f8-893f-6422e535ea8c",
+                    "uuid": "01969b47-ad7b-76f8-a98e-1c65c9788658",
                     "value": "200"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:35.123456789Z",
+                    "created_on": "2025-05-04T12:31:33.123456789Z",
                     "msg": {
                         "locale": "eng-US",
                         "text": "Would you like to continue again?\n\n1. \n2. {greeting: hello}\n3. {greeting: hello}",
                         "unsendable_reason": "no_route"
                     },
                     "type": "msg_created",
-                    "uuid": "01969b47-c4eb-76f8-b4dd-bb13b355a627"
+                    "uuid": "01969b47-bd1b-76f8-bffe-b26e15b12b0f"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:40.123456789Z",
-                    "expires_on": "2025-05-11T12:31:38.123456789Z",
+                    "created_on": "2025-05-04T12:31:38.123456789Z",
+                    "expires_on": "2025-05-11T12:31:36.123456789Z",
                     "type": "msg_wait",
-                    "uuid": "01969b47-d873-76f8-a58f-30ba497b0d21"
+                    "uuid": "01969b47-d0a3-76f8-9aeb-7faa667f1355"
                 }
             ],
             "segments": [
@@ -246,7 +236,7 @@
                     "exit_uuid": "bd58fffa-f763-4622-bed6-70f1fcd83159",
                     "flow_uuid": "68dae09d-db22-4879-90a7-a89395e3167b",
                     "node_uuid": "23eb8d34-59b6-46b6-991a-440381c54947",
-                    "time": "2025-05-04T12:31:22.123456789Z"
+                    "time": "2025-05-04T12:31:20.123456789Z"
                 },
                 {
                     "destination_uuid": "71e72160-bb45-4abf-ba22-ab646178722a",
@@ -254,14 +244,14 @@
                     "flow_uuid": "68dae09d-db22-4879-90a7-a89395e3167b",
                     "node_uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
                     "operand": "200",
-                    "time": "2025-05-04T12:31:32.123456789Z"
+                    "time": "2025-05-04T12:31:30.123456789Z"
                 },
                 {
                     "destination_uuid": "a28a6ec4-8e43-4362-9c0f-32be98f0b00c",
                     "exit_uuid": "20d4d0a1-b1a8-4bc8-a50d-c5f6cf09cc88",
                     "flow_uuid": "68dae09d-db22-4879-90a7-a89395e3167b",
                     "node_uuid": "71e72160-bb45-4abf-ba22-ab646178722a",
-                    "time": "2025-05-04T12:31:36.123456789Z"
+                    "time": "2025-05-04T12:31:34.123456789Z"
                 }
             ],
             "session": {
@@ -284,7 +274,7 @@
                             "uuid": "68dae09d-db22-4879-90a7-a89395e3167b"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:31:41.123456789Z",
+                        "modified_on": "2025-05-04T12:31:39.123456789Z",
                         "path": [
                             {
                                 "arrived_on": "2025-05-04T12:30:51.123456789Z",
@@ -311,21 +301,21 @@
                                 "uuid": "7913265b-ea6e-42a0-a943-ec055bbeb3b4"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:23.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:21.123456789Z",
                                 "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b",
                                 "node_uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
-                                "uuid": "94070388-5c8b-4c1d-87c7-10f327cbfde2"
+                                "uuid": "c7e91e47-648c-4373-b3a5-b9dac4767740"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:33.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:31.123456789Z",
                                 "exit_uuid": "20d4d0a1-b1a8-4bc8-a50d-c5f6cf09cc88",
                                 "node_uuid": "71e72160-bb45-4abf-ba22-ab646178722a",
-                                "uuid": "a1be431d-f57d-4db6-bffe-b26e15b12b0f"
+                                "uuid": "2dceef06-e669-4bdc-893f-6422e535ea8c"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:37.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:35.123456789Z",
                                 "node_uuid": "a28a6ec4-8e43-4362-9c0f-32be98f0b00c",
-                                "uuid": "ac67e9eb-b541-43e4-9aeb-7faa667f1355"
+                                "uuid": "5f9e5e2d-ea8c-40fd-b4dd-bb13b355a627"
                             }
                         ],
                         "results": {
@@ -339,7 +329,7 @@
                             },
                             "call_2": {
                                 "category": "Success",
-                                "created_on": "2025-05-04T12:31:28.123456789Z",
+                                "created_on": "2025-05-04T12:31:26.123456789Z",
                                 "extra": {
                                     "greeting": "hello"
                                 },
@@ -388,24 +378,24 @@
             "events": [
                 {
                     "category": "All Responses",
-                    "created_on": "2025-05-04T12:31:46.123456789Z",
+                    "created_on": "2025-05-04T12:31:44.123456789Z",
                     "name": "Response 2",
                     "type": "run_result_changed",
-                    "uuid": "01969b47-efe3-76f8-aab8-757fffa552e6",
+                    "uuid": "01969b47-e813-76f8-a8c9-d76ecec32717",
                     "value": "Sure"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:50.123456789Z",
+                    "created_on": "2025-05-04T12:31:48.123456789Z",
                     "msg": {
                         "locale": "eng-US",
                         "text": "Finally..\n\n1. \n2. {greeting: hello}\n3. {greeting: hello}",
                         "unsendable_reason": "no_route"
                     },
                     "type": "msg_created",
-                    "uuid": "01969b47-ff83-76f8-bbf4-9afbc59f7bb4"
+                    "uuid": "01969b47-f7b3-76f8-95d6-85696b970f6a"
                 },
                 {
-                    "created_on": "2025-05-04T12:31:53.123456789Z",
+                    "created_on": "2025-05-04T12:31:51.123456789Z",
                     "flow": {
                         "name": "Webhook Results",
                         "revision": 23,
@@ -414,7 +404,7 @@
                     "run_uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
                     "status": "completed",
                     "type": "run_ended",
-                    "uuid": "01969b48-0b3b-76f8-ab7b-b7ab5b0dc119"
+                    "uuid": "01969b48-036b-76f8-bbf4-9afbc59f7bb4"
                 }
             ],
             "segments": [
@@ -424,7 +414,7 @@
                     "flow_uuid": "68dae09d-db22-4879-90a7-a89395e3167b",
                     "node_uuid": "a28a6ec4-8e43-4362-9c0f-32be98f0b00c",
                     "operand": "Sure",
-                    "time": "2025-05-04T12:31:47.123456789Z"
+                    "time": "2025-05-04T12:31:45.123456789Z"
                 }
             ],
             "session": {
@@ -440,14 +430,14 @@
                 "runs": [
                     {
                         "created_on": "2025-05-04T12:30:47.123456789Z",
-                        "exited_on": "2025-05-04T12:31:51.123456789Z",
+                        "exited_on": "2025-05-04T12:31:49.123456789Z",
                         "flow": {
                             "name": "Webhook Results",
                             "revision": 23,
                             "uuid": "68dae09d-db22-4879-90a7-a89395e3167b"
                         },
                         "had_input": true,
-                        "modified_on": "2025-05-04T12:31:51.123456789Z",
+                        "modified_on": "2025-05-04T12:31:49.123456789Z",
                         "path": [
                             {
                                 "arrived_on": "2025-05-04T12:30:51.123456789Z",
@@ -474,28 +464,28 @@
                                 "uuid": "7913265b-ea6e-42a0-a943-ec055bbeb3b4"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:23.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:21.123456789Z",
                                 "exit_uuid": "24493dc0-687e-4d16-98e5-6e422624729b",
                                 "node_uuid": "4eab7a66-0b55-45f6-803f-129a6f49e723",
-                                "uuid": "94070388-5c8b-4c1d-87c7-10f327cbfde2"
+                                "uuid": "c7e91e47-648c-4373-b3a5-b9dac4767740"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:33.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:31.123456789Z",
                                 "exit_uuid": "20d4d0a1-b1a8-4bc8-a50d-c5f6cf09cc88",
                                 "node_uuid": "71e72160-bb45-4abf-ba22-ab646178722a",
-                                "uuid": "a1be431d-f57d-4db6-bffe-b26e15b12b0f"
+                                "uuid": "2dceef06-e669-4bdc-893f-6422e535ea8c"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:37.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:35.123456789Z",
                                 "exit_uuid": "066c4b62-72f2-460b-a671-b4fa919c745a",
                                 "node_uuid": "a28a6ec4-8e43-4362-9c0f-32be98f0b00c",
-                                "uuid": "ac67e9eb-b541-43e4-9aeb-7faa667f1355"
+                                "uuid": "5f9e5e2d-ea8c-40fd-b4dd-bb13b355a627"
                             },
                             {
-                                "arrived_on": "2025-05-04T12:31:48.123456789Z",
+                                "arrived_on": "2025-05-04T12:31:46.123456789Z",
                                 "exit_uuid": "28236174-02ce-49b0-bdce-403afd9850fb",
                                 "node_uuid": "066c0ea6-68f1-4849-a4f5-5ef3465e9e97",
-                                "uuid": "77c27f9f-cee2-4c0a-95d6-85696b970f6a"
+                                "uuid": "99d743e0-7972-4b93-aab8-757fffa552e6"
                             }
                         ],
                         "results": {
@@ -509,7 +499,7 @@
                             },
                             "call_2": {
                                 "category": "Success",
-                                "created_on": "2025-05-04T12:31:28.123456789Z",
+                                "created_on": "2025-05-04T12:31:26.123456789Z",
                                 "extra": {
                                     "greeting": "hello"
                                 },
@@ -528,7 +518,7 @@
                             },
                             "response_2": {
                                 "category": "All Responses",
-                                "created_on": "2025-05-04T12:31:43.123456789Z",
+                                "created_on": "2025-05-04T12:31:41.123456789Z",
                                 "input": "Sure",
                                 "name": "Response 2",
                                 "node_uuid": "a28a6ec4-8e43-4362-9c0f-32be98f0b00c",


### PR DESCRIPTION
Since #1586, webhook and resthook actions clear `@webhook` before executing so it never holds a stale result from a previous call. A side effect is that flows referencing webhook properties after a skipped call (invalid URL, resthook with no subscribers) hit null lookup errors — e.g. a router with a bare `@webhook.status` operand logs `null doesn't support lookups` error events.

This makes `@webhook` present a zero valued call context instead of null when no call has been recorded:

* `status` → `0`
* `headers` → `{}`
* `json` → null (matching what a real failed call produces, so `@webhook.json.foo` behaves the same after a skipped call as after a failed one)
* `__default__` → empty text

Flows routing on `@webhook.status` now route to their failure category without errors and without needing to wrap the operand in `default(webhook.status, 0)` (which still works unchanged). Run persistence is untouched — a run with no webhook call still marshals without a `webhook` field.

Follows the same approach as #1592 did for `@input.payload`.