### PR TITLE
Change request_optin action to log an error event as opt-in requests are no longer supported

### DIFF
--- a/cmd/docgen/docs/html_renderers.go
+++ b/cmd/docgen/docs/html_renderers.go
@@ -451,10 +451,13 @@ func eventsForAction(action flows.Action, msgSession flows.Session, voiceSession
 
 	eventJSON := make([]json.RawMessage, len(eventList))
 	for i, event := range eventList {
-		// action examples aren't supposed to generate error events - if they have, something went wrong
+		// aside from unsupported actions, action examples aren't supposed to generate error events -
+		// if they have, something went wrong
 		if event.Type() == events.TypeError {
 			errEvent := event.(*events.Error)
-			return nil, fmt.Errorf("error event generated: %s", errEvent.Text)
+			if errEvent.Code != events.ErrorCodeActionUnsupported {
+				return nil, fmt.Errorf("error event generated: %s", errEvent.Text)
+			}
 		}
 
 		eventJSON[i], err = jsonx.MarshalPretty(event)

--- a/core/events/error.go
+++ b/core/events/error.go
@@ -14,6 +14,7 @@ func init() {
 const TypeError string = "error"
 
 const (
+	ErrorCodeActionUnsupported    = "action:unsupported"
 	ErrorCodeDependencyMissing    = "dependency:missing"
 	ErrorCodeURNTaken             = "urn:taken"
 	ErrorCodeExpression           = "expression"
@@ -69,4 +70,9 @@ func NewRawError(err error) *Error {
 // NewDependencyError returns an error event for a missing dependency
 func NewDependencyError(ref assets.Reference) *Error {
 	return NewError(fmt.Sprintf("Missing dependency: %s", ref.String()), ErrorCodeDependencyMissing)
+}
+
+// NewActionUnsupportedError returns an error event for an action that is no longer supported
+func NewActionUnsupportedError(text string) *Error {
+	return NewError(text, ErrorCodeActionUnsupported)
 }

--- a/flows/actions/request_optin.go
+++ b/flows/actions/request_optin.go
@@ -15,9 +15,9 @@ func init() {
 // TypeRequestOptIn is the type for the send optin action
 const TypeRequestOptIn string = "request_optin"
 
-// RequestOptIn can be used to request an optin from the contact.
+// RequestOptIn was used to request an optin from the contact but is no longer supported.
 //
-// An [event:optin_requested] event will be created if the contact has a channel that supports optins.
+// An [event:error] event will be created.
 //
 //	{
 //	  "uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",
@@ -44,19 +44,9 @@ func NewRequestOptIn(uuid flows.ActionUUID, optIn *assets.OptInReference) *Reque
 	}
 }
 
-// Execute creates the optin events
+// Execute logs an error event as this action is no longer supported
 func (a *RequestOptIn) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
-	optIn := run.Session().Assets().OptIns().Get(a.OptIn.UUID)
-	if optIn == nil {
-		log(events.NewDependencyError(a.OptIn))
-		return nil
-	}
-
-	route := run.Contact().ResolveRoute()
-
-	if route != nil && route.Channel.HasFeature(assets.ChannelFeatureOptIns) {
-		log(events.NewOptInRequested(optIn.Reference(), route.Channel.Reference(), route.URN))
-	}
+	log(events.NewActionUnsupportedError("opt-in requests are no longer supported"))
 
 	return nil
 }

--- a/flows/actions/testdata/request_optin.json
+++ b/flows/actions/testdata/request_optin.json
@@ -1,6 +1,44 @@
 [
     {
-        "description": "Error event for invalid optin reference",
+        "description": "Error event because action is no longer supported",
+        "action": {
+            "type": "request_optin",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "optin": {
+                "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
+                "name": "Joke Of The Day"
+            }
+        },
+        "events": [
+            {
+                "uuid": "01969b47-307b-76f8-a7eb-cc4cc9ec3e6b",
+                "type": "error",
+                "created_on": "2025-05-04T12:30:57.123456789Z",
+                "text": "opt-in requests are no longer supported",
+                "code": "action:unsupported"
+            }
+        ],
+        "locals_after": {},
+        "inspection": {
+            "counts": {
+                "languages": 0,
+                "nodes": 1
+            },
+            "dependencies": [
+                {
+                    "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
+                    "name": "Joke Of The Day",
+                    "type": "optin"
+                }
+            ],
+            "locals": [],
+            "results": [],
+            "parent_refs": [],
+            "issues": []
+        }
+    },
+    {
+        "description": "Missing optin dependency still reported by inspection",
         "action": {
             "type": "request_optin",
             "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
@@ -14,8 +52,8 @@
                 "uuid": "01969b47-307b-76f8-a7eb-cc4cc9ec3e6b",
                 "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
-                "text": "Missing dependency: optin[uuid=e0f463b9-2704-4d9c-b04a-bfc1187430ba,name=Deleted]",
-                "code": "dependency:missing"
+                "text": "opt-in requests are no longer supported",
+                "code": "action:unsupported"
             }
         ],
         "locals_after": {},
@@ -48,94 +86,6 @@
                     }
                 }
             ]
-        }
-    },
-    {
-        "description": "NOOP when channel doesn't support optins feature",
-        "action": {
-            "type": "request_optin",
-            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
-            "optin": {
-                "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
-                "name": "Joke Of The Day"
-            }
-        },
-        "events": [],
-        "locals_after": {},
-        "inspection": {
-            "counts": {
-                "languages": 0,
-                "nodes": 1
-            },
-            "dependencies": [
-                {
-                    "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
-                    "name": "Joke Of The Day",
-                    "type": "optin"
-                }
-            ],
-            "locals": [],
-            "results": [],
-            "parent_refs": [],
-            "issues": []
-        }
-    },
-    {
-        "description": "Event created when channel does support optins feature",
-        "contact": {
-            "uuid": "5d76d86b-3bb9-4d5a-b822-c9d86f5d8e4f",
-            "name": "Ryan Lewis",
-            "status": "active",
-            "language": "eng",
-            "timezone": "America/Guayaquil",
-            "urns": [
-                "facebook:1234567890"
-            ],
-            "groups": [],
-            "fields": {},
-            "created_on": "2018-06-20T11:40:30.123456789-00:00"
-        },
-        "action": {
-            "type": "request_optin",
-            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
-            "optin": {
-                "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
-                "name": "Joke Of The Day"
-            }
-        },
-        "events": [
-            {
-                "uuid": "01969b47-307b-76f8-a7eb-cc4cc9ec3e6b",
-                "type": "optin_requested",
-                "created_on": "2025-05-04T12:30:57.123456789Z",
-                "optin": {
-                    "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
-                    "name": "Joke Of The Day"
-                },
-                "channel": {
-                    "uuid": "4bb288a0-7fca-4da1-abe8-59a593aff648",
-                    "name": "Facebook Channel"
-                },
-                "urn": "facebook:1234567890"
-            }
-        ],
-        "locals_after": {},
-        "inspection": {
-            "counts": {
-                "languages": 0,
-                "nodes": 1
-            },
-            "dependencies": [
-                {
-                    "uuid": "248be71d-78e9-4d71-a6c4-9981d369e5cb",
-                    "name": "Joke Of The Day",
-                    "type": "optin"
-                }
-            ],
-            "locals": [],
-            "results": [],
-            "parent_refs": [],
-            "issues": []
         }
     }
 ]


### PR DESCRIPTION
Meta deprecated the Recurring Notifications API that underpinned Facebook opt-in requests, so this action can no longer do anything useful.

## What changed

* `request_optin` now unconditionally logs an error event (`opt-in requests are no longer supported`) and never emits `optin_requested`. The action still parses, validates and reports its opt-in dependency via inspection, so existing flow definitions remain valid.
* Adds a new generic error code `action:unsupported` (with `NewActionUnsupportedError` constructor) that can be reused for future action retirements.
* Docgen previously failed if an action example generated an error event — it now allows `action:unsupported` errors and renders them as the action's documented output.

## Reviewer notes

Mailroom's `PersistEvent` filter will need a follow-up change to persist `action:unsupported` errors to contact history.