### PR TITLE
Add size limits to flow _ui section and localization values

### DIFF
--- a/flows/definition/flow.go
+++ b/flows/definition/flow.go
@@ -109,6 +109,9 @@ func (f *flow) validate() error {
 	if len(f.nodes) > flows.MaxNodesPerFlow {
 		return fmt.Errorf("flow can't have more than %d nodes (has %d)", flows.MaxNodesPerFlow, len(f.nodes))
 	}
+	if len(f.ui) > flows.MaxUIBytes {
+		return fmt.Errorf("flow UI can't be larger than %d bytes (is %d)", flows.MaxUIBytes, len(f.ui))
+	}
 
 	// track UUIDs used by nodes and actions to ensure that they are unique
 	seenUUIDs := make(map[uuids.UUID]bool)
@@ -334,7 +337,7 @@ func readFlow(data []byte, mc *migrations.Config, a assets.Flow) (flows.Flow, er
 		mc = migrations.DefaultConfig
 	}
 
-	// reject flows with too many nodes before migrating - migration re-reads and re-marshals the entire
+	// reject over-sized flows before migrating - migration re-reads and re-marshals the entire
 	// definition once per version step, so this avoids doing that expensive work for a definition that
 	// will be rejected by validation anyway
 	if err := checkFlowSize(data); err != nil {
@@ -371,11 +374,11 @@ func readFlow(data []byte, mc *migrations.Config, a assets.Flow) (flows.Flow, er
 	return NewFlow(e.UUID, e.Name, e.Language, e.Type, e.Revision, time.Duration(e.ExpireAfterMinutes)*time.Minute, e.Localization, nodes, e.UI, a)
 }
 
-// checkFlowSize counts the nodes in a flow definition (current or legacy format) and returns an error if
-// there are more than are allowed. It walks only the relevant arrays without decoding their contents or the
-// rest of the definition, so it's cheap relative to the full parse and migration that follow. Malformed or
-// duplicated input can only make it under-count, so it never rejects a flow that would otherwise be valid -
-// the authoritative check remains the post-migration validation.
+// checkFlowSize counts the nodes and measures the _ui section of a flow definition (current or legacy
+// format) and returns an error if either exceeds what is allowed. It walks only the relevant parts without
+// decoding their contents or the rest of the definition, so it's cheap relative to the full parse and
+// migration that follow. Malformed or duplicated input can only make it under-count, so it never rejects a
+// flow that would otherwise be valid - the authoritative checks remain the post-migration validation.
 func checkFlowSize(data []byte) error {
 	numNodes := 0
 	countElement := func([]byte, jsonparser.ValueType, int, error) { numNodes++ }
@@ -386,6 +389,10 @@ func checkFlowSize(data []byte) error {
 
 	if numNodes > flows.MaxNodesPerFlow {
 		return fmt.Errorf("flow can't have more than %d nodes (has %d)", flows.MaxNodesPerFlow, numNodes)
+	}
+
+	if ui, _, _, _ := jsonparser.Get(data, "_ui"); len(ui) > flows.MaxUIBytes {
+		return fmt.Errorf("flow UI can't be larger than %d bytes (is %d)", flows.MaxUIBytes, len(ui))
 	}
 
 	return nil

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -577,7 +577,7 @@ func TestReadFlowWithOversizedLocalization(t *testing.T) {
 
 	// translated properties can't have too many values
 	err = read(fmt.Sprintf(`{"spa": {"7e994e0d-9c51-4050-bc66-d698b8391684": {"text": [%s"x"]}}}`, strings.Repeat(`"x",`, flows.MaxValuesPerProperty)))
-	assert.EqualError(t, err, "invalid localization: invalid translation for 'spa': invalid item translation for '7e994e0d-9c51-4050-bc66-d698b8391684': translation for 'text' can't have more than 100 values (has 101)")
+	assert.EqualError(t, err, "invalid localization: invalid translation for 'spa': invalid item translation for '7e994e0d-9c51-4050-bc66-d698b8391684': translation for 'text' can't have more than 10 values (has 11)")
 
 	// items can't have too many translated properties
 	props := make([]string, flows.MaxPropertiesPerItem+1)

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -1,6 +1,7 @@
 package definition_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -548,6 +549,47 @@ func TestReadFlowSizeGuard(t *testing.T) {
 
 	_, err := definition.ReadFlow([]byte(legacyDef), nil)
 	assert.EqualError(t, err, fmt.Sprintf("flow can't have more than %d nodes (has %d)", flows.MaxNodesPerFlow, flows.MaxNodesPerFlow+1))
+}
+
+func TestReadFlowWithOversizedUI(t *testing.T) {
+	// a definition with an over-sized _ui section is rejected up front, before the expensive migration passes
+	ui := fmt.Sprintf(`{"stuff": "%s"}`, strings.Repeat("x", flows.MaxUIBytes))
+	def := fmt.Sprintf(`{"uuid":"8ca44c09-791d-453a-9799-a70dd3303306","name":"Test","spec_version":"%s","language":"eng","type":"messaging","nodes":[],"_ui":%s}`, definition.CurrentSpecVersion, ui)
+
+	_, err := definition.ReadFlow([]byte(def), nil)
+	assert.EqualError(t, err, fmt.Sprintf("flow UI can't be larger than %d bytes (is %d)", flows.MaxUIBytes, len(ui)))
+
+	// and the same limit is enforced when constructing a flow directly
+	_, err = definition.NewFlow("8ca44c09-791d-453a-9799-a70dd3303306", "Test", "eng", flows.FlowTypeMessaging, 1, 0, definition.NewLocalization(), nil, json.RawMessage(ui), nil)
+	assert.EqualError(t, err, fmt.Sprintf("flow UI can't be larger than %d bytes (is %d)", flows.MaxUIBytes, len(ui)))
+}
+
+func TestReadFlowWithOversizedLocalization(t *testing.T) {
+	read := func(l10n string) error {
+		def := fmt.Sprintf(`{"uuid":"8ca44c09-791d-453a-9799-a70dd3303306","name":"Test","spec_version":"%s","language":"eng","type":"messaging","localization":%s,"nodes":[]}`, definition.CurrentSpecVersion, l10n)
+		_, err := definition.ReadFlow([]byte(def), nil)
+		return err
+	}
+
+	// translation values can't be longer than the longest localizable text
+	err := read(fmt.Sprintf(`{"spa": {"7e994e0d-9c51-4050-bc66-d698b8391684": {"text": ["%s"]}}}`, strings.Repeat("x", flows.MaxTranslationValueChars+1)))
+	assert.EqualError(t, err, "invalid localization: invalid translation for 'spa': invalid item translation for '7e994e0d-9c51-4050-bc66-d698b8391684': translation value for 'text' can't be longer than 10000 chars (is 10001)")
+
+	// translated properties can't have too many values
+	err = read(fmt.Sprintf(`{"spa": {"7e994e0d-9c51-4050-bc66-d698b8391684": {"text": [%s"x"]}}}`, strings.Repeat(`"x",`, flows.MaxValuesPerProperty)))
+	assert.EqualError(t, err, "invalid localization: invalid translation for 'spa': invalid item translation for '7e994e0d-9c51-4050-bc66-d698b8391684': translation for 'text' can't have more than 100 values (has 101)")
+
+	// items can't have too many translated properties
+	props := make([]string, flows.MaxPropertiesPerItem+1)
+	for i := range props {
+		props[i] = fmt.Sprintf(`"prop%d": ["x"]`, i)
+	}
+	err = read(fmt.Sprintf(`{"spa": {"7e994e0d-9c51-4050-bc66-d698b8391684": {%s}}}`, strings.Join(props, ",")))
+	assert.EqualError(t, err, "invalid localization: invalid translation for 'spa': invalid item translation for '7e994e0d-9c51-4050-bc66-d698b8391684': can't have more than 10 properties (has 11)")
+
+	// non-string values (e.g. _ui metadata) are limited by their marshaled size
+	err = read(fmt.Sprintf(`{"spa": {"7e994e0d-9c51-4050-bc66-d698b8391684": {"_ui": {"stuff": "%s"}}}}`, strings.Repeat("x", flows.MaxTranslationValueChars)))
+	assert.EqualError(t, err, "invalid localization: invalid translation for 'spa': invalid item translation for '7e994e0d-9c51-4050-bc66-d698b8391684': translation value for '_ui' can't be larger than 10000 bytes (is 10012)")
 }
 
 func TestExtractTemplatesAndLocalizables(t *testing.T) {

--- a/flows/definition/localization.go
+++ b/flows/definition/localization.go
@@ -2,6 +2,7 @@ package definition
 
 import (
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
@@ -20,10 +21,40 @@ import (
 type itemTranslation map[string]any
 
 func (l itemTranslation) validate() error {
-	for property := range l {
+	if len(l) > flows.MaxPropertiesPerItem {
+		return fmt.Errorf("can't have more than %d properties (has %d)", flows.MaxPropertiesPerItem, len(l))
+	}
+
+	for property, value := range l {
 		if len(property) == 0 || len(property) > 64 {
 			return fmt.Errorf("invalid property name '%s'", stringsx.TruncateEllipsis(property, 32))
 		}
+
+		if asSlice, ok := value.([]any); ok {
+			if len(asSlice) > flows.MaxValuesPerProperty {
+				return fmt.Errorf("translation for '%s' can't have more than %d values (has %d)", property, flows.MaxValuesPerProperty, len(asSlice))
+			}
+			for _, v := range asSlice {
+				if err := checkTranslationValue(property, v); err != nil {
+					return err
+				}
+			}
+		} else if err := checkTranslationValue(property, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checks the size of a single translation value - values should be strings but editors are allowed to
+// stuff other things in here (e.g. _ui metadata) which we tolerate but still limit by size
+func checkTranslationValue(property string, v any) error {
+	if asString, ok := v.(string); ok {
+		if length := utf8.RuneCountInString(asString); length > flows.MaxTranslationValueChars {
+			return fmt.Errorf("translation value for '%s' can't be longer than %d chars (is %d)", property, flows.MaxTranslationValueChars, length)
+		}
+	} else if marshaled, _ := jsonx.Marshal(v); len(marshaled) > flows.MaxTranslationValueChars {
+		return fmt.Errorf("translation value for '%s' can't be larger than %d bytes (is %d)", property, flows.MaxTranslationValueChars, len(marshaled))
 	}
 	return nil
 }
@@ -70,6 +101,10 @@ func (t itemTranslation) get(property string) []string {
 type languageTranslation map[uuids.UUID]itemTranslation
 
 func (l languageTranslation) validate() error {
+	if len(l) > flows.MaxItemsPerLanguage {
+		return fmt.Errorf("can't have more than %d item translations (has %d)", flows.MaxItemsPerLanguage, len(l))
+	}
+
 	for uuid, item := range l {
 		if !uuids.Is(string(uuid)) {
 			return fmt.Errorf("invalid item uuid '%s'", uuid)

--- a/flows/definition/localization_test.go
+++ b/flows/definition/localization_test.go
@@ -1,11 +1,15 @@
 package definition_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/nyaruka/gocommon/i18n"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/definition"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocalization(t *testing.T) {
@@ -45,4 +49,22 @@ func TestLocalization(t *testing.T) {
 	assert.Nil(t, l8n.GetItemTranslation("spa", "ac110f56-a66c-4462-921c-b2c6d1c6dadb", "bad1"))
 	assert.Nil(t, l8n.GetItemTranslation("spa", "ac110f56-a66c-4462-921c-b2c6d1c6dadb", "bad2"))
 	assert.Nil(t, l8n.GetItemTranslation("spa", "ac110f56-a66c-4462-921c-b2c6d1c6dadb", "xxx"))
+}
+
+func TestLocalizationWithTooManyItems(t *testing.T) {
+	// a language can't have translations for more items than a max sized flow could possibly contain
+	b := &strings.Builder{}
+	b.WriteString(`{"spa": {`)
+	for i := 0; i <= flows.MaxItemsPerLanguage; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(b, `"e0323e14-9dcf-4a8d-b721-%012d": {}`, i)
+	}
+	b.WriteString(`}}`)
+
+	l8n, err := definition.ReadLocalization([]byte(b.String()))
+	require.NoError(t, err)
+
+	assert.EqualError(t, l8n.Validate(), fmt.Sprintf("invalid translation for 'spa': can't have more than %d item translations (has %d)", flows.MaxItemsPerLanguage, flows.MaxItemsPerLanguage+1))
 }

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -32,7 +32,7 @@ const (
 	// localizable items are actions, cases and categories, so the limits above give us the max possible per language
 	MaxItemsPerLanguage      = MaxNodesPerFlow * (MaxActionsPerNode + MaxCasesPerRouter + MaxCategoriesPerRouter)
 	MaxPropertiesPerItem     = 10    // no item has more than a few localizable properties (plus _ui metadata)
-	MaxValuesPerProperty     = 100   // max number of values in a translated property (e.g. quick replies)
+	MaxValuesPerProperty     = 10    // no localizable array is allowed more values than this (quick replies, attachments, case arguments)
 	MaxTranslationValueChars = 10000 // max length of a translation value (same as longest localizable text)
 )
 

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -21,12 +21,19 @@ import (
 )
 
 const (
-	MaxNodesPerFlow        = 1000 // max number of nodes in a flow
-	MaxActionsPerNode      = 100  // max number of actions in a node
-	MaxExitsPerNode        = 100  // max number of exits in a node
-	MaxCategoriesPerRouter = 100  // max number of categories a router can have
-	MaxCasesPerRouter      = 100  // max number of categories a switch router can have
-	MaxArgumentsPerCase    = 10   // max number of test arguments a switch router case can have
+	MaxNodesPerFlow        = 1000   // max number of nodes in a flow
+	MaxActionsPerNode      = 100    // max number of actions in a node
+	MaxExitsPerNode        = 100    // max number of exits in a node
+	MaxCategoriesPerRouter = 100    // max number of categories a router can have
+	MaxCasesPerRouter      = 100    // max number of categories a switch router can have
+	MaxArgumentsPerCase    = 10     // max number of test arguments a switch router case can have
+	MaxUIBytes             = 262144 // max size in bytes of a flow's _ui section
+
+	// localizable items are actions, cases and categories, so the limits above give us the max possible per language
+	MaxItemsPerLanguage      = MaxNodesPerFlow * (MaxActionsPerNode + MaxCasesPerRouter + MaxCategoriesPerRouter)
+	MaxPropertiesPerItem     = 10    // no item has more than a few localizable properties (plus _ui metadata)
+	MaxValuesPerProperty     = 100   // max number of values in a translated property (e.g. quick replies)
+	MaxTranslationValueChars = 10000 // max length of a translation value (same as longest localizable text)
 )
 
 // CategoryUUID is the UUID of a node category


### PR DESCRIPTION
Follows the recent work adding length limits to flow definition fields by closing the two remaining places where arbitrary amounts of data could be stuffed into a definition.

## \_ui section

The engine doesn't parse `_ui` so it can't be validated structurally - instead it now gets a total size limit (`MaxUIBytes` = 256KiB). The authoritative check lives in flow validation, with a cheap pre-migration guard in `checkFlowSize` (same pattern as the node count) so an over-sized definition is rejected before paying for the per-version migration passes. Analysis of real-world flows shows the largest `_ui` sections are around half this limit, so no existing flows are affected.

## Localization

Previously only language codes, item UUIDs and property names were validated - values could be arbitrary JSON of any size. There's now a cap at every level of the hierarchy:

* `MaxItemsPerLanguage` (300,000) - derived from the structural limits, since localizable items are actions, cases and categories: `MaxNodesPerFlow * (MaxActionsPerNode + MaxCasesPerRouter + MaxCategoriesPerRouter)`
* `MaxPropertiesPerItem` (10) - no item has more than a few localizable properties plus editor `_ui` metadata
* `MaxValuesPerProperty` (10) - matches the largest localizable arrays (quick replies, attachments, case arguments)
* `MaxTranslationValueChars` (10,000) - matches the longest localizable text (message text, email body), measured in runes to be consistent with `max=10000` validator semantics on the source fields

Non-string-array values in item translations (i.e. the `_ui` metadata editors stuff in there) are still tolerated but are now capped by their marshaled size instead of being unlimited.
