### PR TITLE
Add max length validation to asset reference names

### DIFF
--- a/assets/campaign.go
+++ b/assets/campaign.go
@@ -28,7 +28,7 @@ type Campaign interface {
 // CampaignReference is used to reference a campaign
 type CampaignReference struct {
 	UUID CampaignUUID `json:"uuid" validate:"required,uuid"`
-	Name string       `json:"name"`
+	Name string       `json:"name" validate:"max=64"`
 }
 
 // NewCampaignReference creates a new campaign reference with the given UUID and name

--- a/assets/channel.go
+++ b/assets/channel.go
@@ -56,7 +56,7 @@ type Channel interface {
 // ChannelReference is used to reference a channel
 type ChannelReference struct {
 	UUID ChannelUUID `json:"uuid" validate:"required,uuid"`
-	Name string      `json:"name"`
+	Name string      `json:"name" validate:"max=64"`
 }
 
 // NewChannelReference creates a new channel reference with the given UUID and name

--- a/assets/field.go
+++ b/assets/field.go
@@ -41,8 +41,8 @@ type Field interface {
 
 // FieldReference is a reference to a field
 type FieldReference struct {
-	Key  string `json:"key" validate:"required"`
-	Name string `json:"name"`
+	Key  string `json:"key" validate:"required,max=64"`
+	Name string `json:"name" validate:"max=64"`
 }
 
 // NewFieldReference creates a new field reference with the given key and name

--- a/assets/flow.go
+++ b/assets/flow.go
@@ -29,7 +29,7 @@ type Flow interface {
 // FlowReference is used to reference a flow from another flow
 type FlowReference struct {
 	UUID     FlowUUID `json:"uuid" validate:"required,uuid"`
-	Name     string   `json:"name"`
+	Name     string   `json:"name" validate:"max=64"`
 	Revision int      `json:"revision,omitempty"`
 }
 

--- a/assets/global.go
+++ b/assets/global.go
@@ -19,8 +19,8 @@ type Global interface {
 
 // GlobalReference is a reference to a global
 type GlobalReference struct {
-	Key  string `json:"key" validate:"required"`
-	Name string `json:"name"`
+	Key  string `json:"key" validate:"required,max=64"`
+	Name string `json:"name" validate:"max=64"`
 }
 
 // NewGlobalReference creates a new global reference with the given key and name

--- a/assets/group.go
+++ b/assets/group.go
@@ -33,8 +33,8 @@ type Group interface {
 // GroupReference is used to reference a group
 type GroupReference struct {
 	UUID      GroupUUID `json:"uuid,omitempty" validate:"omitempty,uuid"`
-	Name      string    `json:"name,omitempty"`
-	NameMatch string    `json:"name_match,omitempty" engine:"evaluated"`
+	Name      string    `json:"name,omitempty" validate:"max=64"`
+	NameMatch string    `json:"name_match,omitempty" validate:"max=1000" engine:"evaluated"`
 }
 
 // NewGroupReference creates a new group reference with the given UUID and name

--- a/assets/label.go
+++ b/assets/label.go
@@ -31,8 +31,8 @@ type Label interface {
 // LabelReference is used to reference a label
 type LabelReference struct {
 	UUID      LabelUUID `json:"uuid,omitempty" validate:"omitempty,uuid"`
-	Name      string    `json:"name,omitempty"`
-	NameMatch string    `json:"name_match,omitempty" engine:"evaluated"`
+	Name      string    `json:"name,omitempty" validate:"max=64"`
+	NameMatch string    `json:"name_match,omitempty" validate:"max=1000" engine:"evaluated"`
 }
 
 // NewLabelReference creates a new label reference with the given UUID and name

--- a/assets/llm.go
+++ b/assets/llm.go
@@ -38,7 +38,7 @@ type LLM interface {
 // LLMReference is used to reference an LLM
 type LLMReference struct {
 	UUID LLMUUID `json:"uuid" validate:"required,uuid"`
-	Name string  `json:"name"`
+	Name string  `json:"name" validate:"max=64"`
 }
 
 // NewLLMReference creates a new LLM reference with the given UUID and name

--- a/assets/optin.go
+++ b/assets/optin.go
@@ -25,7 +25,7 @@ type OptIn interface {
 // OptInReference is used to reference an opt in
 type OptInReference struct {
 	UUID OptInUUID `json:"uuid" validate:"required,uuid"`
-	Name string    `json:"name"`
+	Name string    `json:"name" validate:"max=64"`
 }
 
 // NewOptInReference creates a new optin reference with the given UUID and name

--- a/assets/template.go
+++ b/assets/template.go
@@ -81,7 +81,7 @@ type TemplateTranslation interface {
 // TemplateReference is used to reference a Template
 type TemplateReference struct {
 	UUID TemplateUUID `json:"uuid" validate:"required,uuid"`
-	Name string       `json:"name"`
+	Name string       `json:"name" validate:"max=512"`
 }
 
 // NewTemplateReference creates a new template reference with the given UUID and name

--- a/assets/topic.go
+++ b/assets/topic.go
@@ -25,7 +25,7 @@ type Topic interface {
 // TopicReference is used to reference a topic
 type TopicReference struct {
 	UUID TopicUUID `json:"uuid" validate:"required,uuid"`
-	Name string    `json:"name"`
+	Name string    `json:"name" validate:"max=64"`
 }
 
 // NewTopicReference creates a new topic reference with the given UUID and name

--- a/assets/user.go
+++ b/assets/user.go
@@ -33,8 +33,8 @@ type User interface {
 // UserReference is used to reference a user
 type UserReference struct {
 	UUID       UserUUID `json:"uuid,omitempty" validate:"omitempty,uuid"`
-	Name       string   `json:"name,omitempty"`
-	EmailMatch string   `json:"email,omitempty" engine:"evaluated"` // TODO should really be email_match in JSON
+	Name       string   `json:"name,omitempty" validate:"max=320"` // first and last names can each be 150 chars
+	EmailMatch string   `json:"email,omitempty" validate:"max=1000" engine:"evaluated"` // TODO should really be email_match in JSON
 }
 
 // NewUserReference creates a new user reference with the given UUID and name

--- a/core/contact.go
+++ b/core/contact.go
@@ -51,7 +51,7 @@ const (
 // ContactReference is used to reference a contact
 type ContactReference struct {
 	UUID ContactUUID `json:"uuid" validate:"required,uuid"`
-	Name string      `json:"name"`
+	Name string      `json:"name" validate:"max=128"`
 }
 
 // NewContactReference creates a new contact reference with the given UUID and name

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -86,6 +86,10 @@ func TestBrokenFlows(t *testing.T) {
 			"unable to read action[0]: field 'text' is required",
 		},
 		{
+			"invalid_group_ref_name.json",
+			"unable to read action[0]: field 'groups[0].name' must be less than or equal to 64",
+		},
+		{
 			"invalid_action_by_method.json",
 			"invalid node[uuid=a58be63b-907d-4a1a-856b-0bb5579d7507]: invalid action[uuid=e5a03dde-3b2f-4603-b5d0-d927f6bcc361, type=call_webhook]: header '\"$?' is not a valid HTTP header",
 		},

--- a/flows/definition/testdata/broken_flows/invalid_group_ref_name.json
+++ b/flows/definition/testdata/broken_flows/invalid_group_ref_name.json
@@ -1,0 +1,33 @@
+{
+    "flows": [
+        {
+            "uuid": "76f0a02f-3b75-4b86-9064-e9195e1b3a02",
+            "name": "Test Flow",
+            "spec_version": "13.0.0",
+            "language": "eng",
+            "type": "messaging",
+            "nodes": [
+                {
+                    "uuid": "a58be63b-907d-4a1a-856b-0bb5579d7507",
+                    "actions": [
+                        {
+                            "uuid": "e5a03dde-3b2f-4603-b5d0-d927f6bcc361",
+                            "type": "add_contact_groups",
+                            "groups": [
+                                {
+                                    "uuid": "35b71b7c-3e9c-46a6-9b4d-4c5f01e5a02b",
+                                    "name": "12345678901234567890123456789012345678901234567890123456789012345"
+                                }
+                            ]
+                        }
+                    ],
+                    "exits": [
+                        {
+                            "uuid": "23a7a64b-5f07-4a91-acc0-ddb52d7ff5ca"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Continues the work of limiting what can be stuffed into a flow definition, this time closing the unbounded `name` fields on asset references, which appear in nearly every action type.

Limits are taken from the constraints on the corresponding RapidPro models rather than assuming a uniform value:

* 64 for flow, group, label, channel, campaign, LLM, opt-in and topic references (`TembaModel` name limit), and also used for field and global names and keys (the models allow 36, so this leaves some slack)
* 128 for contact references (contact names allow 128)
* 512 for template references (WhatsApp template names are longer)
* 320 for user references, since there is no single name column - references store first + last name, each of which can be 150 chars

Also caps the evaluated template fields on variable references (`name_match` on groups/labels, `email` on users) at 1000, consistent with other short evaluated fields.