### PR TITLE
Add max length validation to remaining unbounded flow definition fields

### DIFF
--- a/core/hints/digits.go
+++ b/core/hints/digits.go
@@ -12,7 +12,7 @@ type Digits struct {
 	baseHint
 
 	Count        *int   `json:"count,omitempty"`
-	TerminatedBy string `json:"terminated_by,omitempty"`
+	TerminatedBy string `json:"terminated_by,omitempty" validate:"max=8"`
 }
 
 // NewFixedDigits creates a new digits hint for a fixed count of digits

--- a/flows/actions/base.go
+++ b/flows/actions/base.go
@@ -280,7 +280,7 @@ func (a *otherContactsAction) resolveRecipients(ctx context.Context, run flows.R
 // utility struct for actions which create a message
 type createMsgAction struct {
 	Text              string                    `json:"text"                       validate:"required,max=10000"     engine:"localized,evaluated"`
-	Attachments       []string                  `json:"attachments,omitempty"      validate:"max=10,dive,attachment" engine:"localized,evaluated"`
+	Attachments       []string                  `json:"attachments,omitempty"      validate:"max=10,dive,attachment,max=8192" engine:"localized,evaluated"`
 	QuickReplies      []string                  `json:"quick_replies,omitempty"    validate:"max=10,dive,max=1000"   engine:"localized,evaluated"`
 	Template          *assets.TemplateReference `json:"template,omitempty"`
 	TemplateVariables []string                  `json:"template_variables,omitempty" validate:"max=100,dive,max=10000" engine:"evaluated"`

--- a/flows/actions/deprecated.go
+++ b/flows/actions/deprecated.go
@@ -26,7 +26,7 @@ type CallClassifier struct {
 	baseAction
 	onlineAction
 
-	Input      string `json:"input" validate:"required" engine:"evaluated"`
+	Input      string `json:"input" validate:"required,max=10000" engine:"evaluated"`
 	ResultName string `json:"result_name" validate:"required,result_name"`
 }
 

--- a/flows/actions/open_ticket.go
+++ b/flows/actions/open_ticket.go
@@ -46,7 +46,7 @@ type OpenTicket struct {
 
 	Topic    *assets.TopicReference `json:"topic"`
 	Assignee *assets.UserReference  `json:"assignee,omitempty"`
-	Note     string                 `json:"note,omitempty"     engine:"evaluated"`
+	Note     string                 `json:"note,omitempty"     validate:"max=10000" engine:"evaluated"`
 }
 
 // NewOpenTicket creates a new open ticket action

--- a/flows/actions/say_msg.go
+++ b/flows/actions/say_msg.go
@@ -36,7 +36,7 @@ type SayMsg struct {
 	voiceAction
 
 	Text     string `json:"text"                 validate:"required,max=10000" engine:"localized,evaluated"`
-	AudioURL string `json:"audio_url,omitempty"                                engine:"localized"`
+	AudioURL string `json:"audio_url,omitempty" validate:"max=8192"           engine:"localized"`
 }
 
 // NewSayMsg creates a new say message action

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -34,7 +34,7 @@ type SetContactField struct {
 	universalAction
 
 	Field *assets.FieldReference `json:"field" validate:"required"`
-	Value string                 `json:"value" engine:"evaluated"`
+	Value string                 `json:"value" validate:"max=1000" engine:"evaluated"`
 }
 
 // NewSetContactField creates a new set channel action

--- a/flows/actions/set_contact_language.go
+++ b/flows/actions/set_contact_language.go
@@ -32,7 +32,7 @@ type SetContactLanguage struct {
 	baseAction
 	universalAction
 
-	Language string `json:"language" engine:"evaluated"`
+	Language string `json:"language" validate:"max=1000" engine:"evaluated"`
 }
 
 // NewSetContactLanguage creates a new set language action

--- a/flows/actions/set_contact_timezone.go
+++ b/flows/actions/set_contact_timezone.go
@@ -33,7 +33,7 @@ type SetContactTimezone struct {
 	baseAction
 	universalAction
 
-	Timezone string `json:"timezone" engine:"evaluated"`
+	Timezone string `json:"timezone" validate:"max=1000" engine:"evaluated"`
 }
 
 // NewSetContactTimezone creates a new set timezone action

--- a/flows/actions/transfer_airtime.go
+++ b/flows/actions/transfer_airtime.go
@@ -46,7 +46,7 @@ type TransferAirtime struct {
 	baseAction
 	onlineAction
 
-	Amounts map[string]decimal.Decimal `json:"amounts" validate:"required,max=100"`
+	Amounts map[string]decimal.Decimal `json:"amounts" validate:"required,max=100,dive,keys,max=8,endkeys"`
 }
 
 // Validate validates our action is valid

--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
-	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/core"
 	"github.com/nyaruka/goflow/core/hints"
@@ -299,7 +298,7 @@ func TestNewFlow(t *testing.T) {
 					},
 					"@input.text",
 					[]*routers.Case{
-						routers.NewCase(uuids.UUID("9f593e22-7886-4c08-a52f-0e8780504d75"), "has_any_word", []string{"yes yeah"}, flows.CategoryUUID("97b9451c-2856-475b-af38-32af68100897")),
+						routers.NewCase(flows.CaseUUID("9f593e22-7886-4c08-a52f-0e8780504d75"), "has_any_word", []string{"yes yeah"}, flows.CategoryUUID("97b9451c-2856-475b-af38-32af68100897")),
 					},
 					flows.CategoryUUID("8fd08f1c-8f4e-42c1-af6c-df2db2e0eda6"),
 				),

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -39,6 +39,9 @@ const (
 // CategoryUUID is the UUID of a node category
 type CategoryUUID uuids.UUID
 
+// CaseUUID is the UUID of a router case
+type CaseUUID uuids.UUID
+
 // ActionUUID is the UUID of an action
 type ActionUUID uuids.UUID
 

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -26,7 +26,7 @@ const TypeSwitch string = "switch"
 
 // Case represents a single case and test in our switch
 type Case struct {
-	UUID         uuids.UUID         `json:"uuid"                   validate:"required"`
+	UUID         uuids.UUID         `json:"uuid"                   validate:"required,uuid"`
 	Type         string             `json:"type"                   validate:"required"`
 	Arguments    []string           `json:"arguments,omitempty"    validate:"dive,max=10000" engine:"localized,evaluated"`
 	CategoryUUID flows.CategoryUUID `json:"category_uuid"          validate:"required"`

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -26,14 +26,14 @@ const TypeSwitch string = "switch"
 
 // Case represents a single case and test in our switch
 type Case struct {
-	UUID         uuids.UUID         `json:"uuid"                   validate:"required,uuid"`
+	UUID         flows.CaseUUID     `json:"uuid"                   validate:"required,uuid"`
 	Type         string             `json:"type"                   validate:"required"`
 	Arguments    []string           `json:"arguments,omitempty"    validate:"dive,max=10000" engine:"localized,evaluated"`
 	CategoryUUID flows.CategoryUUID `json:"category_uuid"          validate:"required"`
 }
 
 // NewCase creates a new case
-func NewCase(uuid uuids.UUID, type_ string, arguments []string, categoryUUID flows.CategoryUUID) *Case {
+func NewCase(uuid flows.CaseUUID, type_ string, arguments []string, categoryUUID flows.CategoryUUID) *Case {
 	return &Case{
 		UUID:         uuid,
 		Type:         type_,
@@ -153,7 +153,7 @@ func (r *Switch) matchCase(ctx context.Context, run flows.Run, operand types.XVa
 		// build our argument list which starts with the operand
 		args := []types.XValue{operand}
 
-		localizedArgs, _ := run.GetTextArray(c.UUID, "arguments", c.Arguments, nil)
+		localizedArgs, _ := run.GetTextArray(uuids.UUID(c.UUID), "arguments", c.Arguments, nil)
 
 		// this shouldn't happen but if the number of localized args doesn't match the base arguments, ignore them
 		if len(localizedArgs) != len(c.Arguments) {

--- a/flows/routers/waits/dial.go
+++ b/flows/routers/waits/dial.go
@@ -94,7 +94,7 @@ var _ flows.Wait = (*Dial)(nil)
 type dialEnvelope struct {
 	baseEnvelope
 
-	Phone            string `json:"phone" validate:"required"`
+	Phone            string `json:"phone" validate:"required,max=1000"`
 	DialLimitSeconds int    `json:"dial_limit_seconds,omitempty"`
 	CallLimitSeconds int    `json:"call_limit_seconds,omitempty"`
 }


### PR DESCRIPTION
Closes out the remaining places found in the definition-limits audit where unlimited data could be stuffed into a flow definition. All mechanical `validate` tag additions:

* `open_ticket.note` → 10000 (same as other long evaluated text)
* `set_contact_field.value`, `set_contact_language.language`, `set_contact_timezone.timezone`, dial wait `phone` → 1000 (same as other short evaluated fields)
* `say_msg.audio_url` → 8192 (matching `play_audio.audio_url`)
* `call_classifier.input` → 10000 (deprecated action but still parsed)
* message attachments → 8192 per attachment (the `attachment` validator checks `type:url` format but not length)
* switch router case `uuid` → now must actually be a UUID, closing an arbitrary-length string field, and gets a `CaseUUID` type for consistency with the other flow UUID types
* `transfer_airtime.amounts` map keys → 8 (currency codes)
* digits hint `terminated_by` → 8 (a single DTMF key)
