### PR TITLE
Raise max length of set_contact_field value to 10000

### DIFF
--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -761,6 +761,15 @@ func TestReadAction(t *testing.T) {
 	_, err = actions.Read([]byte(`{"type": "do_the_foo", "foo": "bar"}`))
 	assert.EqualError(t, err, "unknown type: 'do_the_foo'")
 
+	// limit on the value field is tested here rather than as a fixture to avoid a huge testdata string
+	_, err = actions.Read(fmt.Appendf(nil, `{
+		"type": "set_contact_field",
+		"uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+		"field": {"key": "age", "name": "Age"},
+		"value": %q
+	}`, strings.Repeat("x", 10001)))
+	assert.EqualError(t, err, "field 'value' must be less than or equal to 10000")
+
 	// legacy call_classifier action with a classifier asset reference parses fine -
 	// the now-removed classifier field is silently ignored
 	action, err := actions.Read([]byte(`{

--- a/flows/actions/set_contact_field.go
+++ b/flows/actions/set_contact_field.go
@@ -34,7 +34,7 @@ type SetContactField struct {
 	universalAction
 
 	Field *assets.FieldReference `json:"field" validate:"required"`
-	Value string                 `json:"value" validate:"max=1000" engine:"evaluated"`
+	Value string                 `json:"value" validate:"max=10000" engine:"evaluated"` // matches the engine's template length limit
 }
 
 // NewSetContactField creates a new set channel action


### PR DESCRIPTION
The cap of 1000 added in #1599 turned out to be stricter than real usage: `set_contact_field.value` is an evaluated template whose *source* can legitimately be much longer than its output — e.g. long `replace()` chains or `foreach` expressions that evaluate to short values. Raise it to 10000, matching the template length limit (`MaxTemplateChars`) and other evaluated free-text fields.

The over-limit read test lives in `TestReadAction` rather than a fixture to avoid a huge testdata string.