### PR TITLE
Add warning event for webhook calls to restricted domains

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -91,7 +91,7 @@ func createEngine() flows.Engine {
 	return engine.NewBuilder().
 		WithHTTPClient(http.DefaultClient).
 		WithWebhookLimits(256*1024, 10000).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-runner"})).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-runner"}, nil)).
 		Build()
 }
 

--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -567,7 +567,7 @@ func TestWebhookCalledEventTrimming(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", strings.NewReader(strings.Repeat("X", 20000)))
 
-	svc := webhooks.NewService(client, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 
@@ -592,7 +592,7 @@ func TestWebhookCalledEventValid(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", nil)
 
-	svc := webhooks.NewService(client, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 
@@ -612,7 +612,7 @@ func TestWebhookCalledEventNullChar(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", nil)
 
-	svc := webhooks.NewService(client, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 
@@ -633,7 +633,7 @@ func TestWebhookCalledEventBadUTF8(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", nil)
 
-	svc := webhooks.NewService(client, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 

--- a/core/events/warning.go
+++ b/core/events/warning.go
@@ -7,7 +7,12 @@ func init() {
 // TypeWarning is the type of our warning events
 const TypeWarning string = "warning"
 
-// Warning events are created for things like accessing deprecated context values.
+const (
+	WarningCodeGraylistedURL = "url:graylisted"
+)
+
+// Warning events are created for things like accessing deprecated context values. Some warnings have
+// a `code` which identifies the type of warning.
 //
 //	{
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
@@ -21,12 +26,14 @@ type Warning struct {
 	BaseEvent
 
 	Text string `json:"text" validate:"required"`
+	Code string `json:"code,omitempty"`
 }
 
 // NewWarning returns a new warning event
-func NewWarning(text string) *Warning {
+func NewWarning(text, code string) *Warning {
 	return &Warning{
 		BaseEvent: NewBaseEvent(TypeWarning),
 		Text:      text,
+		Code:      code,
 	}
 }

--- a/core/events/warning.go
+++ b/core/events/warning.go
@@ -8,7 +8,7 @@ func init() {
 const TypeWarning string = "warning"
 
 const (
-	WarningCodeWebhookMessaging = "webhook:messaging"
+	WarningCodeURLRestricted = "url:restricted"
 )
 
 // Warning events are created for things like accessing deprecated context values. Some warnings have

--- a/core/events/warning.go
+++ b/core/events/warning.go
@@ -8,7 +8,7 @@ func init() {
 const TypeWarning string = "warning"
 
 const (
-	WarningCodeGraylistedURL = "url:graylisted"
+	WarningCodeWebhookMessaging = "webhook:messaging"
 )
 
 // Warning events are created for things like accessing deprecated context values. Some warnings have

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -225,7 +225,7 @@ func testActionType(t *testing.T, assetsJSON []byte, typeName string) {
 				return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io", nil)
 			}).
 			WithWebhookLimits(256*1024, 100000).
-			WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"})).
+			WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"})).
 			WithLLMServiceFactory(func(l *core.LLM) (flows.LLMService, error) {
 				return services.NewLLM(), nil
 			}).
@@ -1072,7 +1072,7 @@ func TestCallWebhookAlwaysUpdatesWebhook(t *testing.T) {
 
 	eng := engine.NewBuilder().
 		WithHTTPClient(httpClient).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(nil)).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(nil, nil)).
 		Build()
 
 	flow := assets.NewFlowReference("5472a1c3-63e1-484f-8485-cc8ecb16a058", "Webhooks")

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -20,7 +20,7 @@ import (
 
 // domains of WhatsApp API providers which flows shouldn't be calling directly - for now calls to these
 // only generate warnings but eventually they may be blocked entirely
-var graylistedDomains = []string{
+var messagingDomains = []string{
 	"360dialog.io",       // 360Dialog
 	"api.twilio.com",     // Twilio
 	"api.zenvia.com",     // Zenvia
@@ -41,10 +41,10 @@ func parseURL(u string) *url.URL {
 	return parsed
 }
 
-// checks the given URL host against the graylisted domains, returning the matched domain or empty string
-func graylistedDomain(host string) string {
+// checks the given URL host against the messaging provider domains, returning the matched domain or empty string
+func messagingDomain(host string) string {
 	host = strings.ToLower(host)
-	for _, domain := range graylistedDomains {
+	for _, domain := range messagingDomains {
 		if host == domain || strings.HasSuffix(host, "."+domain) {
 			return domain
 		}
@@ -146,8 +146,8 @@ func (a *CallWebhook) Execute(ctx context.Context, run flows.Run, step flows.Ste
 		return nil
 	}
 
-	if domain := graylistedDomain(parsedURL.Hostname()); domain != "" {
-		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", domain), events.WarningCodeGraylistedURL))
+	if domain := messagingDomain(parsedURL.Hostname()); domain != "" {
+		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", domain), events.WarningCodeWebhookMessaging))
 	}
 
 	method := strings.ToUpper(a.Method)

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -165,9 +165,9 @@ func (a *CallWebhook) call(ctx context.Context, run flows.Run, step flows.Step, 
 		return nil
 	}
 
-	// for now direct calls to messaging provider APIs only generate warnings but eventually they may be blocked
-	if svc.IsMessagingAPI(req.URL) {
-		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", req.URL.Hostname()), events.WarningCodeWebhookMessaging))
+	// for now calls to restricted URLs only generate warnings but eventually they may be blocked
+	if svc.IsRestricted(req.URL) {
+		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", req.URL.Hostname()), events.WarningCodeURLRestricted))
 	}
 
 	trace, err := svc.Call(req)

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -18,12 +18,38 @@ import (
 	"golang.org/x/net/http/httpguts"
 )
 
-func isValidURL(u string) bool {
+// domains of WhatsApp API providers which flows shouldn't be calling directly - for now calls to these
+// only generate warnings but eventually they may be blocked entirely
+var graylistedDomains = []string{
+	"360dialog.io",       // 360Dialog
+	"api.twilio.com",     // Twilio
+	"api.zenvia.com",     // Zenvia
+	"graph.facebook.com", // Meta Cloud API
+	"kaleyra.io",         // Kaleyra
+	"turn.io",            // Turn.io
+}
+
+// parses the given webhook URL, returning nil if it's too long or unparseable
+func parseURL(u string) *url.URL {
 	if utf8.RuneCountInString(u) > 8192 {
-		return false
+		return nil
 	}
-	_, err := url.Parse(u)
-	return err == nil
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil
+	}
+	return parsed
+}
+
+// checks the given URL host against the graylisted domains, returning the matched domain or empty string
+func graylistedDomain(host string) string {
+	host = strings.ToLower(host)
+	for _, domain := range graylistedDomains {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return domain
+		}
+	}
+	return ""
 }
 
 // approximates the size in bytes of the request as it will be serialized on the wire
@@ -113,9 +139,15 @@ func (a *CallWebhook) Execute(ctx context.Context, run flows.Run, step flows.Ste
 		log(events.NewError("Webhook URL evaluated to empty string", ""))
 		return nil
 	}
-	if !isValidURL(url) {
+
+	parsedURL := parseURL(url)
+	if parsedURL == nil {
 		log(events.NewError(fmt.Sprintf("Webhook URL evaluated to an invalid URL: '%s'", stringsx.TruncateEllipsis(url, 255)), ""))
 		return nil
+	}
+
+	if domain := graylistedDomain(parsedURL.Hostname()); domain != "" {
+		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", domain), events.WarningCodeGraylistedURL))
 	}
 
 	method := strings.ToUpper(a.Method)
@@ -195,7 +227,7 @@ func (a *CallWebhook) Inspect(dependency func(assets.Reference), local func(stri
 // is still recorded (as a connection error) and the flow routes on that as usual
 func logCallError(err error, log events.EventLogger) {
 	if errors.Is(err, httpx.ErrResponseSize) {
-		log(events.NewWarning(err.Error()))
+		log(events.NewWarning(err.Error(), ""))
 	} else {
 		log(events.NewRawError(err))
 	}

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -18,38 +18,12 @@ import (
 	"golang.org/x/net/http/httpguts"
 )
 
-// domains of WhatsApp API providers which flows shouldn't be calling directly - for now calls to these
-// only generate warnings but eventually they may be blocked entirely
-var messagingDomains = []string{
-	"360dialog.io",       // 360Dialog
-	"api.twilio.com",     // Twilio
-	"api.zenvia.com",     // Zenvia
-	"graph.facebook.com", // Meta Cloud API
-	"kaleyra.io",         // Kaleyra
-	"turn.io",            // Turn.io
-}
-
-// parses the given webhook URL, returning nil if it's too long or unparseable
-func parseURL(u string) *url.URL {
+func isValidURL(u string) bool {
 	if utf8.RuneCountInString(u) > 8192 {
-		return nil
+		return false
 	}
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return nil
-	}
-	return parsed
-}
-
-// checks the given URL host against the messaging provider domains, returning the matched domain or empty string
-func messagingDomain(host string) string {
-	host = strings.ToLower(host)
-	for _, domain := range messagingDomains {
-		if host == domain || strings.HasSuffix(host, "."+domain) {
-			return domain
-		}
-	}
-	return ""
+	_, err := url.Parse(u)
+	return err == nil
 }
 
 // approximates the size in bytes of the request as it will be serialized on the wire
@@ -140,14 +114,9 @@ func (a *CallWebhook) Execute(ctx context.Context, run flows.Run, step flows.Ste
 		return nil
 	}
 
-	parsedURL := parseURL(url)
-	if parsedURL == nil {
+	if !isValidURL(url) {
 		log(events.NewError(fmt.Sprintf("Webhook URL evaluated to an invalid URL: '%s'", stringsx.TruncateEllipsis(url, 255)), ""))
 		return nil
-	}
-
-	if domain := messagingDomain(parsedURL.Hostname()); domain != "" {
-		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", domain), events.WarningCodeWebhookMessaging))
 	}
 
 	method := strings.ToUpper(a.Method)
@@ -194,6 +163,11 @@ func (a *CallWebhook) call(ctx context.Context, run flows.Run, step flows.Step, 
 	if err != nil {
 		log(events.NewRawError(err))
 		return nil
+	}
+
+	// for now direct calls to messaging provider APIs only generate warnings but eventually they may be blocked
+	if svc.IsMessagingAPI(req.URL) {
+		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", req.URL.Hostname()), events.WarningCodeWebhookMessaging))
 	}
 
 	trace, err := svc.Call(req)

--- a/flows/actions/deprecated.go
+++ b/flows/actions/deprecated.go
@@ -43,7 +43,7 @@ func NewCallClassifier(uuid flows.ActionUUID, input string, resultName string) *
 func (a *CallClassifier) Execute(ctx context.Context, run flows.Run, step flows.Step, log events.EventLogger) error {
 	input, _ := run.EvaluateTemplate(ctx, a.Input, log)
 
-	log(events.NewWarning("NLU classifiers are no longer supported"))
+	log(events.NewWarning("NLU classifiers are no longer supported", ""))
 	a.saveResult(run, step, a.ResultName, "0", CategoryFailure, "", input, nil, log)
 	return nil
 }

--- a/flows/actions/testdata/call_webhook.json
+++ b/flows/actions/testdata/call_webhook.json
@@ -353,7 +353,7 @@
         }
     },
     {
-        "description": "Warning event created if URL is in a graylisted domain",
+        "description": "Warning event created if URL is a messaging provider domain",
         "http_mocks": {
             "https://graph.facebook.com/v25.0/1234/messages": [
                 {
@@ -375,7 +375,7 @@
                 "type": "warning",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Webhook calls to graph.facebook.com may be blocked in the future",
-                "code": "url:graylisted"
+                "code": "webhook:messaging"
             },
             {
                 "uuid": "01969b47-401b-76f8-aac5-d9d0ae409dbe",

--- a/flows/actions/testdata/call_webhook.json
+++ b/flows/actions/testdata/call_webhook.json
@@ -353,7 +353,7 @@
         }
     },
     {
-        "description": "Warning event created if URL is a messaging provider domain",
+        "description": "Warning event created if URL is in a restricted domain",
         "http_mocks": {
             "https://graph.facebook.com/v25.0/1234/messages": [
                 {
@@ -375,7 +375,7 @@
                 "type": "warning",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
                 "text": "Webhook calls to graph.facebook.com may be blocked in the future",
-                "code": "webhook:messaging"
+                "code": "url:restricted"
             },
             {
                 "uuid": "01969b47-401b-76f8-aac5-d9d0ae409dbe",

--- a/flows/actions/testdata/call_webhook.json
+++ b/flows/actions/testdata/call_webhook.json
@@ -353,6 +353,65 @@
         }
     },
     {
+        "description": "Warning event created if URL is in a graylisted domain",
+        "http_mocks": {
+            "https://graph.facebook.com/v25.0/1234/messages": [
+                {
+                    "status": 200,
+                    "body": "{}"
+                }
+            ]
+        },
+        "action": {
+            "type": "call_webhook",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "method": "POST",
+            "url": "https://graph.facebook.com/v25.0/1234/messages",
+            "body": "{}"
+        },
+        "events": [
+            {
+                "uuid": "01969b47-307b-76f8-a7eb-cc4cc9ec3e6b",
+                "type": "warning",
+                "created_on": "2025-05-04T12:30:57.123456789Z",
+                "text": "Webhook calls to graph.facebook.com may be blocked in the future",
+                "code": "url:graylisted"
+            },
+            {
+                "uuid": "01969b47-401b-76f8-aac5-d9d0ae409dbe",
+                "type": "webhook_called",
+                "created_on": "2025-05-04T12:31:01.123456789Z",
+                "url": "https://graph.facebook.com/v25.0/1234/messages",
+                "status_code": 200,
+                "request": "POST /v25.0/1234/messages HTTP/1.1\r\nHost: graph.facebook.com\r\nUser-Agent: goflow-testing\r\nContent-Length: 2\r\nAccept-Encoding: gzip\r\n\r\n{}",
+                "response": "HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\n{}",
+                "elapsed_ms": 1000,
+                "retries": 0,
+                "sizes": {
+                    "request": 136,
+                    "response": 40
+                },
+                "status": "success"
+            }
+        ],
+        "locals_after": {},
+        "templates": [
+            "https://graph.facebook.com/v25.0/1234/messages",
+            "{}"
+        ],
+        "inspection": {
+            "counts": {
+                "languages": 0,
+                "nodes": 1
+            },
+            "dependencies": [],
+            "locals": [],
+            "results": [],
+            "parent_refs": [],
+            "issues": []
+        }
+    },
+    {
         "description": "Result changed event created if result name set",
         "http_mocks": {
             "http://temba.io/": [

--- a/flows/engine/engine_test.go
+++ b/flows/engine/engine_test.go
@@ -42,7 +42,7 @@ func TestBuilder(t *testing.T) {
 	assert.EqualError(t, err, "no webhook service factory configured")
 
 	// include a webhook service
-	webhookSvc := webhooks.NewService(&http.Client{}, map[string]string{"User-Agent": "goflow"}, 1000)
+	webhookSvc := webhooks.NewService(&http.Client{}, map[string]string{"User-Agent": "goflow"}, nil, 1000)
 
 	eng = engine.NewBuilder().
 		WithWebhookServiceFactory(func(flows.Engine, flows.SessionAssets) (flows.WebhookService, error) { return webhookSvc, nil }).

--- a/flows/engine/run.go
+++ b/flows/engine/run.go
@@ -313,7 +313,7 @@ func (r *run) EvaluateTemplateValue(ctx context.Context, template string, log ev
 		r.errorToEvents(err, log)
 	}
 	for _, w := range warnings {
-		log(events.NewWarning(w))
+		log(events.NewWarning(w, ""))
 	}
 	return value, err == nil
 }
@@ -327,7 +327,7 @@ func (r *run) EvaluateTemplateText(ctx context.Context, template string, escapin
 		r.errorToEvents(err, log)
 	}
 	for _, w := range warnings {
-		log(events.NewWarning(w))
+		log(events.NewWarning(w, ""))
 	}
 	if truncate {
 		value = stringsx.TruncateEllipsis(value, r.Session().Engine().Options().MaxTemplateChars)

--- a/flows/services.go
+++ b/flows/services.go
@@ -31,9 +31,8 @@ type WebhookService interface {
 	// Call makes the given HTTP request and returns the trace
 	Call(request *http.Request) (*httpx.Trace, error)
 
-	// IsMessagingAPI returns whether the given URL belongs to a messaging provider API which flows
-	// shouldn't be calling directly
-	IsMessagingAPI(u *url.URL) bool
+	// IsRestricted returns whether the given URL is restricted and shouldn't be called from flows
+	IsRestricted(u *url.URL) bool
 }
 
 // LLMService provides LLM functionality to the engine

--- a/flows/services.go
+++ b/flows/services.go
@@ -3,6 +3,7 @@ package flows
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/gocommon/urns"
@@ -27,7 +28,12 @@ type EmailService interface {
 
 // WebhookService provides webhook functionality to the engine
 type WebhookService interface {
+	// Call makes the given HTTP request and returns the trace
 	Call(request *http.Request) (*httpx.Trace, error)
+
+	// IsMessagingAPI returns whether the given URL belongs to a messaging provider API which flows
+	// shouldn't be calling directly
+	IsMessagingAPI(u *url.URL) bool
 }
 
 // LLMService provides LLM functionality to the engine

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -13,37 +13,37 @@ import (
 )
 
 type service struct {
-	httpClient       *http.Client
-	defaultHeaders   map[string]string
-	messagingDomains []string
-	maxResponseBytes int
+	httpClient        *http.Client
+	defaultHeaders    map[string]string
+	restrictedDomains []string
+	maxResponseBytes  int
 }
 
 // NewServiceFactory creates a new webhook service factory. The engine supplies the HTTP client and the maximum
 // response size; the client's transport can be configured with tracing, mocking or access control as needed
-// (see github.com/nyaruka/gocommon/httpx). The messaging domains are the domains of messaging provider APIs
+// (see github.com/nyaruka/gocommon/httpx). The restricted domains are domains (e.g. messaging provider APIs)
 // which flows shouldn't be calling directly.
-func NewServiceFactory(defaultHeaders map[string]string, messagingDomains []string) engine.WebhookServiceFactory {
+func NewServiceFactory(defaultHeaders map[string]string, restrictedDomains []string) engine.WebhookServiceFactory {
 	return func(eng flows.Engine, sa flows.SessionAssets) (flows.WebhookService, error) {
-		return NewService(eng.HTTPClient(), defaultHeaders, messagingDomains, eng.Options().MaxResponseBytes), nil
+		return NewService(eng.HTTPClient(), defaultHeaders, restrictedDomains, eng.Options().MaxResponseBytes), nil
 	}
 }
 
 // NewService creates a new default webhook service
-func NewService(httpClient *http.Client, defaultHeaders map[string]string, messagingDomains []string, maxResponseBytes int) flows.WebhookService {
+func NewService(httpClient *http.Client, defaultHeaders map[string]string, restrictedDomains []string, maxResponseBytes int) flows.WebhookService {
 	return &service{
-		httpClient:       httpClient,
-		defaultHeaders:   defaultHeaders,
-		messagingDomains: messagingDomains,
-		maxResponseBytes: maxResponseBytes,
+		httpClient:        httpClient,
+		defaultHeaders:    defaultHeaders,
+		restrictedDomains: restrictedDomains,
+		maxResponseBytes:  maxResponseBytes,
 	}
 }
 
-// IsMessagingAPI returns whether the host of the given URL matches or is a subdomain of one of our
-// configured messaging provider domains.
-func (s *service) IsMessagingAPI(u *url.URL) bool {
+// IsRestricted returns whether the host of the given URL matches or is a subdomain of one of our
+// configured restricted domains.
+func (s *service) IsRestricted(u *url.URL) bool {
 	host := strings.ToLower(u.Hostname())
-	for _, domain := range s.messagingDomains {
+	for _, domain := range s.restrictedDomains {
 		if host == domain || strings.HasSuffix(host, "."+domain) {
 			return true
 		}

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/goflow/flows"
@@ -13,25 +15,40 @@ import (
 type service struct {
 	httpClient       *http.Client
 	defaultHeaders   map[string]string
+	messagingDomains []string
 	maxResponseBytes int
 }
 
 // NewServiceFactory creates a new webhook service factory. The engine supplies the HTTP client and the maximum
 // response size; the client's transport can be configured with tracing, mocking or access control as needed
-// (see github.com/nyaruka/gocommon/httpx).
-func NewServiceFactory(defaultHeaders map[string]string) engine.WebhookServiceFactory {
+// (see github.com/nyaruka/gocommon/httpx). The messaging domains are the domains of messaging provider APIs
+// which flows shouldn't be calling directly.
+func NewServiceFactory(defaultHeaders map[string]string, messagingDomains []string) engine.WebhookServiceFactory {
 	return func(eng flows.Engine, sa flows.SessionAssets) (flows.WebhookService, error) {
-		return NewService(eng.HTTPClient(), defaultHeaders, eng.Options().MaxResponseBytes), nil
+		return NewService(eng.HTTPClient(), defaultHeaders, messagingDomains, eng.Options().MaxResponseBytes), nil
 	}
 }
 
 // NewService creates a new default webhook service
-func NewService(httpClient *http.Client, defaultHeaders map[string]string, maxResponseBytes int) flows.WebhookService {
+func NewService(httpClient *http.Client, defaultHeaders map[string]string, messagingDomains []string, maxResponseBytes int) flows.WebhookService {
 	return &service{
 		httpClient:       httpClient,
 		defaultHeaders:   defaultHeaders,
+		messagingDomains: messagingDomains,
 		maxResponseBytes: maxResponseBytes,
 	}
+}
+
+// IsMessagingAPI returns whether the host of the given URL matches or is a subdomain of one of our
+// configured messaging provider domains.
+func (s *service) IsMessagingAPI(u *url.URL) bool {
+	host := strings.ToLower(u.Hostname())
+	for _, domain := range s.messagingDomains {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *service) Call(request *http.Request) (*httpx.Trace, error) {

--- a/services/webhooks/service_test.go
+++ b/services/webhooks/service_test.go
@@ -3,6 +3,7 @@ package webhooks_test
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -168,7 +169,7 @@ func TestAccessRestrictions(t *testing.T) {
 
 	eng := engine.NewBuilder().WithHTTPClient(client).Build()
 
-	factory := webhooks.NewServiceFactory(map[string]string{"User-Agent": "Foo"})
+	factory := webhooks.NewServiceFactory(map[string]string{"User-Agent": "Foo"}, nil)
 	svc, err := factory(eng, nil)
 	assert.NoError(t, err)
 
@@ -228,4 +229,27 @@ func TestWebhookResponseWithEscapes(t *testing.T) {
 
 	// check nothing became an escaped NULL
 	assert.NotContains(t, string(jsonx.MustMarshal(session)), `\u0000`)
+}
+
+func TestIsMessagingAPI(t *testing.T) {
+	svc := webhooks.NewService(http.DefaultClient, nil, []string{"graph.facebook.com", "360dialog.io"}, 1024)
+
+	tcs := []struct {
+		url         string
+		isMessaging bool
+	}{
+		{"https://graph.facebook.com/v25.0/1234/messages", true},
+		{"https://GRAPH.FACEBOOK.COM/v25.0/1234/messages", true}, // check case insensitivity
+		{"https://waba-v2.360dialog.io/messages", true},          // check subdomain matching
+		{"https://facebook.com/some/page", false},
+		{"https://notgraph.facebook.com.evil.com/", false},
+		{"https://temba.io/", false},
+	}
+
+	for _, tc := range tcs {
+		u, err := url.Parse(tc.url)
+		require.NoError(t, err)
+
+		assert.Equal(t, tc.isMessaging, svc.IsMessagingAPI(u), "IsMessagingAPI mismatch for %s", tc.url)
+	}
 }

--- a/services/webhooks/service_test.go
+++ b/services/webhooks/service_test.go
@@ -231,12 +231,12 @@ func TestWebhookResponseWithEscapes(t *testing.T) {
 	assert.NotContains(t, string(jsonx.MustMarshal(session)), `\u0000`)
 }
 
-func TestIsMessagingAPI(t *testing.T) {
+func TestIsRestricted(t *testing.T) {
 	svc := webhooks.NewService(http.DefaultClient, nil, []string{"graph.facebook.com", "360dialog.io"}, 1024)
 
 	tcs := []struct {
-		url         string
-		isMessaging bool
+		url          string
+		isRestricted bool
 	}{
 		{"https://graph.facebook.com/v25.0/1234/messages", true},
 		{"https://GRAPH.FACEBOOK.COM/v25.0/1234/messages", true}, // check case insensitivity
@@ -250,6 +250,6 @@ func TestIsMessagingAPI(t *testing.T) {
 		u, err := url.Parse(tc.url)
 		require.NoError(t, err)
 
-		assert.Equal(t, tc.isMessaging, svc.IsMessagingAPI(u), "IsMessagingAPI mismatch for %s", tc.url)
+		assert.Equal(t, tc.isRestricted, svc.IsRestricted(u), "IsRestricted mismatch for %s", tc.url)
 	}
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -34,7 +34,7 @@ func newEngine(httpClient *http.Client) flows.Engine {
 			"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following: {{ .arg1 }}")),
 		}).
 		WithWebhookLimits(256*1024, 10000).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"})).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"})).
 		WithEmailServiceFactory(func(s flows.SessionAssets) (flows.EmailService, error) {
 			return services.NewEmail(), nil
 		}).

--- a/test/runner_test.go
+++ b/test/runner_test.go
@@ -138,7 +138,7 @@ func runFlow(assetsPath string, rawEnv []byte, rawContact *core.ContactEnvelope,
 			return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io", nil)
 		}).
 		WithWebhookLimits(256*1024, 100000).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"})).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"})).
 		WithLLMServiceFactory(func(l *core.LLM) (flows.LLMService, error) {
 			return services.NewLLM(), nil
 		}).


### PR DESCRIPTION
Adds support for restricted domains — domains (for now, messaging provider APIs) which flows shouldn't be calling directly via the `call_webhook` action. The list is passed to the webhook service by its host, and when the evaluated URL's host matches a restricted domain (exactly or as a subdomain), a `warning` event is logged — the call itself still proceeds as normal, but the warning is visible in the simulator and can be tracked by the engine's consumers. Eventually calls to these domains may be blocked entirely.

To support identifying these warnings programmatically, `warning` events gain an optional `code` field (matching the pattern on `error` events), and this case uses `url:restricted`.