### PR TITLE
Make warning event messages user facing

### DIFF
--- a/core/contact.go
+++ b/core/contact.go
@@ -436,10 +436,10 @@ func (c *Contact) Context(env envs.Environment) map[string]types.XValue {
 	}
 
 	id := types.NewXText(strconv.Itoa(int(c.id)))
-	id.SetDeprecated("contact.id: use contact.ref instead")
+	id.SetDeprecated("@contact.id is deprecated, use @contact.ref instead")
 
 	tickets := c.tickets.Open().ToXValue(env)
-	tickets.SetDeprecated("contact.tickets: use ticket instead")
+	tickets.SetDeprecated("@contact.tickets is deprecated, use @ticket instead")
 
 	return map[string]types.XValue{
 		"__default__":  types.NewXText(c.Format(env)),

--- a/core/events/warning.go
+++ b/core/events/warning.go
@@ -8,7 +8,9 @@ func init() {
 const TypeWarning string = "warning"
 
 const (
-	WarningCodeURLRestricted = "url:restricted"
+	WarningCodeDeprecatedContext   = "context:deprecated"
+	WarningCodeURLRestricted       = "url:restricted"
+	WarningCodeWebhookResponseSize = "webhook:response_size"
 )
 
 // Warning events are created for things like accessing deprecated context values. Some warnings have
@@ -18,7 +20,8 @@ const (
 //	  "uuid": "0197b335-6ded-79a4-95a6-3af85b57f108",
 //	  "type": "warning",
 //	  "created_on": "2006-01-02T15:04:05Z",
-//	  "text": "deprecated context value accessed: legacy_extra"
+//	  "text": "@legacy_extra is deprecated",
+//	  "code": "context:deprecated"
 //	}
 //
 // @event warning

--- a/excellent/base_test.go
+++ b/excellent/base_test.go
@@ -399,12 +399,12 @@ func TestEvaluateTemplateWithDeprecatedValues(t *testing.T) {
 	val, warnings, err = eval.Template(t.Context(), env, ctx, `Hi @foo.zzz`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi abc`, val)
-	assert.Equal(t, []string{"deprecated context value accessed: foooo"}, warnings)
+	assert.Equal(t, []string{"foooo"}, warnings)
 
 	val, warnings, err = eval.Template(t.Context(), env, ctx, `Hi @yyy @foo.zzz`, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, `Hi xyz abc`, val)
-	assert.Equal(t, []string{"deprecated context value accessed: noooo", "deprecated context value accessed: foooo"}, warnings)
+	assert.Equal(t, []string{"noooo", "foooo"}, warnings)
 }
 
 func TestEvaluationErrors(t *testing.T) {

--- a/excellent/tree.go
+++ b/excellent/tree.go
@@ -24,7 +24,7 @@ func (w *Warnings) add(m string) {
 }
 
 func (w *Warnings) deprecatedContext(v types.XValue) {
-	w.add("deprecated context value accessed: " + v.Deprecated())
+	w.add(v.Deprecated())
 }
 
 // Expression is the base interface of all syntax elements

--- a/flows/actions/call_resthook.go
+++ b/flows/actions/call_resthook.go
@@ -131,7 +131,7 @@ func (a *CallResthook) Execute(ctx context.Context, run flows.Run, step flows.St
 		call, err := svc.Call(req)
 
 		if err != nil {
-			logCallError(err, log)
+			logCallError(err, run, log)
 		}
 		if call != nil {
 			calls = append(calls, call)

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -172,7 +172,7 @@ func (a *CallWebhook) call(ctx context.Context, run flows.Run, step flows.Step, 
 
 	trace, err := svc.Call(req)
 	if err != nil {
-		logCallError(err, log)
+		logCallError(err, run, log)
 	}
 
 	if trace != nil {
@@ -199,9 +199,10 @@ func (a *CallWebhook) Inspect(dependency func(assets.Reference), local func(stri
 
 // logs an error from the webhook service - a response exceeding the size limit is only a warning because the call
 // is still recorded (as a connection error) and the flow routes on that as usual
-func logCallError(err error, log events.EventLogger) {
+func logCallError(err error, run flows.Run, log events.EventLogger) {
 	if errors.Is(err, httpx.ErrResponseSize) {
-		log(events.NewWarning(err.Error(), ""))
+		maxResponseBytes := run.Session().Engine().Options().MaxResponseBytes
+		log(events.NewWarning(fmt.Sprintf("Webhook response exceeded the limit of %d bytes", maxResponseBytes), events.WarningCodeWebhookResponseSize))
 	} else {
 		log(events.NewRawError(err))
 	}

--- a/flows/actions/testdata/call_webhook.json
+++ b/flows/actions/testdata/call_webhook.json
@@ -925,7 +925,8 @@
                 "uuid": "01969b47-384b-76f8-a7eb-cc4cc9ec3e6b",
                 "type": "warning",
                 "created_on": "2025-05-04T12:30:59.123456789Z",
-                "text": "response body exceeds size limit"
+                "text": "Webhook response exceeded the limit of 100000 bytes",
+                "code": "webhook:response_size"
             },
             {
                 "uuid": "01969b47-401b-76f8-aac5-d9d0ae409dbe",

--- a/flows/engine/legacy.go
+++ b/flows/engine/legacy.go
@@ -48,7 +48,7 @@ func newLegacyExtra(run flows.Run) *legacyExtra {
 
 func (e *legacyExtra) ToXValue(env envs.Environment) types.XValue {
 	value := types.NewXObject(e.values)
-	value.SetDeprecated("legacy_extra")
+	value.SetDeprecated("@legacy_extra is deprecated")
 	return value
 }
 

--- a/flows/engine/run.go
+++ b/flows/engine/run.go
@@ -313,7 +313,8 @@ func (r *run) EvaluateTemplateValue(ctx context.Context, template string, log ev
 		r.errorToEvents(err, log)
 	}
 	for _, w := range warnings {
-		log(events.NewWarning(w, ""))
+		// currently the only warnings the evaluator produces are deprecated context usages
+		log(events.NewWarning(w, events.WarningCodeDeprecatedContext))
 	}
 	return value, err == nil
 }
@@ -327,7 +328,8 @@ func (r *run) EvaluateTemplateText(ctx context.Context, template string, escapin
 		r.errorToEvents(err, log)
 	}
 	for _, w := range warnings {
-		log(events.NewWarning(w, ""))
+		// currently the only warnings the evaluator produces are deprecated context usages
+		log(events.NewWarning(w, events.WarningCodeDeprecatedContext))
 	}
 	if truncate {
 		value = stringsx.TruncateEllipsis(value, r.Session().Engine().Options().MaxTemplateChars)

--- a/flows/engine/summary.go
+++ b/flows/engine/summary.go
@@ -71,7 +71,7 @@ func (c *relatedRunContext) Context(env envs.Environment) map[string]types.XValu
 	}
 
 	legacyStatus := types.NewXText(string(c.run.Status()))
-	legacyStatus.SetDeprecated("child.run.status: use child.status instead")
+	legacyStatus.SetDeprecated("@child.run.status is deprecated, use @child.status instead")
 
 	return map[string]types.XValue{
 		"__default__": types.NewXText(FormatRunSummary(env, c.run)),

--- a/flows/engine/testdata/templates.json
+++ b/flows/engine/testdata/templates.json
@@ -12,7 +12,8 @@
                 "uuid": "01969b48-c2d3-76f8-af42-abb6278d787f",
                 "type": "warning",
                 "created_on": "2025-05-04T12:32:40.123456789Z",
-                "text": "deprecated context value accessed: contact.id: use contact.ref instead"
+                "text": "@contact.id is deprecated, use @contact.ref instead",
+                "code": "context:deprecated"
             }
         ]
     },
@@ -469,7 +470,8 @@
                 "uuid": "01969b48-e9e3-76f8-be3d-ee0d6d09117e",
                 "type": "warning",
                 "created_on": "2025-05-04T12:32:50.123456789Z",
-                "text": "deprecated context value accessed: legacy_extra"
+                "text": "@legacy_extra is deprecated",
+                "code": "context:deprecated"
             }
         ]
     },
@@ -529,7 +531,8 @@
                 "uuid": "01969b48-f1b3-76f8-8876-bd2f7154ab08",
                 "type": "warning",
                 "created_on": "2025-05-04T12:32:52.123456789Z",
-                "text": "deprecated context value accessed: contact.tickets: use ticket instead"
+                "text": "@contact.tickets is deprecated, use @ticket instead",
+                "code": "context:deprecated"
             }
         ]
     },

--- a/test/testdata/runner/expirations.test_all_expire.json
+++ b/test/testdata/runner/expirations.test_all_expire.json
@@ -177,8 +177,9 @@
                     "uuid": "01969b47-6b13-76f8-b3a5-b9dac4767740"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:14.123456789Z",
-                    "text": "deprecated context value accessed: child.run.status: use child.status instead",
+                    "text": "@child.run.status is deprecated, use @child.status instead",
                     "type": "warning",
                     "uuid": "01969b47-72e3-76f8-87c7-10f327cbfde2"
                 },
@@ -327,8 +328,9 @@
                     "uuid": "01969b47-a5ab-76f8-a58f-30ba497b0d21"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:29.123456789Z",
-                    "text": "deprecated context value accessed: child.run.status: use child.status instead",
+                    "text": "@child.run.status is deprecated, use @child.status instead",
                     "type": "warning",
                     "uuid": "01969b47-ad7b-76f8-a8c9-d76ecec32717"
                 },

--- a/test/testdata/runner/expirations.test_input_for_all.json
+++ b/test/testdata/runner/expirations.test_input_for_all.json
@@ -185,8 +185,9 @@
                     "uuid": "01969b47-8283-76f8-87c7-10f327cbfde2"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:20.123456789Z",
-                    "text": "deprecated context value accessed: child.run.status: use child.status instead",
+                    "text": "@child.run.status is deprecated, use @child.status instead",
                     "type": "warning",
                     "uuid": "01969b47-8a53-76f8-a98e-1c65c9788658"
                 },
@@ -362,8 +363,9 @@
                     "uuid": "01969b47-d48b-76f8-aab8-757fffa552e6"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:41.123456789Z",
-                    "text": "deprecated context value accessed: child.run.status: use child.status instead",
+                    "text": "@child.run.status is deprecated, use @child.status instead",
                     "type": "warning",
                     "uuid": "01969b47-dc5b-76f8-95d6-85696b970f6a"
                 },

--- a/test/testdata/runner/extra.test.json
+++ b/test/testdata/runner/extra.test.json
@@ -34,8 +34,9 @@
                     "uuid": "01969b47-1523-76f8-92ed-42cbd11a03fd"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:30:53.123456789Z",
-                    "text": "deprecated context value accessed: legacy_extra",
+                    "text": "@legacy_extra is deprecated",
                     "type": "warning",
                     "uuid": "01969b47-20db-76f8-b774-0a98171a0712"
                 },
@@ -67,8 +68,9 @@
                     "value": "Ben Haggerty"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:05.123456789Z",
-                    "text": "deprecated context value accessed: legacy_extra",
+                    "text": "@legacy_extra is deprecated",
                     "type": "warning",
                     "uuid": "01969b47-4fbb-76f8-8b42-056e0211d5b9"
                 },
@@ -114,8 +116,9 @@
                     "value": "200"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:17.123456789Z",
-                    "text": "deprecated context value accessed: legacy_extra",
+                    "text": "@legacy_extra is deprecated",
                     "type": "warning",
                     "uuid": "01969b47-7e9b-76f8-b384-a4094c3d60be"
                 },
@@ -258,8 +261,9 @@
                     "value": "Ryan Lewis"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:33.123456789Z",
-                    "text": "deprecated context value accessed: legacy_extra",
+                    "text": "@legacy_extra is deprecated",
                     "type": "warning",
                     "uuid": "01969b47-bd1b-76f8-b4dd-bb13b355a627"
                 },

--- a/test/testdata/runner/legacy_webhook.test.json
+++ b/test/testdata/runner/legacy_webhook.test.json
@@ -62,8 +62,9 @@
                     "value": "200"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:03.123456789Z",
-                    "text": "deprecated context value accessed: legacy_extra",
+                    "text": "@legacy_extra is deprecated",
                     "type": "warning",
                     "uuid": "01969b47-47eb-76f8-a943-ec055bbeb3b4"
                 },

--- a/test/testdata/runner/redact_urns.test.json
+++ b/test/testdata/runner/redact_urns.test.json
@@ -45,8 +45,9 @@
                     "uuid": "01969b47-1523-76f8-92ed-42cbd11a03fd"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:30:53.123456789Z",
-                    "text": "deprecated context value accessed: contact.id: use contact.ref instead",
+                    "text": "@contact.id is deprecated, use @contact.ref instead",
                     "type": "warning",
                     "uuid": "01969b47-20db-76f8-b774-0a98171a0712"
                 },

--- a/test/testdata/runner/ticketing.test.json
+++ b/test/testdata/runner/ticketing.test.json
@@ -133,8 +133,9 @@
                     "value": "01969b47-5f5b-76f8-89aa-1577771fa183"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:20.123456789Z",
-                    "text": "deprecated context value accessed: contact.tickets: use ticket instead",
+                    "text": "@contact.tickets is deprecated, use @ticket instead",
                     "type": "warning",
                     "uuid": "01969b47-8a53-76f8-87c7-10f327cbfde2"
                 },

--- a/test/testdata/runner/ticketing_resultless.test.json
+++ b/test/testdata/runner/ticketing_resultless.test.json
@@ -125,8 +125,9 @@
                     "uuid": "01969b47-6b13-76f8-a943-ec055bbeb3b4"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:16.123456789Z",
-                    "text": "deprecated context value accessed: contact.tickets: use ticket instead",
+                    "text": "@contact.tickets is deprecated, use @ticket instead",
                     "type": "warning",
                     "uuid": "01969b47-7ab3-76f8-b3a5-b9dac4767740"
                 },

--- a/test/testdata/runner/webhook_migrated.test.json
+++ b/test/testdata/runner/webhook_migrated.test.json
@@ -116,8 +116,9 @@
                     "value": "200"
                 },
                 {
+                    "code": "context:deprecated",
                     "created_on": "2025-05-04T12:31:15.123456789Z",
-                    "text": "deprecated context value accessed: legacy_extra",
+                    "text": "@legacy_extra is deprecated",
                     "type": "warning",
                     "uuid": "01969b47-76cb-76f8-8f55-b7788ac5e343"
                 },


### PR DESCRIPTION
Gives warning events the same treatment that failure events got in #1474 — messages that make sense to flow builders rather than developers:

* Deprecated context warnings become `@contact.id is deprecated, use @contact.ref instead` (previously `deprecated context value accessed: contact.id: use contact.ref instead`) — the `SetDeprecated()` message is now the complete user-facing text.
* Webhook response size warnings become `Webhook response exceeded the limit of 100000 bytes` (previously the raw `response body exceeds size limit` error).

Warnings also now carry codes (`context:deprecated`, `webhook:response_size`) so consumers can identify them without matching on text — deprecated context usage tracking should switch to the code and extract the context key from the leading `@token`.

Closes #1478