### PR TITLE
Add engine limit on number of runs per session

### DIFF
--- a/flows/engine/engine.go
+++ b/flows/engine/engine.go
@@ -97,6 +97,7 @@ func NewBuilder() *Builder {
 			options: &flows.EngineOptions{
 				MaxStepsPerSprint:    100,
 				MaxSprintsPerSession: 500,
+				MaxRunsPerSession:    500,
 				MaxTemplateChars:     10000,
 				MaxNameChars:         128,
 				MaxFieldChars:        640,
@@ -157,6 +158,12 @@ func (b *Builder) WithMaxStepsPerSprint(max int) *Builder {
 // WithMaxSprintsPerSession sets the maximum number of resumes allowed in a single session
 func (b *Builder) WithMaxSprintsPerSession(max int) *Builder {
 	b.eng.options.MaxSprintsPerSession = max
+	return b
+}
+
+// WithMaxRunsPerSession sets the maximum number of runs allowed in a single session
+func (b *Builder) WithMaxRunsPerSession(max int) *Builder {
+	b.eng.options.MaxRunsPerSession = max
 	return b
 }
 

--- a/flows/engine/engine_test.go
+++ b/flows/engine/engine_test.go
@@ -18,6 +18,7 @@ func TestBuilder(t *testing.T) {
 	eng := engine.NewBuilder().
 		WithMaxStepsPerSprint(123).
 		WithMaxSprintsPerSession(567).
+		WithMaxRunsPerSession(345).
 		WithMaxTemplateChars(999).
 		WithMaxNameChars(100).
 		WithMaxFieldChars(888).
@@ -27,6 +28,7 @@ func TestBuilder(t *testing.T) {
 
 	assert.Equal(t, 123, eng.Options().MaxStepsPerSprint)
 	assert.Equal(t, 567, eng.Options().MaxSprintsPerSession)
+	assert.Equal(t, 345, eng.Options().MaxRunsPerSession)
 	assert.Equal(t, 999, eng.Options().MaxTemplateChars)
 	assert.Equal(t, 100, eng.Options().MaxNameChars)
 	assert.Equal(t, 888, eng.Options().MaxFieldChars)

--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -347,32 +347,38 @@ func (s *session) continueUntilWait(ctx context.Context, sprint *sprint, current
 
 		// if a new flow has been pushed, find a destination there
 		if s.pushedFlow != nil {
-			// if this is terminal, then we need to mark all other runs as completed so we don't try to resume them
-			if s.pushedFlow.terminal {
-				for _, run := range s.runs {
-					if run.Status() == core.RunStatusActive || run.Status() == core.RunStatusWaiting {
-						run.Exit(core.RunStatusCompleted)
-						sprint.logEvent(events.NewRunEnded(run.UUID(), run.FlowReference(), core.RunStatusCompleted))
+			if len(s.runs) >= s.engine.Options().MaxRunsPerSession {
+				// we've hit the run limit - usually a sign of a loop between flows
+				failRun(sprint, currentRun, step, fmt.Sprintf("Reached maximum number of runs per session (%d)", s.engine.Options().MaxRunsPerSession))
+				s.pushedFlow = nil
+				destination = ""
+			} else {
+				// if this is terminal, then we need to mark all other runs as completed so we don't try to resume them
+				if s.pushedFlow.terminal {
+					for _, run := range s.runs {
+						if run.Status() == core.RunStatusActive || run.Status() == core.RunStatusWaiting {
+							run.Exit(core.RunStatusCompleted)
+							sprint.logEvent(events.NewRunEnded(run.UUID(), run.FlowReference(), core.RunStatusCompleted))
+						}
 					}
 				}
+
+				// create a new run for it
+				flow := s.pushedFlow.flow
+				currentRun = newRun(s, s.pushedFlow.flow, currentRun)
+				s.addRun(currentRun)
+				sprint.logEvent(events.NewRunStarted(currentRun.FlowReference(), currentRun.UUID(), parentRunUUID(currentRun), s.pushedFlow.terminal))
+				sprint.logFlow(flow)
+
+				// our destination is the first node in that flow... if such a node exists
+				if len(flow.Nodes()) > 0 {
+					destination = flow.Nodes()[0].UUID()
+				} else {
+					destination = ""
+				}
+
+				s.pushedFlow = nil // clear the trigger
 			}
-
-			// create a new run for it
-			flow := s.pushedFlow.flow
-			currentRun = newRun(s, s.pushedFlow.flow, currentRun)
-			s.addRun(currentRun)
-			sprint.logEvent(events.NewRunStarted(currentRun.FlowReference(), currentRun.UUID(), parentRunUUID(currentRun), s.pushedFlow.terminal))
-			sprint.logFlow(flow)
-
-			// our destination is the first node in that flow... if such a node exists
-			if len(flow.Nodes()) > 0 {
-				destination = flow.Nodes()[0].UUID()
-			} else {
-				destination = ""
-			}
-
-			s.pushedFlow = nil // clear the trigger
-
 		} else if exit != nil {
 			// if we're at an exit, use its destination
 			destination = exit.DestinationUUID()

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -388,6 +388,30 @@ func TestMaxSprintsPerSession(t *testing.T) {
 	assert.Equal(t, 500, numResumes)
 }
 
+func TestMaxRunsPerSession(t *testing.T) {
+	ctx := t.Context()
+	_, session, _ := test.NewSessionBuilder().WithAssetsPath("../../test/testdata/runner/enter_flow_loop.json").WithFlow("0fcfcd7d-ae83-4bfa-b02c-23d5d9ce3e69").MustBuild()
+	require.Equal(t, flows.SessionStatusWaiting, session.Status())
+
+	numResumes := 0
+	for {
+		msg := core.NewMsgIn("tel:+593979123456", nil, "name", nil, "SMS1234", nil)
+		resume := resumes.NewMsg(events.NewMsgReceived(msg, ""))
+		numResumes++
+
+		_, err := session.Resume(ctx, resume)
+		require.NoError(t, err)
+
+		if session.Status() == flows.SessionStatusFailed {
+			break
+		}
+	}
+
+	// each resume creates 2 new runs so we hit the limit of 500 runs after 250 resumes
+	assert.Equal(t, 250, numResumes)
+	assert.Equal(t, 500, len(session.Runs()))
+}
+
 func TestEngineErrors(t *testing.T) {
 	ctx := t.Context()
 

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -252,6 +252,7 @@ type ClaimURNCallback func(context.Context, SessionAssets, *core.Contact, urns.U
 type EngineOptions struct {
 	MaxStepsPerSprint    int
 	MaxSprintsPerSession int
+	MaxRunsPerSession    int
 	MaxTemplateChars     int
 	MaxNameChars         int
 	MaxFieldChars        int


### PR DESCRIPTION
## Summary

Sessions had limits on steps per sprint and sprints per session, but nothing bounded the total number of runs. Subflow-heavy flow architectures can create sessions with 150+ runs in relatively few sprints — each resume cascading through many subflows — growing session output far beyond what the sprint cap was meant to prevent, which matters as session storage may move to backends with item size limits.

## Changes

- Added `MaxRunsPerSession` to `EngineOptions` with a default of 500 (matching `MaxSprintsPerSession`) and a `WithMaxRunsPerSession` builder option.
- Enforced at the single point where a pushed flow becomes a new run: if the session already contains the maximum number of runs, the pushing run is failed with `Reached maximum number of runs per session (500)` and the failure bubbles up the run hierarchy, ending the session with a failed status — same pattern as the steps-per-sprint limit.

## Test plan

- `TestBuilder` extended to cover the new option.
- New `TestMaxRunsPerSession` mirrors `TestMaxSprintsPerSession`, using the existing `enter_flow_loop` fixture where each resume creates 2 new runs — verifies the session fails after exactly 250 resumes with exactly 500 runs, well before the sprint cap.
- Full suite passes (`go test -p=1 ./...`).

Callers that configure the other limits explicitly will use the default until they wire up this option.