### PR TITLE
Also clear locals and webhook of exited runs in Session.Compact()

### DIFF
--- a/flows/engine/session.go
+++ b/flows/engine/session.go
@@ -147,12 +147,16 @@ func (s *session) waitingRun() *run {
 	return nil
 }
 
-// Compact removes state which the engine will never need again - i.e. the paths of exited runs. Callers should only
-// invoke this after extracting anything they themselves need from the session, and before marshaling it for storage.
+// Compact removes state which the engine will never need again - i.e. the paths, locals and webhooks of exited runs.
+// Callers should only invoke this after extracting anything they themselves need from the session, and before
+// marshaling it for storage.
 func (s *session) Compact() {
 	for _, r := range s.runs {
 		if r.Status() != core.RunStatusActive && r.Status() != core.RunStatusWaiting {
-			r.(*run).path = nil
+			rr := r.(*run)
+			rr.path = nil
+			rr.locals = nil
+			rr.webhook = nil
 		}
 	}
 }

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -449,6 +449,10 @@ func TestSessionCompact(t *testing.T) {
 
 	require.NotNil(t, session.Runs()[1].Locals())
 
+	// give the exited run a webhook so we can check that it's cleared
+	session.Runs()[1].SetWebhook(&flows.WebhookCall{Method: "GET", URL: "http://example.com", ResponseStatus: 200})
+	require.NotNil(t, session.Runs()[1].Webhook())
+
 	session.Compact()
 
 	// waiting run keeps its path, exited run loses its path, locals and webhook

--- a/flows/engine/session_test.go
+++ b/flows/engine/session_test.go
@@ -447,11 +447,16 @@ func TestSessionCompact(t *testing.T) {
 	require.NotEmpty(t, session.Runs()[0].Path())
 	require.NotEmpty(t, session.Runs()[1].Path())
 
+	require.NotNil(t, session.Runs()[1].Locals())
+
 	session.Compact()
 
-	// waiting run keeps its path, exited run loses its
+	// waiting run keeps its path, exited run loses its path, locals and webhook
 	assert.NotEmpty(t, session.Runs()[0].Path())
+	assert.NotNil(t, session.Runs()[0].Locals())
 	assert.Empty(t, session.Runs()[1].Path())
+	assert.Nil(t, session.Runs()[1].Locals())
+	assert.Nil(t, session.Runs()[1].Webhook())
 
 	// and in the marshaled session, the exited run has no path key at all
 	marshaled, err := jsonx.Marshal(session)

--- a/test/testdata/runner/airtime.test_successful_transfer.json
+++ b/test/testdata/runner/airtime.test_successful_transfer.json
@@ -84,9 +84,6 @@
                             "name": "Airtime Test",
                             "uuid": "8ca44c09-791d-453a-9799-a70dd3303306"
                         },
-                        "locals": {
-                            "_new_transfer": "01969b47-20db-76f8-b20c-e3cb6203e029"
-                        },
                         "modified_on": "2025-05-04T12:30:58.123456789Z",
                         "results": {
                             "transfer": {

--- a/test/testdata/runner/airtime_noresult.test.json
+++ b/test/testdata/runner/airtime_noresult.test.json
@@ -76,9 +76,6 @@
                             "name": "Airtime Test",
                             "uuid": "8ca44c09-791d-453a-9799-a70dd3303306"
                         },
-                        "locals": {
-                            "_new_transfer": "01969b47-20db-76f8-b20c-e3cb6203e029"
-                        },
                         "modified_on": "2025-05-04T12:30:54.123456789Z",
                         "status": "completed",
                         "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"

--- a/test/testdata/runner/all_actions.test.json
+++ b/test/testdata/runner/all_actions.test.json
@@ -460,10 +460,6 @@
                             "uuid": "8ca44c09-791d-453a-9799-a70dd3303306"
                         },
                         "had_input": true,
-                        "locals": {
-                            "_has_urn": "twitter:ben_haggerty",
-                            "counter": "2"
-                        },
                         "modified_on": "2025-05-04T12:31:51.123456789Z",
                         "results": {
                             "gender": {
@@ -475,16 +471,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "ok": "true"
-                            },
-                            "method": "GET",
-                            "status": 200,
-                            "url": "http://localhost/?cmd=success&name=Jeff%20Jefferson%202"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     },
                     {
                         "created_on": "2025-05-04T12:31:44.123456789Z",

--- a/test/testdata/runner/extra.test.json
+++ b/test/testdata/runner/extra.test.json
@@ -357,16 +357,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "ok": "true"
-                            },
-                            "method": "GET",
-                            "status": 200,
-                            "url": "http://localhost/?cmd=extra"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     }
                 ],
                 "sprints": 2,

--- a/test/testdata/runner/legacy_webhook.test.json
+++ b/test/testdata/runner/legacy_webhook.test.json
@@ -128,16 +128,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-aac5-d9d0ae409dbe",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "foo": "bar"
-                            },
-                            "method": "POST",
-                            "status": 200,
-                            "url": "http://localhost/?cmd=foo"
-                        }
+                        "uuid": "01969b47-113b-76f8-aac5-d9d0ae409dbe"
                     }
                 ],
                 "sprints": 1,

--- a/test/testdata/runner/llm_categorize.failure.json
+++ b/test/testdata/runner/llm_categorize.failure.json
@@ -157,9 +157,6 @@
                             "uuid": "79a67c64-b43d-45f2-a5fc-1c2eeed6d04e"
                         },
                         "had_input": true,
-                        "locals": {
-                            "_llm_output": "<ERROR>"
-                        },
                         "modified_on": "2025-05-04T12:31:15.123456789Z",
                         "results": {
                             "intent": {

--- a/test/testdata/runner/llm_categorize.flight.json
+++ b/test/testdata/runner/llm_categorize.flight.json
@@ -186,9 +186,6 @@
                             "uuid": "79a67c64-b43d-45f2-a5fc-1c2eeed6d04e"
                         },
                         "had_input": true,
-                        "locals": {
-                            "_llm_output": "Hotels"
-                        },
                         "modified_on": "2025-05-04T12:31:20.123456789Z",
                         "results": {
                             "intent": {

--- a/test/testdata/runner/phone_number.test.json
+++ b/test/testdata/runner/phone_number.test.json
@@ -307,9 +307,6 @@
                             "uuid": "825f87d3-b160-4a03-877f-ae1a200794d4"
                         },
                         "had_input": true,
-                        "locals": {
-                            "_has_urn": "tel:+17184567890"
-                        },
                         "modified_on": "2025-05-04T12:31:29.123456789Z",
                         "results": {
                             "backup_phone": {

--- a/test/testdata/runner/redact_urns.test.json
+++ b/test/testdata/runner/redact_urns.test.json
@@ -107,16 +107,7 @@
                         },
                         "modified_on": "2025-05-04T12:31:00.123456789Z",
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "ok": "true"
-                            },
-                            "method": "POST",
-                            "status": 200,
-                            "url": "http://localhost/?cmd=success"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     }
                 ],
                 "sprints": 1,

--- a/test/testdata/runner/resthook.test.json
+++ b/test/testdata/runner/resthook.test.json
@@ -182,18 +182,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "errors": [
-                                    "bad_request"
-                                ]
-                            },
-                            "method": "POST",
-                            "status": 400,
-                            "url": "http://localhost/?cmd=badrequest"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     }
                 ],
                 "sprints": 1,

--- a/test/testdata/runner/smart_groups.test.json
+++ b/test/testdata/runner/smart_groups.test.json
@@ -232,9 +232,6 @@
                             "name": "Smart Groups",
                             "uuid": "1b462ce8-983a-4393-b133-e15a0efdb70c"
                         },
-                        "locals": {
-                            "_has_urn": "tel:+250781234567"
-                        },
                         "modified_on": "2025-05-04T12:31:19.123456789Z",
                         "status": "completed",
                         "uuid": "01969b47-190b-76f8-92ed-42cbd11a03fd"

--- a/test/testdata/runner/ticketing.test.json
+++ b/test/testdata/runner/ticketing.test.json
@@ -195,9 +195,6 @@
                             "uuid": "3486fc59-d417-4189-93cd-e0aa8e3112ac"
                         },
                         "had_input": true,
-                        "locals": {
-                            "_new_ticket": "01969b47-5f5b-76f8-9729-57745fb13b06"
-                        },
                         "modified_on": "2025-05-04T12:31:23.123456789Z",
                         "results": {
                             "response_1": {

--- a/test/testdata/runner/ticketing_resultless.test.json
+++ b/test/testdata/runner/ticketing_resultless.test.json
@@ -187,9 +187,6 @@
                             "uuid": "3486fc59-d417-4189-93cd-e0aa8e3112ac"
                         },
                         "had_input": true,
-                        "locals": {
-                            "_new_ticket": "01969b47-5f5b-76f8-9729-57745fb13b06"
-                        },
                         "modified_on": "2025-05-04T12:31:19.123456789Z",
                         "results": {
                             "response_1": {

--- a/test/testdata/runner/two_questions.test.json
+++ b/test/testdata/runner/two_questions.test.json
@@ -333,16 +333,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "ok": "true"
-                            },
-                            "method": "POST",
-                            "status": 200,
-                            "url": "http://localhost/?cmd=success"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     }
                 ],
                 "sprints": 3,

--- a/test/testdata/runner/webhook_migrated.test.json
+++ b/test/testdata/runner/webhook_migrated.test.json
@@ -209,16 +209,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "exists": "valid"
-                            },
-                            "method": "GET",
-                            "status": 200,
-                            "url": "http://localhost/?cmd=country"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     }
                 ],
                 "sprints": 2,

--- a/test/testdata/runner/webhook_noresult.test.json
+++ b/test/testdata/runner/webhook_noresult.test.json
@@ -150,14 +150,7 @@
                         },
                         "modified_on": "2025-05-04T12:31:10.123456789Z",
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": null,
-                            "json": null,
-                            "method": "GET",
-                            "status": 0,
-                            "url": "http://temba.io/bad"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     }
                 ],
                 "sprints": 1,

--- a/test/testdata/runner/webhook_results.test.json
+++ b/test/testdata/runner/webhook_results.test.json
@@ -468,16 +468,7 @@
                             }
                         },
                         "status": "completed",
-                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a",
-                        "webhook": {
-                            "headers": {},
-                            "json": {
-                                "greeting": "hello"
-                            },
-                            "method": "GET",
-                            "status": 200,
-                            "url": "http://temba.io/2"
-                        }
+                        "uuid": "01969b47-113b-76f8-95cf-9fca95f1c30a"
                     }
                 ],
                 "sprints": 3,


### PR DESCRIPTION
## Summary

Extends `Compact()` (#1611) to also clear the `locals` and `webhook` of exited runs. Like their paths, these are never read again once a run exits: run locals and the last webhook call are only exposed in the expression context of the run currently being evaluated (always active or waiting), and `@child`/`@parent` don't expose either.

Webhooks are the notable saving — a run can persist up to 10K of webhook response, so a session that cascades through webhook-calling subflows carries one such blob per exited run.

## Changes

- `Compact()` sets `locals` and `webhook` to nil alongside `path` for runs that aren't active or waiting. No marshaling changes needed: `locals` is already `omitzero` and `webhook` already nil-guarded, so both keys are simply omitted, and reading a compacted session restores an empty locals.
- `TestSessionCompact` asserts the exited run's locals and webhook are cleared while the waiting run keeps its. The exited run is given a webhook before compaction so the clearing assertion is exercised rather than trivially satisfied.
- Regenerated runner goldens — the corpus round-trips the fuller compaction through read + resume, including fixtures where exited runs carried webhook responses and locals.

## Test plan

- `TestSessionCompact` covers the new clearing directly, with pre-conditions proving the exited run carried locals and a webhook.
- Full suite passes (`go test -p=1 ./...`, 44 packages).