### PR TITLE
Split restricted webhook domains into separate warn and block lists

### DIFF
--- a/cmd/flowrunner/main.go
+++ b/cmd/flowrunner/main.go
@@ -91,7 +91,7 @@ func createEngine() flows.Engine {
 	return engine.NewBuilder().
 		WithHTTPClient(http.DefaultClient).
 		WithWebhookLimits(256*1024, 10000).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-runner"}, nil)).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-runner"}, nil, nil)).
 		Build()
 }
 

--- a/core/events/base_test.go
+++ b/core/events/base_test.go
@@ -554,7 +554,7 @@ func TestWebhookCalledEventTrimming(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", strings.NewReader(strings.Repeat("X", 20000)))
 
-	svc := webhooks.NewService(client, nil, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 
@@ -579,7 +579,7 @@ func TestWebhookCalledEventValid(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", nil)
 
-	svc := webhooks.NewService(client, nil, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 
@@ -599,7 +599,7 @@ func TestWebhookCalledEventNullChar(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", nil)
 
-	svc := webhooks.NewService(client, nil, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 
@@ -620,7 +620,7 @@ func TestWebhookCalledEventBadUTF8(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "http://temba.io/", nil)
 
-	svc := webhooks.NewService(client, nil, nil, 1024*1024)
+	svc := webhooks.NewService(client, nil, nil, nil, 1024*1024)
 	call, err := svc.Call(request)
 	require.NoError(t, err)
 

--- a/core/events/error.go
+++ b/core/events/error.go
@@ -20,6 +20,7 @@ const (
 	ErrorCodeLabelMissing         = "label:missing"
 	ErrorCodeTimezoneInvalid      = "timezone:invalid"
 	ErrorCodeURLInvalid           = "url:invalid"
+	ErrorCodeURLRestricted        = "url:restricted"
 	ErrorCodeURNInvalid           = "urn:invalid"
 	ErrorCodeURNTaken             = "urn:taken"
 	ErrorCodeUserMissing          = "user:missing"

--- a/flows/actions/base_test.go
+++ b/flows/actions/base_test.go
@@ -225,7 +225,7 @@ func testActionType(t *testing.T, assetsJSON []byte, typeName string) {
 				return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io", nil)
 			}).
 			WithWebhookLimits(256*1024, 100000).
-			WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"})).
+			WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"}, []string{"api.twilio.com"})).
 			WithLLMServiceFactory(func(l *core.LLM) (flows.LLMService, error) {
 				return services.NewLLM(), nil
 			}).
@@ -1072,7 +1072,7 @@ func TestCallWebhookAlwaysUpdatesWebhook(t *testing.T) {
 
 	eng := engine.NewBuilder().
 		WithHTTPClient(httpClient).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(nil, nil)).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(nil, nil, nil)).
 		Build()
 
 	flow := assets.NewFlowReference("5472a1c3-63e1-484f-8485-cc8ecb16a058", "Webhooks")

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -167,9 +167,13 @@ func (a *CallWebhook) call(ctx context.Context, run flows.Run, step flows.Step, 
 		return nil
 	}
 
-	// for now calls to restricted URLs only generate warnings but eventually they may be blocked
-	if svc.IsRestricted(req.URL) {
+	// calls to restricted URLs either generate a warning that they may be blocked in the future, or are blocked now
+	switch svc.Restriction(req.URL) {
+	case flows.URLRestrictionWarn:
 		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", req.URL.Hostname()), events.WarningCodeURLRestricted, "hostname", req.URL.Hostname()))
+	case flows.URLRestrictionBlock:
+		log(events.NewError(fmt.Sprintf("Webhook calls to %s are not allowed", req.URL.Hostname()), events.ErrorCodeURLRestricted, "hostname", req.URL.Hostname()))
+		return nil
 	}
 
 	trace, err := svc.Call(req)

--- a/flows/actions/testdata/call_webhook.json
+++ b/flows/actions/testdata/call_webhook.json
@@ -427,6 +427,45 @@
         }
     },
     {
+        "description": "Error event created and no call made if URL is in a blocked domain",
+        "action": {
+            "type": "call_webhook",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "method": "POST",
+            "url": "https://api.twilio.com/2010-04-01/Accounts/1234/Messages.json",
+            "body": "{}"
+        },
+        "events": [
+            {
+                "uuid": "01969b47-307b-76f8-b774-0a98171a0712",
+                "type": "error",
+                "created_on": "2025-05-04T12:30:57.123456789Z",
+                "text": "Webhook calls to api.twilio.com are not allowed",
+                "code": "url:restricted",
+                "extra": {
+                    "hostname": "api.twilio.com"
+                }
+            }
+        ],
+        "webhook": null,
+        "locals_after": {},
+        "templates": [
+            "https://api.twilio.com/2010-04-01/Accounts/1234/Messages.json",
+            "{}"
+        ],
+        "inspection": {
+            "counts": {
+                "languages": 0,
+                "nodes": 1
+            },
+            "dependencies": [],
+            "locals": [],
+            "results": [],
+            "parent_refs": [],
+            "issues": []
+        }
+    },
+    {
         "description": "Result changed event created if result name set",
         "http_mocks": {
             "http://temba.io/": [

--- a/flows/engine/engine_test.go
+++ b/flows/engine/engine_test.go
@@ -44,7 +44,7 @@ func TestBuilder(t *testing.T) {
 	assert.EqualError(t, err, "no webhook service factory configured")
 
 	// include a webhook service
-	webhookSvc := webhooks.NewService(&http.Client{}, map[string]string{"User-Agent": "goflow"}, nil, 1000)
+	webhookSvc := webhooks.NewService(&http.Client{}, map[string]string{"User-Agent": "goflow"}, nil, nil, 1000)
 
 	eng = engine.NewBuilder().
 		WithWebhookServiceFactory(func(flows.Engine, flows.SessionAssets) (flows.WebhookService, error) { return webhookSvc, nil }).

--- a/flows/services.go
+++ b/flows/services.go
@@ -26,13 +26,27 @@ type EmailService interface {
 	Send(ctx context.Context, addresses []string, subject, body string) error
 }
 
+// URLRestriction is the level of restriction which applies to a webhook URL
+type URLRestriction string
+
+const (
+	// URLRestrictionNone means the URL can be called from flows
+	URLRestrictionNone URLRestriction = ""
+
+	// URLRestrictionWarn means the URL can be called from flows but a warning is generated
+	URLRestrictionWarn URLRestriction = "warn"
+
+	// URLRestrictionBlock means the URL can't be called from flows
+	URLRestrictionBlock URLRestriction = "block"
+)
+
 // WebhookService provides webhook functionality to the engine
 type WebhookService interface {
 	// Call makes the given HTTP request and returns the trace
 	Call(request *http.Request) (*httpx.Trace, error)
 
-	// IsRestricted returns whether the given URL is restricted and shouldn't be called from flows
-	IsRestricted(u *url.URL) bool
+	// Restriction returns the level of restriction which applies to the given URL
+	Restriction(u *url.URL) URLRestriction
 }
 
 // LLMService provides LLM functionality to the engine

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -13,24 +13,26 @@ import (
 )
 
 type service struct {
-	httpClient        *http.Client
-	defaultHeaders    map[string]string
-	restrictedDomains []string
-	maxResponseBytes  int
+	httpClient       *http.Client
+	defaultHeaders   map[string]string
+	warnDomains      []string
+	blockDomains     []string
+	maxResponseBytes int
 }
 
 // NewServiceFactory creates a new webhook service factory. The engine supplies the HTTP client and the maximum
 // response size; the client's transport can be configured with tracing, mocking or access control as needed
-// (see github.com/nyaruka/gocommon/httpx). The restricted domains are domains (e.g. messaging provider APIs)
-// which flows shouldn't be calling directly.
-func NewServiceFactory(defaultHeaders map[string]string, restrictedDomains []string) engine.WebhookServiceFactory {
+// (see github.com/nyaruka/gocommon/httpx). The warn and block domains are domains (e.g. messaging provider APIs)
+// which flows shouldn't be calling directly - calls to the former generate a warning, calls to the latter aren't
+// made at all. Domains are expected to be lowercase and match subdomains too.
+func NewServiceFactory(defaultHeaders map[string]string, warnDomains, blockDomains []string) engine.WebhookServiceFactory {
 	return func(eng flows.Engine, sa flows.SessionAssets) (flows.WebhookService, error) {
-		return NewService(eng.HTTPClient(), defaultHeaders, restrictedDomains, eng.Options().MaxResponseBytes), nil
+		return NewService(eng.HTTPClient(), defaultHeaders, warnDomains, blockDomains, eng.Options().MaxResponseBytes), nil
 	}
 }
 
 // NewService creates a new default webhook service
-func NewService(httpClient *http.Client, defaultHeaders map[string]string, restrictedDomains []string, maxResponseBytes int) flows.WebhookService {
+func NewService(httpClient *http.Client, defaultHeaders map[string]string, warnDomains, blockDomains []string, maxResponseBytes int) flows.WebhookService {
 	// build the client this service will call through, layering our concerns onto the transport we were given. The
 	// read limit bounds how much we'll read from an untrusted endpoint and goes inside tracing so it applies before
 	// the body is buffered into the trace; tracing is outermost so that a request denied by access control is still
@@ -44,18 +46,30 @@ func NewService(httpClient *http.Client, defaultHeaders map[string]string, restr
 	traced.Transport = httpx.WithTraces(inner)
 
 	return &service{
-		httpClient:        &traced,
-		defaultHeaders:    defaultHeaders,
-		restrictedDomains: restrictedDomains,
-		maxResponseBytes:  maxResponseBytes,
+		httpClient:       &traced,
+		defaultHeaders:   defaultHeaders,
+		warnDomains:      warnDomains,
+		blockDomains:     blockDomains,
+		maxResponseBytes: maxResponseBytes,
 	}
 }
 
-// IsRestricted returns whether the host of the given URL matches or is a subdomain of one of our
-// configured restricted domains.
-func (s *service) IsRestricted(u *url.URL) bool {
+// Restriction returns the level of restriction which applies to the given URL, based on whether its host matches
+// or is a subdomain of one of our configured domains. Blocking takes precedence over warning.
+func (s *service) Restriction(u *url.URL) flows.URLRestriction {
 	host := strings.ToLower(u.Hostname())
-	for _, domain := range s.restrictedDomains {
+
+	if matchesDomain(host, s.blockDomains) {
+		return flows.URLRestrictionBlock
+	}
+	if matchesDomain(host, s.warnDomains) {
+		return flows.URLRestrictionWarn
+	}
+	return flows.URLRestrictionNone
+}
+
+func matchesDomain(host string, domains []string) bool {
+	for _, domain := range domains {
 		if host == domain || strings.HasSuffix(host, "."+domain) {
 			return true
 		}

--- a/services/webhooks/service_test.go
+++ b/services/webhooks/service_test.go
@@ -169,7 +169,7 @@ func TestAccessRestrictions(t *testing.T) {
 
 	eng := engine.NewBuilder().WithHTTPClient(client).Build()
 
-	factory := webhooks.NewServiceFactory(map[string]string{"User-Agent": "Foo"}, nil)
+	factory := webhooks.NewServiceFactory(map[string]string{"User-Agent": "Foo"}, nil, nil)
 	svc, err := factory(eng, nil)
 	assert.NoError(t, err)
 
@@ -231,25 +231,26 @@ func TestWebhookResponseWithEscapes(t *testing.T) {
 	assert.NotContains(t, string(jsonx.MustMarshal(session)), `\u0000`)
 }
 
-func TestIsRestricted(t *testing.T) {
-	svc := webhooks.NewService(http.DefaultClient, nil, []string{"graph.facebook.com", "360dialog.io"}, 1024)
+func TestRestriction(t *testing.T) {
+	svc := webhooks.NewService(http.DefaultClient, nil, []string{"graph.facebook.com", "360dialog.io"}, []string{"api.twilio.com", "360dialog.io"}, 1024)
 
 	tcs := []struct {
-		url          string
-		isRestricted bool
+		url         string
+		restriction flows.URLRestriction
 	}{
-		{"https://graph.facebook.com/v25.0/1234/messages", true},
-		{"https://GRAPH.FACEBOOK.COM/v25.0/1234/messages", true}, // check case insensitivity
-		{"https://waba-v2.360dialog.io/messages", true},          // check subdomain matching
-		{"https://facebook.com/some/page", false},
-		{"https://notgraph.facebook.com.evil.com/", false},
-		{"https://temba.io/", false},
+		{"https://graph.facebook.com/v25.0/1234/messages", flows.URLRestrictionWarn},
+		{"https://GRAPH.FACEBOOK.COM/v25.0/1234/messages", flows.URLRestrictionWarn}, // check case insensitivity
+		{"https://api.twilio.com/2010-04-01/Accounts", flows.URLRestrictionBlock},
+		{"https://waba-v2.360dialog.io/messages", flows.URLRestrictionBlock}, // check subdomain matching, blocking wins
+		{"https://facebook.com/some/page", flows.URLRestrictionNone},
+		{"https://notgraph.facebook.com.evil.com/", flows.URLRestrictionNone},
+		{"https://temba.io/", flows.URLRestrictionNone},
 	}
 
 	for _, tc := range tcs {
 		u, err := url.Parse(tc.url)
 		require.NoError(t, err)
 
-		assert.Equal(t, tc.isRestricted, svc.IsRestricted(u), "IsRestricted mismatch for %s", tc.url)
+		assert.Equal(t, tc.restriction, svc.Restriction(u), "restriction mismatch for %s", tc.url)
 	}
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -34,7 +34,7 @@ func newEngine(httpClient *http.Client) flows.Engine {
 			"categorize": template.Must(template.New("").Parse("Categorize the following text into one of the following: {{ .arg1 }}")),
 		}).
 		WithWebhookLimits(256*1024, 10000).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"})).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"}, []string{"api.twilio.com"})).
 		WithEmailServiceFactory(func(s flows.SessionAssets) (flows.EmailService, error) {
 			return services.NewEmail(), nil
 		}).

--- a/test/runner_test.go
+++ b/test/runner_test.go
@@ -138,7 +138,7 @@ func runFlow(assetsPath string, rawEnv []byte, rawContact *core.ContactEnvelope,
 			return smtp.NewService("smtp://nyaruka:pass123@mail.temba.io?from=flows@temba.io", nil)
 		}).
 		WithWebhookLimits(256*1024, 100000).
-		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"})).
+		WithWebhookServiceFactory(webhooks.NewServiceFactory(map[string]string{"User-Agent": "goflow-testing"}, []string{"graph.facebook.com"}, []string{"api.twilio.com"})).
 		WithLLMServiceFactory(func(l *core.LLM) (flows.LLMService, error) {
 			return services.NewLLM(), nil
 		}).


### PR DESCRIPTION
## Summary

Webhook domain restrictions were a single list that only ever produced a warning event. This splits them into two lists: domains that warn (calls still go through) and domains that are blocked (the call isn't made at all), so domains can be migrated from the first to the second as operators are ready.

## Changes

**`flows/services.go`** — `WebhookService.IsRestricted(u) bool` is replaced by `Restriction(u) URLRestriction`, a new string type with values `URLRestrictionNone`, `URLRestrictionWarn` and `URLRestrictionBlock`.

**`services/webhooks/service.go`** — `NewServiceFactory` and `NewService` take `warnDomains` and `blockDomains` in place of the single `restrictedDomains`. Host matching is unchanged (case-insensitive, matches subdomains), factored into a shared `matchesDomain` helper. Blocking takes precedence when a domain appears in both lists.

**`flows/actions/call_webhook.go`** — a warn-listed URL logs the existing `url:restricted` warning and the call proceeds as before; a block-listed URL logs a new `url:restricted` error and the action returns without making the request, leaving `@webhook` cleared.

**`core/events/error.go`** — adds `ErrorCodeURLRestricted` (`url:restricted`). Error and warning codes are separate namespaces, so blocked and warned calls share the code string while differing in event type.

Test engines now configure `graph.facebook.com` as a warn domain and `api.twilio.com` as a block domain.

## Behavior examples

| URL matches | Event | Call made? | `@webhook` |
|---|---|---|---|
| no list | — | yes | call result |
| warn list | `warning` / `url:restricted` — "Webhook calls to X may be blocked in the future" | yes | call result |
| block list | `error` / `url:restricted` — "Webhook calls to X are not allowed" | no | cleared |

Because a blocked call produces no `webhook_called` event, a router branching on `@webhook.status` sees the same state as a webhook that was never called.

## Test plan

- [x] Full suite passes (`go test -p=1 ./...`)
- [x] `TestRestriction` covers warn, block, case insensitivity, subdomain matching, block-wins-over-warn, and non-matching hosts including the `notgraph.facebook.com.evil.com` suffix trap
- [x] New `call_webhook` action fixture asserts the error event, no HTTP call, and null webhook for a blocked domain; regenerating fixtures with `-update` produces no diff