### PR TITLE
Block webhook calls to blocked domains instead of warning

### DIFF
--- a/core/events/error.go
+++ b/core/events/error.go
@@ -19,6 +19,7 @@ const (
 	ErrorCodeGroupMissing         = "group:missing"
 	ErrorCodeLabelMissing         = "label:missing"
 	ErrorCodeTimezoneInvalid      = "timezone:invalid"
+	ErrorCodeURLBlocked           = "url:blocked"
 	ErrorCodeURLInvalid           = "url:invalid"
 	ErrorCodeURNInvalid           = "urn:invalid"
 	ErrorCodeURNTaken             = "urn:taken"

--- a/core/events/warning.go
+++ b/core/events/warning.go
@@ -9,7 +9,6 @@ const TypeWarning string = "warning"
 
 const (
 	WarningCodeDeprecatedContext   = "context:deprecated"
-	WarningCodeURLRestricted       = "url:restricted"
 	WarningCodeWebhookResponseSize = "webhook:response_size"
 )
 

--- a/flows/actions/call_webhook.go
+++ b/flows/actions/call_webhook.go
@@ -167,9 +167,10 @@ func (a *CallWebhook) call(ctx context.Context, run flows.Run, step flows.Step, 
 		return nil
 	}
 
-	// for now calls to restricted URLs only generate warnings but eventually they may be blocked
-	if svc.IsRestricted(req.URL) {
-		log(events.NewWarning(fmt.Sprintf("Webhook calls to %s may be blocked in the future", req.URL.Hostname()), events.WarningCodeURLRestricted, "hostname", req.URL.Hostname()))
+	// the service decides which domains are blocked for this session's workspace
+	if svc.IsBlocked(req.URL) {
+		log(events.NewError(fmt.Sprintf("Webhook calls to %s are not allowed", req.URL.Hostname()), events.ErrorCodeURLBlocked, "hostname", req.URL.Hostname()))
+		return nil
 	}
 
 	trace, err := svc.Call(req)

--- a/flows/actions/testdata/call_webhook.json
+++ b/flows/actions/testdata/call_webhook.json
@@ -365,15 +365,7 @@
         }
     },
     {
-        "description": "Warning event created if URL is in a restricted domain",
-        "http_mocks": {
-            "https://graph.facebook.com/v25.0/1234/messages": [
-                {
-                    "status": 200,
-                    "body": "{}"
-                }
-            ]
-        },
+        "description": "Error event created and call blocked if URL is in a blocked domain",
         "action": {
             "type": "call_webhook",
             "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
@@ -384,29 +376,13 @@
         "events": [
             {
                 "uuid": "01969b47-307b-76f8-b774-0a98171a0712",
-                "type": "warning",
+                "type": "error",
                 "created_on": "2025-05-04T12:30:57.123456789Z",
-                "text": "Webhook calls to graph.facebook.com may be blocked in the future",
-                "code": "url:restricted",
+                "text": "Webhook calls to graph.facebook.com are not allowed",
+                "code": "url:blocked",
                 "extra": {
                     "hostname": "graph.facebook.com"
                 }
-            },
-            {
-                "uuid": "01969b47-401b-76f8-a7eb-cc4cc9ec3e6b",
-                "type": "webhook_called",
-                "created_on": "2025-05-04T12:31:01.123456789Z",
-                "url": "https://graph.facebook.com/v25.0/1234/messages",
-                "status_code": 200,
-                "request": "POST /v25.0/1234/messages HTTP/1.1\r\nHost: graph.facebook.com\r\nUser-Agent: goflow-testing\r\nContent-Length: 2\r\nAccept-Encoding: gzip\r\n\r\n{}",
-                "response": "HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\n{}",
-                "elapsed_ms": 1000,
-                "retries": 0,
-                "sizes": {
-                    "request": 136,
-                    "response": 40
-                },
-                "status": "success"
             }
         ],
         "locals_after": {},

--- a/flows/services.go
+++ b/flows/services.go
@@ -31,8 +31,8 @@ type WebhookService interface {
 	// Call makes the given HTTP request and returns the trace
 	Call(request *http.Request) (*httpx.Trace, error)
 
-	// IsRestricted returns whether the given URL is restricted and shouldn't be called from flows
-	IsRestricted(u *url.URL) bool
+	// IsBlocked returns whether the given URL is in a blocked domain and shouldn't be called from flows
+	IsBlocked(u *url.URL) bool
 }
 
 // LLMService provides LLM functionality to the engine

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -13,24 +13,28 @@ import (
 )
 
 type service struct {
-	httpClient        *http.Client
-	defaultHeaders    map[string]string
-	restrictedDomains []string
-	maxResponseBytes  int
+	httpClient       *http.Client
+	defaultHeaders   map[string]string
+	blockedDomains   []string
+	maxResponseBytes int
 }
 
-// NewServiceFactory creates a new webhook service factory. The engine supplies the HTTP client and the maximum
-// response size; the client's transport can be configured with tracing, mocking or access control as needed
-// (see github.com/nyaruka/gocommon/httpx). The restricted domains are domains (e.g. messaging provider APIs)
-// which flows shouldn't be calling directly.
-func NewServiceFactory(defaultHeaders map[string]string, restrictedDomains []string) engine.WebhookServiceFactory {
+// NewServiceFactory creates a webhook service factory which gives every session the same service. The engine
+// supplies the HTTP client and the maximum response size; the client's transport can be configured with tracing,
+// mocking or access control as needed (see github.com/nyaruka/gocommon/httpx). The blocked domains are domains
+// (e.g. messaging provider APIs) which flows shouldn't be calling directly.
+//
+// Hosts which need webhook policy to vary by workspace - different blocked domains, timeouts or size limits -
+// should implement engine.WebhookServiceFactory themselves and construct services with NewService, resolving the
+// workspace from the session assets' source.
+func NewServiceFactory(defaultHeaders map[string]string, blockedDomains []string) engine.WebhookServiceFactory {
 	return func(eng flows.Engine, sa flows.SessionAssets) (flows.WebhookService, error) {
-		return NewService(eng.HTTPClient(), defaultHeaders, restrictedDomains, eng.Options().MaxResponseBytes), nil
+		return NewService(eng.HTTPClient(), defaultHeaders, blockedDomains, eng.Options().MaxResponseBytes), nil
 	}
 }
 
 // NewService creates a new default webhook service
-func NewService(httpClient *http.Client, defaultHeaders map[string]string, restrictedDomains []string, maxResponseBytes int) flows.WebhookService {
+func NewService(httpClient *http.Client, defaultHeaders map[string]string, blockedDomains []string, maxResponseBytes int) flows.WebhookService {
 	// build the client this service will call through, layering our concerns onto the transport we were given. The
 	// read limit bounds how much we'll read from an untrusted endpoint and goes inside tracing so it applies before
 	// the body is buffered into the trace; tracing is outermost so that a request denied by access control is still
@@ -44,18 +48,18 @@ func NewService(httpClient *http.Client, defaultHeaders map[string]string, restr
 	traced.Transport = httpx.WithTraces(inner)
 
 	return &service{
-		httpClient:        &traced,
-		defaultHeaders:    defaultHeaders,
-		restrictedDomains: restrictedDomains,
-		maxResponseBytes:  maxResponseBytes,
+		httpClient:       &traced,
+		defaultHeaders:   defaultHeaders,
+		blockedDomains:   blockedDomains,
+		maxResponseBytes: maxResponseBytes,
 	}
 }
 
-// IsRestricted returns whether the host of the given URL matches or is a subdomain of one of our
-// configured restricted domains.
-func (s *service) IsRestricted(u *url.URL) bool {
+// IsBlocked returns whether the host of the given URL matches or is a subdomain of one of our
+// configured blocked domains.
+func (s *service) IsBlocked(u *url.URL) bool {
 	host := strings.ToLower(u.Hostname())
-	for _, domain := range s.restrictedDomains {
+	for _, domain := range s.blockedDomains {
 		if host == domain || strings.HasSuffix(host, "."+domain) {
 			return true
 		}

--- a/services/webhooks/service.go
+++ b/services/webhooks/service.go
@@ -56,9 +56,11 @@ func NewService(httpClient *http.Client, defaultHeaders map[string]string, block
 }
 
 // IsBlocked returns whether the host of the given URL matches or is a subdomain of one of our
-// configured blocked domains.
+// configured blocked domains. The trailing dot of a fully qualified name is stripped first - it
+// resolves to the same host, so leaving it on would let "example.com." slip past a block on
+// "example.com".
 func (s *service) IsBlocked(u *url.URL) bool {
-	host := strings.ToLower(u.Hostname())
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
 	for _, domain := range s.blockedDomains {
 		if host == domain || strings.HasSuffix(host, "."+domain) {
 			return true

--- a/services/webhooks/service_test.go
+++ b/services/webhooks/service_test.go
@@ -231,12 +231,12 @@ func TestWebhookResponseWithEscapes(t *testing.T) {
 	assert.NotContains(t, string(jsonx.MustMarshal(session)), `\u0000`)
 }
 
-func TestIsRestricted(t *testing.T) {
+func TestIsBlocked(t *testing.T) {
 	svc := webhooks.NewService(http.DefaultClient, nil, []string{"graph.facebook.com", "360dialog.io"}, 1024)
 
 	tcs := []struct {
-		url          string
-		isRestricted bool
+		url       string
+		isBlocked bool
 	}{
 		{"https://graph.facebook.com/v25.0/1234/messages", true},
 		{"https://GRAPH.FACEBOOK.COM/v25.0/1234/messages", true}, // check case insensitivity
@@ -250,6 +250,6 @@ func TestIsRestricted(t *testing.T) {
 		u, err := url.Parse(tc.url)
 		require.NoError(t, err)
 
-		assert.Equal(t, tc.isRestricted, svc.IsRestricted(u), "IsRestricted mismatch for %s", tc.url)
+		assert.Equal(t, tc.isBlocked, svc.IsBlocked(u), "IsBlocked mismatch for %s", tc.url)
 	}
 }

--- a/services/webhooks/service_test.go
+++ b/services/webhooks/service_test.go
@@ -239,8 +239,10 @@ func TestIsBlocked(t *testing.T) {
 		isBlocked bool
 	}{
 		{"https://graph.facebook.com/v25.0/1234/messages", true},
-		{"https://GRAPH.FACEBOOK.COM/v25.0/1234/messages", true}, // check case insensitivity
-		{"https://waba-v2.360dialog.io/messages", true},          // check subdomain matching
+		{"https://GRAPH.FACEBOOK.COM/v25.0/1234/messages", true},  // check case insensitivity
+		{"https://waba-v2.360dialog.io/messages", true},           // check subdomain matching
+		{"https://graph.facebook.com./v25.0/1234/messages", true}, // check trailing dot of a FQDN
+		{"https://waba-v2.360dialog.io./messages", true},          // check trailing dot on a subdomain
 		{"https://facebook.com/some/page", false},
 		{"https://notgraph.facebook.com.evil.com/", false},
 		{"https://temba.io/", false},


### PR DESCRIPTION
## Summary

Webhook calls from flows to domains the host has marked as blocked (e.g. messaging provider APIs which shouldn't be called directly) previously produced a warning event and then went ahead and made the call. They are now blocked: an error event is logged and no request is made.

Also lays the groundwork for hosts that need this policy to vary per workspace — e.g. granting a workspace an exemption, or a longer timeout — by documenting `engine.WebhookServiceFactory` as the seam for that, rather than adding a narrower one alongside it.

## Changes

**Blocking** — `call_webhook` now returns before `svc.Call` when the URL is blocked, logging an error event. This follows the existing `MaxRequestBytes` check a few lines above it: `@webhook` is left unset and routers fall through exactly as they do for that case.

**Host normalization** — `IsBlocked` now strips the trailing dot of a fully qualified name before comparing. `u.Hostname()` preserves it, so `graph.facebook.com.` matched neither the exact-domain nor the subdomain branch while still resolving to the same host — a bypass of the block for any configured domain. Pre-existing, and harmless while this only logged a warning, but load-bearing once the check actually blocks.

**Vocabulary** — renamed "restricted" to "blocked" throughout:

| Before | After |
|---|---|
| `WebhookService.IsRestricted(u)` | `WebhookService.IsBlocked(u)` |
| `events.WarningCodeURLRestricted` | `events.ErrorCodeURLBlocked` |
| `restrictedDomains` | `blockedDomains` |

**Per-workspace policy** — `webhooks.NewServiceFactory` keeps its static domain list and is now documented as the convenience for hosts with a single policy. Hosts needing policy to vary by workspace implement `engine.WebhookServiceFactory` themselves and construct services with `webhooks.NewService`, resolving the workspace from the session assets' source. That hook already existed; no new API was added for it.

## Behavior examples

For a flow calling a blocked domain:

| | Before | After |
|---|---|---|
| Event type | `warning` | `error` |
| Event code | `url:restricted` | `url:blocked` |
| Event text | "Webhook calls to X may be blocked in the future" | "Webhook calls to X are not allowed" |
| Request made | yes | no |
| `webhook_called` event | yes | none |
| `@webhook` | result of the call | unset |

The `hostname` extra is unchanged.

With `graph.facebook.com` configured as blocked:

| URL | Before | After |
|---|---|---|
| `https://graph.facebook.com/x` | blocked | blocked |
| `https://GRAPH.FACEBOOK.COM/x` | blocked | blocked |
| `https://graph.facebook.com./x` | **not blocked** | blocked |
| `https://waba.graph.facebook.com./x` | **not blocked** | blocked |
| `https://notgraph.facebook.com.evil.com/` | not blocked | not blocked |

## Notes for hosts

- The event type changes from `warning` to `error`, so anything matching on the old `url:restricted` warning needs updating regardless of the code rename.
- `call_resthook` shares the webhook service but does not consult `IsBlocked`, so resthook subscribers can still reach blocked domains. Left as-is deliberately — those URLs are workspace-configured rather than flow-authored — but worth a decision rather than inheriting by omission.
- `MaxRequestBytes` is still read from engine options before the service is resolved, so it can't vary per workspace yet. Worth moving onto the service alongside per-workspace timeouts, at which point `NewService`'s parameter list should become a config struct.
- The service is constructed per action execution rather than per session, so a host factory that does a workspace lookup on every call may want to cache the constructed service.

## Test plan

- [x] `go test -p=1 ./...` passes in full
- [x] `call_webhook.json` fixture updated: the blocked-domain case now expects a single `error` event with code `url:blocked`, no `webhook_called` event, and no HTTP mock (the test asserts all mocks are consumed, so a leftover mock would fail)
- [x] Trailing-dot bypass reproduced against the pre-fix code before fixing, then covered by `TestIsBlocked` for both the bare and subdomain forms
- [x] `TestIsBlocked` still covers exact match, case insensitivity, subdomain matching, and the suffix-confusion case (`notgraph.facebook.com.evil.com` is not blocked by `facebook.com`)
- [x] `gofmt` clean on all changed files

## Review notes

- The `review` job flagged the trailing-dot normalization gap in `IsBlocked`. Verified by test that it was a real bypass, then fixed in 14c491df with regression coverage.