### PR TITLE
Allow voice flows to enter messaging flows via enter_flow action

### DIFF
--- a/flows/actions/enter_flow.go
+++ b/flows/actions/enter_flow.go
@@ -56,7 +56,7 @@ func (a *EnterFlow) Execute(ctx context.Context, run flows.Run, step flows.Step,
 		return nil
 	}
 
-	if run.Session().Type() != flow.Type() && flow.Type() != flows.FlowTypeMessagingBackground {
+	if !run.Session().Type().CanEnter(flow.Type()) {
 		a.fail(run, fmt.Sprintf("Can't enter %s of type %s from type %s", flow.Reference(false), flow.Type(), run.Session().Type()), log)
 		return nil
 	}

--- a/flows/actions/testdata/enter_flow.json
+++ b/flows/actions/testdata/enter_flow.json
@@ -88,6 +88,84 @@
         }
     },
     {
+        "description": "Messaging flow can be entered from voice flow",
+        "no_input": true,
+        "action": {
+            "type": "enter_flow",
+            "uuid": "ad154980-7bf7-4ab8-8728-545fd6378912",
+            "flow": {
+                "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
+                "name": "Collect Age"
+            }
+        },
+        "in_flow_type": "voice",
+        "events": [
+            {
+                "uuid": "01969b47-2c93-76f8-b774-0a98171a0712",
+                "type": "run_started",
+                "created_on": "2025-05-04T12:30:56.123456789Z",
+                "flow": {
+                    "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
+                    "name": "Collect Age",
+                    "revision": 123
+                },
+                "run_uuid": "01969b47-28ab-76f8-b20c-e3cb6203e029",
+                "parent_uuid": "01969b47-1523-76f8-95cf-9fca95f1c30a"
+            },
+            {
+                "uuid": "01969b47-401b-76f8-a7eb-cc4cc9ec3e6b",
+                "type": "run_result_changed",
+                "created_on": "2025-05-04T12:31:01.123456789Z",
+                "name": "Age",
+                "value": "23",
+                "category": "Youth"
+            },
+            {
+                "uuid": "01969b47-4bd3-76f8-aac5-d9d0ae409dbe",
+                "type": "contact_field_changed",
+                "created_on": "2025-05-04T12:31:04.123456789Z",
+                "field": {
+                    "key": "age",
+                    "name": "Age"
+                },
+                "value": {
+                    "text": "23",
+                    "number": 23
+                }
+            },
+            {
+                "uuid": "01969b47-578b-76f8-9729-57745fb13b06",
+                "type": "run_ended",
+                "created_on": "2025-05-04T12:31:07.123456789Z",
+                "run_uuid": "01969b47-28ab-76f8-b20c-e3cb6203e029",
+                "flow": {
+                    "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
+                    "name": "Collect Age",
+                    "revision": 123
+                },
+                "status": "completed"
+            }
+        ],
+        "locals_after": {},
+        "inspection": {
+            "counts": {
+                "languages": 0,
+                "nodes": 1
+            },
+            "dependencies": [
+                {
+                    "uuid": "b7cf0d83-f1c9-411c-96fd-c511a4cfa86d",
+                    "name": "Collect Age",
+                    "type": "flow"
+                }
+            ],
+            "locals": [],
+            "results": [],
+            "parent_refs": [],
+            "issues": []
+        }
+    },
+    {
         "description": "Background flow can be entered from messaging flow",
         "action": {
             "type": "enter_flow",

--- a/flows/flows.go
+++ b/flows/flows.go
@@ -32,6 +32,17 @@ const (
 	FlowTypeVoice FlowType = "voice"
 )
 
+// CanEnter returns whether a session of this type can enter a flow of the given type
+func (t FlowType) CanEnter(other FlowType) bool {
+	// same type is always fine, and any type of session can enter a background flow
+	if t == other || other == FlowTypeMessagingBackground {
+		return true
+	}
+
+	// voice sessions can also enter messaging flows
+	return t == FlowTypeVoice && other == FlowTypeMessaging
+}
+
 // Allows returns whether this flow type allows the given item
 func (t FlowType) Allows(r FlowTypeRestricted) bool {
 	for _, allowedType := range r.AllowedFlowTypes() {

--- a/flows/flows_test.go
+++ b/flows/flows_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFlowTypeCanEnter(t *testing.T) {
+	tcs := []struct {
+		session  flows.FlowType
+		entered  flows.FlowType
+		expected bool
+	}{
+		{flows.FlowTypeMessaging, flows.FlowTypeMessaging, true},
+		{flows.FlowTypeMessaging, flows.FlowTypeMessagingBackground, true},
+		{flows.FlowTypeMessaging, flows.FlowTypeMessagingOffline, false},
+		{flows.FlowTypeMessaging, flows.FlowTypeVoice, false},
+		{flows.FlowTypeMessagingOffline, flows.FlowTypeMessaging, false},
+		{flows.FlowTypeMessagingOffline, flows.FlowTypeMessagingOffline, true},
+		{flows.FlowTypeVoice, flows.FlowTypeMessaging, true}, // voice can drop into messaging
+		{flows.FlowTypeVoice, flows.FlowTypeMessagingBackground, true},
+		{flows.FlowTypeVoice, flows.FlowTypeMessagingOffline, false},
+		{flows.FlowTypeVoice, flows.FlowTypeVoice, true},
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.expected, tc.session.CanEnter(tc.entered), "can enter mismatch for %s entering %s", tc.session, tc.entered)
+	}
+}
+
 func TestFlowTypeAllows(t *testing.T) {
 	webhookAction, err := actions.Read([]byte(`{
 		"uuid": "8eebd020-1af5-431c-b943-aa670fc74da9",


### PR DESCRIPTION
Previously the `enter_flow` action only allowed a session to enter a flow of the same type, with `messaging_background` as the sole exception. That meant a voice session couldn't hand off to a messaging flow, even though messaging flows are runnable in a voice session.

This adds voice → messaging to the set of permitted transitions.

## Changes

- New `FlowType.CanEnter(other)` in `flows/flows.go` which encodes the full matrix in one place: same type is always allowed, any session type can enter a `messaging_background` flow, and voice sessions can additionally enter `messaging` flows.
- `enter_flow` now uses that helper instead of its own inline check. The failure message is unchanged.

Everything else still fails as before — messaging → voice, and anything → `messaging_offline`.

## Notes for reviewers

A messaging subflow's actions and waits are validated against the `messaging` type, so it can contain things like `send_msg` and message waits which will now execute inside a voice call. The engine emits those events as normal; how they're delivered mid-call is up to the caller.

## Testing

- Table test over the full flow type matrix in `flows/flows_test.go`.
- New `enter_flow` action test case covering a messaging subflow started from a voice session and running to completion.
- Full suite passes.
