### PR TITLE
Add template enumeration for dial wait phone field

### DIFF
--- a/flows/definition/flow_test.go
+++ b/flows/definition/flow_test.go
@@ -692,6 +692,26 @@ func TestExtractTemplatesAndLocalizables(t *testing.T) {
 				"Male",
 			},
 		},
+		{
+			"../../test/testdata/runner/ivr_dial.json",
+			"90420633-8c92-4480-940a-382cdd6a33b9",
+			[]string{
+				`@(default(resume.dial.status, ""))`,
+				`answered`,
+				`no_answer`,
+				`busy`,
+				`@fields.supervisor_phone`,
+			},
+			[]string{
+				`answered`,
+				`no_answer`,
+				`busy`,
+				`Answered`,
+				`No Answer`,
+				`Busy`,
+				`Failed`,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/flows/definition/migrations/specdata/templates.json
+++ b/flows/definition/migrations/specdata/templates.json
@@ -88,11 +88,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -185,11 +187,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -282,11 +286,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -379,11 +385,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -475,11 +483,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -571,11 +581,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -667,11 +679,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -763,11 +777,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -852,11 +868,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -941,11 +959,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -1030,11 +1050,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -1119,11 +1141,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -1208,11 +1232,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     },
@@ -1298,11 +1324,13 @@
         "routers": {
             "random": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ],
             "switch": [
                 ".operand",
-                ".cases[*].arguments[*]"
+                ".cases[*].arguments[*]",
+                ".wait.phone"
             ]
         }
     }

--- a/flows/definition/migrations/templates_test.go
+++ b/flows/definition/migrations/templates_test.go
@@ -18,8 +18,8 @@ func TestCurrentTemplateCatalog(t *testing.T) {
 	s := &migrations.TemplateCatalog{
 		Actions: make(map[string][]string),
 		Routers: map[string][]string{
-			"random": {".operand", ".cases[*].arguments[*]"},
-			"switch": {".operand", ".cases[*].arguments[*]"},
+			"random": {".operand", ".cases[*].arguments[*]", ".wait.phone"},
+			"switch": {".operand", ".cases[*].arguments[*]", ".wait.phone"},
 		},
 	}
 

--- a/flows/definition/migrations/testdata/templates1.json
+++ b/flows/definition/migrations/testdata/templates1.json
@@ -95,6 +95,33 @@
                     "uuid": "e80bc037-3b57-45b5-9f19-a8346a475578"
                 }
             ]
+        },
+        {
+            "uuid": "27d47130-64f7-45f8-b3b7-b0cdadb478ba",
+            "actions": [],
+            "router": {
+                "type": "switch",
+                "wait": {
+                    "type": "dial",
+                    "phone": "@fields.supervisor_phone"
+                },
+                "default_category_uuid": "b8bcb45c-c886-4d43-8bdc-e30cee4a4f7b",
+                "result_name": "Dial",
+                "operand": "@input.text",
+                "cases": [],
+                "categories": [
+                    {
+                        "uuid": "b8bcb45c-c886-4d43-8bdc-e30cee4a4f7b",
+                        "name": "Other",
+                        "exit_uuid": "d3ad3232-cbd8-4a47-b41a-d24d69bf7cc4"
+                    }
+                ]
+            },
+            "exits": [
+                {
+                    "uuid": "d3ad3232-cbd8-4a47-b41a-d24d69bf7cc4"
+                }
+            ]
         }
     ]
 }

--- a/flows/definition/migrations/testdata/templates1.upper.json
+++ b/flows/definition/migrations/testdata/templates1.upper.json
@@ -95,6 +95,33 @@
                     "uuid": "e80bc037-3b57-45b5-9f19-a8346a475578"
                 }
             ]
+        },
+        {
+            "uuid": "27d47130-64f7-45f8-b3b7-b0cdadb478ba",
+            "actions": [],
+            "router": {
+                "type": "switch",
+                "wait": {
+                    "type": "dial",
+                    "phone": "@FIELDS.SUPERVISOR_PHONE"
+                },
+                "default_category_uuid": "b8bcb45c-c886-4d43-8bdc-e30cee4a4f7b",
+                "result_name": "Dial",
+                "operand": "@INPUT.TEXT",
+                "cases": [],
+                "categories": [
+                    {
+                        "uuid": "b8bcb45c-c886-4d43-8bdc-e30cee4a4f7b",
+                        "name": "Other",
+                        "exit_uuid": "d3ad3232-cbd8-4a47-b41a-d24d69bf7cc4"
+                    }
+                ]
+            },
+            "exits": [
+                {
+                    "uuid": "d3ad3232-cbd8-4a47-b41a-d24d69bf7cc4"
+                }
+            ]
         }
     ]
 }

--- a/flows/interfaces.go
+++ b/flows/interfaces.go
@@ -165,6 +165,7 @@ type Timeout interface {
 type Wait interface {
 	utils.Typed
 	FlowTypeRestricted
+	TemplateEnumerator
 
 	Timeout() Timeout
 

--- a/flows/routers/base.go
+++ b/flows/routers/base.go
@@ -74,6 +74,9 @@ func (r *baseRouter) Inspect(result func(*flows.ResultInfo), dependency func(ass
 
 // EnumerateTemplates enumerates all expressions on this object and its children
 func (r *baseRouter) EnumerateTemplates(localization flows.Localization, include func(i18n.Language, string)) {
+	if r.wait != nil {
+		r.wait.EnumerateTemplates(localization, include)
+	}
 }
 
 // EnumerateLocalizables enumerates all the localizable text on this object

--- a/flows/routers/switch.go
+++ b/flows/routers/switch.go
@@ -221,6 +221,8 @@ func (r *Switch) EnumerateTemplates(localization flows.Localization, include fun
 	include(i18n.NilLanguage, r.operand)
 
 	inspect.Templates(r.cases, localization, include)
+
+	r.baseRouter.EnumerateTemplates(localization, include)
 }
 
 // EnumerateLocalizables enumerates all the localizable text on this object

--- a/flows/routers/waits/base.go
+++ b/flows/routers/waits/base.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 )
@@ -56,6 +57,10 @@ func (w *baseWait) Timeout() flows.Timeout {
 
 func (w *baseWait) expiresOn(run flows.Run) time.Time {
 	return dates.Now().Add(run.Flow().ExpireAfter())
+}
+
+// EnumerateTemplates enumerates all expressions on this object
+func (w *baseWait) EnumerateTemplates(localization flows.Localization, include func(i18n.Language, string)) {
 }
 
 //------------------------------------------------------------------------------------------

--- a/flows/routers/waits/dial.go
+++ b/flows/routers/waits/dial.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core/events"
@@ -83,6 +84,11 @@ func (w *Dial) Begin(ctx context.Context, run flows.Run, log events.EventLogger)
 // Accept returns whether this wait accepts the given resume
 func (w *Dial) Accepts(resume flows.Resume) bool {
 	return resume.Type() == resumes.TypeDial
+}
+
+// EnumerateTemplates enumerates all expressions on this object
+func (w *Dial) EnumerateTemplates(localization flows.Localization, include func(i18n.Language, string)) {
+	include(i18n.NilLanguage, w.phone)
 }
 
 var _ flows.Wait = (*Dial)(nil)

--- a/flows/routers/waits/dial_test.go
+++ b/flows/routers/waits/dial_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nyaruka/gocommon/i18n"
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/core"
@@ -43,6 +44,11 @@ func TestDialWait(t *testing.T) {
 	marshaled, err := jsonx.Marshal(wait)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"type":"dial","phone":"@(\"+\" & \"593979123456\")","dial_limit_seconds":10,"call_limit_seconds":120}`, string(marshaled))
+
+	// phone is enumerated as a template
+	templates := make([]string, 0)
+	wait.EnumerateTemplates(nil, func(l i18n.Language, t string) { templates = append(templates, t) })
+	assert.Equal(t, []string{`@("+" & "593979123456")`}, templates)
 
 	// try activating the wait
 	log := test.NewEventLog()


### PR DESCRIPTION
## Summary

The dial wait's `phone` field is evaluated as a template at runtime but was never enumerated as one, so `Flow.ExtractTemplates()` / `Flow.Info()` missed expressions in it (skipping dependency extraction and issue checks), and the migration template catalogs never rewrote expressions inside it.

## Changes

- `flows.Wait` now embeds `TemplateEnumerator`; `baseWait` provides an empty implementation and the dial wait overrides it to include its `phone` field.
- `baseRouter.EnumerateTemplates` enumerates the router's wait (covers the random router), and the switch router now also delegates to the base implementation after its operand and cases.
- Added `.wait.phone` to the `switch` and `random` router entries in **all** template catalog versions (13.2.0–14.4.2). The dial wait predates spec 13.2, so every cataloged version could legitimately contain one — the catalogs were simply incomplete. This means the 13.2.0 and 13.6.1 `RewriteTemplates`-based migrations now correctly rewrite expressions inside dial wait phones for old definitions migrated from now on.

## Behavior examples

For a voice flow with a dial wait `{"type": "dial", "phone": "@fields.supervisor_phone"}`:

| | Before | After |
|---|---|---|
| `ExtractTemplates()` | phone omitted | includes `@fields.supervisor_phone` |
| `Inspect()` dependencies | `supervisor_phone` field missed | field dependency extracted |
| 13.2/13.6 migrations | phone never rewritten | phone rewritten like other templates |

## Test plan

- New assertion in `TestDialWait` that the phone is enumerated as a template
- New `TestExtractTemplatesAndLocalizables` case using the `ivr_dial` test flow
- Extended the `RewriteTemplates` fixture with a dial wait node to exercise `.wait.phone` rewriting
- Updated `TestCurrentTemplateCatalog` expectations
- Full suite passes: `go test -p=1 ./...`